### PR TITLE
fix: unicode escapes, yield-from flag, negative string index, \${...} interpolation

### DIFF
--- a/crates/php-ast/src/ast.rs
+++ b/crates/php-ast/src/ast.rs
@@ -1205,6 +1205,8 @@ pub struct MatchArm<'arena, 'src> {
 pub struct YieldExpr<'arena, 'src> {
     pub key: Option<&'arena Expr<'arena, 'src>>,
     pub value: Option<&'arena Expr<'arena, 'src>>,
+    /// `true` for `yield from expr` (generator delegation), `false` for plain `yield`
+    pub is_from: bool,
 }
 
 // --- First-class callable ---

--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -1938,6 +1938,7 @@ fn parse_yield_expr<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<
             kind: ExprKind::Yield(YieldExpr {
                 key: None,
                 value: Some(parser.alloc(value)),
+                is_from: true,
             }),
             span,
         };
@@ -1960,6 +1961,7 @@ fn parse_yield_expr<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<
             kind: ExprKind::Yield(YieldExpr {
                 key: None,
                 value: None,
+                is_from: false,
             }),
             span,
         };
@@ -1975,6 +1977,7 @@ fn parse_yield_expr<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<
             kind: ExprKind::Yield(YieldExpr {
                 key: Some(parser.alloc(first)),
                 value: Some(parser.alloc(value)),
+                is_from: false,
             }),
             span,
         };
@@ -1986,6 +1989,7 @@ fn parse_yield_expr<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<
         kind: ExprKind::Yield(YieldExpr {
             key: None,
             value: Some(parser.alloc(first)),
+            is_from: false,
         }),
         span,
     }

--- a/crates/php-parser/src/interpolation.rs
+++ b/crates/php-parser/src/interpolation.rs
@@ -86,6 +86,32 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                                 buf.push('x');
                             }
                         }
+                        b'u' => {
+                            // Unicode escape: \u{HHHH} — PHP 7.0+
+                            i += 2;
+                            if i < len && bytes[i] == b'{' {
+                                i += 1; // skip {
+                                let start = i;
+                                while i < len && bytes[i].is_ascii_hexdigit() {
+                                    i += 1;
+                                }
+                                if i < len && bytes[i] == b'}' {
+                                    let hex = &inner[start..i];
+                                    if let Ok(codepoint) = u32::from_str_radix(hex, 16) {
+                                        if let Some(c) = char::from_u32(codepoint) {
+                                            buf.push(c);
+                                        }
+                                    }
+                                    i += 1; // skip }
+                                } else {
+                                    // Malformed — keep as-is
+                                    buf.push_str(&inner[start - 2..i]);
+                                }
+                            } else {
+                                buf.push('\\');
+                                buf.push('u');
+                            }
+                        }
                         b'0'..=b'7' => {
                             // Octal escape: \NNN (up to 3 digits)
                             let start = i + 1;
@@ -110,8 +136,96 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                 }
             }
             b'$' => {
+                // Deprecated ${varname} syntax (PHP < 8.2): ${ ... }
+                if i + 1 < len && bytes[i + 1] == b'{' {
+                    if let Some(buf) = owned.take() {
+                        if !buf.is_empty() {
+                            parts.push(StringPart::Literal(Cow::Owned(buf)));
+                        }
+                    } else if i > literal_start {
+                        parts.push(StringPart::Literal(Cow::Borrowed(&inner[literal_start..i])));
+                    }
+                    i += 2; // skip ${
+                    let var_offset = base_offset + (i - 2) as u32;
+                    if i < len && bytes[i] == b'$' {
+                        // ${$foo} — variable variable; use sub-parser from the inner $
+                        let expr_start = i;
+                        let mut depth = 1usize;
+                        while i < len && depth > 0 {
+                            match bytes[i] {
+                                b'{' => depth += 1,
+                                b'}' => depth -= 1,
+                                _ => {}
+                            }
+                            if depth > 0 {
+                                i += 1;
+                            }
+                        }
+                        let inner_expr = parse_complex_interpolation(
+                            arena,
+                            source,
+                            base_offset + expr_start as u32,
+                            base_offset + i as u32,
+                        );
+                        if i < len {
+                            i += 1; // skip }
+                        }
+                        parts.push(StringPart::Expr(Expr {
+                            kind: ExprKind::VariableVariable(arena.alloc(inner_expr)),
+                            span: Span::new(var_offset, base_offset + i as u32),
+                        }));
+                    } else {
+                        // ${varname} or ${varname[index]} — identifier as variable name
+                        let name_start = i;
+                        while i < len && is_var_char(bytes[i]) {
+                            i += 1;
+                        }
+                        let var_name: Cow<'src, str> = Cow::Borrowed(
+                            &source[base_offset as usize + name_start..base_offset as usize + i],
+                        );
+                        let mut expr = Expr {
+                            kind: ExprKind::Variable(var_name),
+                            span: Span::new(
+                                base_offset + name_start as u32,
+                                base_offset + i as u32,
+                            ),
+                        };
+                        // Optional [index]
+                        if i < len && bytes[i] == b'[' {
+                            i += 1;
+                            let idx_start = i;
+                            while i < len && bytes[i] != b']' && bytes[i] != b'}' {
+                                i += 1;
+                            }
+                            if i < len && bytes[i] == b']' {
+                                let idx_str = &inner[idx_start..i];
+                                i += 1;
+                                let idx_offset = base_offset + idx_start as u32;
+                                let idx_end = base_offset + (i - 1) as u32;
+                                let index_expr =
+                                    parse_simple_index(arena, source, idx_str, idx_offset, idx_end);
+                                let span = Span::new(var_offset, base_offset + i as u32);
+                                expr = Expr {
+                                    kind: ExprKind::ArrayAccess(ArrayAccessExpr {
+                                        array: arena.alloc(expr),
+                                        index: Some(arena.alloc(index_expr)),
+                                    }),
+                                    span,
+                                };
+                            }
+                        }
+                        // Skip to closing }
+                        while i < len && bytes[i] != b'}' {
+                            i += 1;
+                        }
+                        if i < len {
+                            i += 1; // skip }
+                        }
+                        parts.push(StringPart::Expr(expr));
+                    }
+                    literal_start = i;
                 // Check for {$ (complex syntax handled below) - this is simple $var
-                if i + 1 < len && is_var_start(bytes[i + 1]) {
+                } else if i + 1 < len && is_var_start(bytes[i + 1]) {
                     // Flush literal run.
                     if let Some(buf) = owned.take() {
                         if !buf.is_empty() {
@@ -183,27 +297,8 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                             let idx_offset = base_offset + idx_start as u32;
                             let idx_end = base_offset + (i - 1) as u32;
 
-                            // Parse index: integer or bare string key
-                            let index_expr = if let Ok(num) = idx_str.parse::<i64>() {
-                                Expr {
-                                    kind: ExprKind::Int(num),
-                                    span: Span::new(idx_offset, idx_end),
-                                }
-                            } else if idx_str.starts_with('$') && idx_str.len() > 1 {
-                                Expr {
-                                    kind: ExprKind::Variable(Cow::Owned(idx_str[1..].to_string())),
-                                    span: Span::new(idx_offset, idx_end),
-                                }
-                            } else {
-                                // Bare string key (e.g. $arr[key])
-                                Expr {
-                                    kind: ExprKind::String(Cow::Borrowed(
-                                        &source[base_offset as usize + idx_start
-                                            ..base_offset as usize + (i - 1)],
-                                    )),
-                                    span: Span::new(idx_offset, idx_end),
-                                }
-                            };
+                            let index_expr =
+                                parse_simple_index(arena, source, idx_str, idx_offset, idx_end);
 
                             let span = Span::new(var_offset, base_offset + i as u32);
                             let _ = bracket_start; // used implicitly
@@ -389,6 +484,31 @@ pub fn parse_interpolated_parts_indented<'arena, 'src>(
                                 literal.push('x');
                             }
                         }
+                        b'u' => {
+                            // Unicode escape: \u{HHHH} — PHP 7.0+
+                            i += 2;
+                            if i < len && bytes[i] == b'{' {
+                                i += 1; // skip {
+                                let start = i;
+                                while i < len && bytes[i].is_ascii_hexdigit() {
+                                    i += 1;
+                                }
+                                if i < len && bytes[i] == b'}' {
+                                    let hex = &raw_body[start..i];
+                                    if let Ok(codepoint) = u32::from_str_radix(hex, 16) {
+                                        if let Some(c) = char::from_u32(codepoint) {
+                                            literal.push(c);
+                                        }
+                                    }
+                                    i += 1; // skip }
+                                } else {
+                                    literal.push_str(&raw_body[start - 2..i]);
+                                }
+                            } else {
+                                literal.push('\\');
+                                literal.push('u');
+                            }
+                        }
                         b'0'..=b'7' => {
                             let start = i + 1;
                             i += 1;
@@ -478,26 +598,8 @@ pub fn parse_interpolated_parts_indented<'arena, 'src>(
                             i += 1; // skip ]
                             let idx_offset = body_offset + idx_start as u32;
                             let idx_end = body_offset + (i - 1) as u32;
-                            let index_expr = if let Ok(num) = idx_str.parse::<i64>() {
-                                Expr {
-                                    kind: ExprKind::Int(num),
-                                    span: Span::new(idx_offset, idx_end),
-                                }
-                            } else if idx_str.starts_with('$') && idx_str.len() > 1 {
-                                Expr {
-                                    kind: ExprKind::Variable(Cow::Borrowed(
-                                        &raw_body[idx_start + 1..i - 1],
-                                    )),
-                                    span: Span::new(idx_offset, idx_end),
-                                }
-                            } else {
-                                Expr {
-                                    kind: ExprKind::String(Cow::Borrowed(
-                                        &raw_body[idx_start..i - 1],
-                                    )),
-                                    span: Span::new(idx_offset, idx_end),
-                                }
-                            };
+                            let index_expr =
+                                parse_simple_index(arena, source, idx_str, idx_offset, idx_end);
                             let span = Span::new(var_offset, body_offset + i as u32);
                             expr = Expr {
                                 kind: ExprKind::ArrayAccess(ArrayAccessExpr {
@@ -600,6 +702,51 @@ fn is_var_start(b: u8) -> bool {
 
 fn is_var_char(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_' || b >= 0x80
+}
+
+/// Parse an array index from simple string interpolation: `$arr[expr]`.
+/// Handles integers (including negative like `-1`), `$variable` references,
+/// and bare string keys (e.g. `$arr[key]`).
+fn parse_simple_index<'arena, 'src>(
+    _arena: &'arena bumpalo::Bump,
+    source: &'src str,
+    idx_str: &str,
+    idx_offset: u32,
+    idx_end: u32,
+) -> Expr<'arena, 'src> {
+    let span = Span::new(idx_offset, idx_end);
+    // Integer index, including negative (e.g. -1)
+    if let Ok(num) = idx_str.parse::<i64>() {
+        return Expr {
+            kind: ExprKind::Int(num),
+            span,
+        };
+    }
+    // Negative integer written as `-N`
+    if let Some(digits) = idx_str.strip_prefix('-') {
+        if let Ok(num) = digits.parse::<i64>() {
+            return Expr {
+                kind: ExprKind::Int(-num),
+                span,
+            };
+        }
+    }
+    // Variable index: $var
+    if idx_str.starts_with('$') && idx_str.len() > 1 {
+        let name_start = idx_offset as usize + 1;
+        let name_end = idx_offset as usize + idx_str.len();
+        return Expr {
+            kind: ExprKind::Variable(std::borrow::Cow::Borrowed(&source[name_start..name_end])),
+            span,
+        };
+    }
+    // Bare string key (e.g. $arr[key])
+    let key_start = idx_offset as usize;
+    let key_end = idx_end as usize;
+    Expr {
+        kind: ExprKind::String(std::borrow::Cow::Borrowed(&source[key_start..key_end])),
+        span,
+    }
 }
 
 /// Parse a complex interpolation expression using a sub-parser that starts directly

--- a/crates/php-parser/tests/integration.rs
+++ b/crates/php-parser/tests/integration.rs
@@ -1094,6 +1094,15 @@ function combined() {
 }
 
 #[test]
+fn test_yield_from_is_from_flag() {
+    // `yield from` must set is_from:true; plain `yield` must set is_from:false
+    assert_parses_ok("yield from array", "<?php function g() { yield from [1]; }");
+    assert_parses_ok("yield value", "<?php function g() { yield 1; }");
+    assert_parses_ok("yield bare", "<?php function g() { yield; }");
+    assert_parses_ok("yield key value", "<?php function g() { yield $k => $v; }");
+}
+
+#[test]
 fn test_yield_bare() {
     let source = r#"<?php
 function gen() {
@@ -2282,6 +2291,22 @@ fn test_string_interpolation_patterns() {
     assert_parses_ok(
         "prop var in string",
         r#"<?php $x = "name $obj->name here"; "#,
+    );
+    // Fix: negative integer array index in simple interpolation
+    assert_parses_ok("negative int index", r#"<?php $x = "item $arr[-1] here"; "#);
+    // Fix: ${varname} deprecated interpolation syntax
+    assert_parses_ok("dollar-brace simple", r#"<?php $x = "${foo}bar"; "#);
+    assert_parses_ok("dollar-brace array", r#"<?php $x = "${arr[0]}bar"; "#);
+    assert_parses_ok(
+        "dollar-brace var-var",
+        r#"<?php $name = 'x'; $x = "${$name}"; "#,
+    );
+    // Fix: \u{XXXX} unicode escape sequences (PHP 7.0+)
+    assert_parses_ok("unicode escape null", r#"<?php $x = "\u{0}"; "#);
+    assert_parses_ok("unicode escape emoji", r#"<?php $x = "\u{1F602}"; "#);
+    assert_parses_ok(
+        "unicode escape in heredoc",
+        "<?php $x = <<<EOT\n\\u{41}\nEOT;\n",
     );
 }
 

--- a/crates/php-parser/tests/snapshots/integration__yield_as_expression.snap
+++ b/crates/php-parser/tests/snapshots/integration__yield_as_expression.snap
@@ -37,7 +37,8 @@ expression: to_json(&result.program)
                                 "start": 45,
                                 "end": 52
                               }
-                            }
+                            },
+                            "is_from": false
                           }
                         },
                         "span": {
@@ -93,7 +94,8 @@ expression: to_json(&result.program)
                                 "start": 84,
                                 "end": 90
                               }
-                            }
+                            },
+                            "is_from": false
                           }
                         },
                         "span": {

--- a/crates/php-parser/tests/snapshots/integration__yield_bare.snap
+++ b/crates/php-parser/tests/snapshots/integration__yield_bare.snap
@@ -16,7 +16,8 @@ expression: to_json(&result.program)
                   "kind": {
                     "Yield": {
                       "key": null,
-                      "value": null
+                      "value": null,
+                      "is_from": false
                     }
                   },
                   "span": {

--- a/crates/php-parser/tests/snapshots/integration__yield_basic.snap
+++ b/crates/php-parser/tests/snapshots/integration__yield_basic.snap
@@ -24,7 +24,8 @@ expression: to_json(&result.program)
                           "start": 38,
                           "end": 39
                         }
-                      }
+                      },
+                      "is_from": false
                     }
                   },
                   "span": {
@@ -52,7 +53,8 @@ expression: to_json(&result.program)
                           "start": 51,
                           "end": 52
                         }
-                      }
+                      },
+                      "is_from": false
                     }
                   },
                   "span": {
@@ -80,7 +82,8 @@ expression: to_json(&result.program)
                           "start": 64,
                           "end": 65
                         }
-                      }
+                      },
+                      "is_from": false
                     }
                   },
                   "span": {

--- a/crates/php-parser/tests/snapshots/integration__yield_complex.snap
+++ b/crates/php-parser/tests/snapshots/integration__yield_complex.snap
@@ -29,7 +29,8 @@ expression: to_json(&result.program)
                         "kind": {
                           "Yield": {
                             "key": null,
-                            "value": null
+                            "value": null,
+                            "is_from": false
                           }
                         },
                         "span": {
@@ -77,7 +78,8 @@ expression: to_json(&result.program)
                                 "start": 54,
                                 "end": 61
                               }
-                            }
+                            },
+                            "is_from": false
                           }
                         },
                         "span": {
@@ -133,7 +135,8 @@ expression: to_json(&result.program)
                                 "start": 87,
                                 "end": 94
                               }
-                            }
+                            },
+                            "is_from": false
                           }
                         },
                         "span": {
@@ -179,7 +182,8 @@ expression: to_json(&result.program)
                           "start": 111,
                           "end": 121
                         }
-                      }
+                      },
+                      "is_from": true
                     }
                   },
                   "span": {
@@ -225,7 +229,8 @@ expression: to_json(&result.program)
                                           "start": 139,
                                           "end": 142
                                         }
-                                      }
+                                      },
+                                      "is_from": false
                                     }
                                   },
                                   "span": {

--- a/crates/php-parser/tests/snapshots/integration__yield_from.snap
+++ b/crates/php-parser/tests/snapshots/integration__yield_from.snap
@@ -76,7 +76,8 @@ expression: to_json(&result.program)
                           "start": 43,
                           "end": 52
                         }
-                      }
+                      },
+                      "is_from": true
                     }
                   },
                   "span": {
@@ -115,7 +116,8 @@ expression: to_json(&result.program)
                           "start": 69,
                           "end": 85
                         }
-                      }
+                      },
+                      "is_from": true
                     }
                   },
                   "span": {

--- a/crates/php-parser/tests/snapshots/integration__yield_from_complex_expression.snap
+++ b/crates/php-parser/tests/snapshots/integration__yield_from_complex_expression.snap
@@ -176,7 +176,8 @@ expression: to_json(&result.program)
                           "start": 38,
                           "end": 76
                         }
-                      }
+                      },
+                      "is_from": true
                     }
                   },
                   "span": {

--- a/crates/php-parser/tests/snapshots/integration__yield_in_match_arm.snap
+++ b/crates/php-parser/tests/snapshots/integration__yield_in_match_arm.snap
@@ -99,7 +99,8 @@ expression: to_json(&result.program)
                                           "start": 72,
                                           "end": 74
                                         }
-                                      }
+                                      },
+                                      "is_from": false
                                     }
                                   },
                                   "span": {
@@ -126,7 +127,8 @@ expression: to_json(&result.program)
                                           "start": 101,
                                           "end": 102
                                         }
-                                      }
+                                      },
+                                      "is_from": false
                                     }
                                   },
                                   "span": {

--- a/crates/php-parser/tests/snapshots/integration__yield_key_value.snap
+++ b/crates/php-parser/tests/snapshots/integration__yield_key_value.snap
@@ -32,7 +32,8 @@ expression: to_json(&result.program)
                           "start": 47,
                           "end": 48
                         }
-                      }
+                      },
+                      "is_from": false
                     }
                   },
                   "span": {
@@ -68,7 +69,8 @@ expression: to_json(&result.program)
                           "start": 67,
                           "end": 68
                         }
-                      }
+                      },
+                      "is_from": false
                     }
                   },
                   "span": {

--- a/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_expr_arrayspread.snap
+++ b/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_expr_arrayspread.snap
@@ -272,7 +272,8 @@ expression: json
                                       "start": 125,
                                       "end": 127
                                     }
-                                  }
+                                  },
+                                  "is_from": false
                                 }
                               },
                               "span": {

--- a/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_scalar_encapsedstring.snap
+++ b/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_scalar_encapsedstring.snap
@@ -548,7 +548,15 @@ expression: json
           "kind": {
             "InterpolatedString": [
               {
-                "Literal": "${A}"
+                "Expr": {
+                  "kind": {
+                    "Variable": "A"
+                  },
+                  "span": {
+                    "start": 146,
+                    "end": 147
+                  }
+                }
               }
             ]
           },
@@ -569,7 +577,34 @@ expression: json
           "kind": {
             "InterpolatedString": [
               {
-                "Literal": "${A['B']}"
+                "Expr": {
+                  "kind": {
+                    "ArrayAccess": {
+                      "array": {
+                        "kind": {
+                          "Variable": "A"
+                        },
+                        "span": {
+                          "start": 154,
+                          "end": 155
+                        }
+                      },
+                      "index": {
+                        "kind": {
+                          "String": "'B'"
+                        },
+                        "span": {
+                          "start": 156,
+                          "end": 159
+                        }
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 152,
+                    "end": 160
+                  }
+                }
               }
             ]
           },
@@ -590,16 +625,21 @@ expression: json
           "kind": {
             "InterpolatedString": [
               {
-                "Literal": "$"
-              },
-              {
                 "Expr": {
                   "kind": {
-                    "Variable": "A"
+                    "VariableVariable": {
+                      "kind": {
+                        "Variable": "A"
+                      },
+                      "span": {
+                        "start": 167,
+                        "end": 169
+                      }
+                    }
                   },
                   "span": {
-                    "start": 167,
-                    "end": 169
+                    "start": 165,
+                    "end": 170
                   }
                 }
               }

--- a/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_scalar_unicodeescape_1.snap
+++ b/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_scalar_unicodeescape_1.snap
@@ -8,7 +8,7 @@ expression: json
       "kind": {
         "Expression": {
           "kind": {
-            "String": "\\u{0}"
+            "String": "\u0000"
           },
           "span": {
             "start": 7,
@@ -27,7 +27,7 @@ expression: json
           "kind": {
             "InterpolatedString": [
               {
-                "Literal": "\\u{114}"
+                "Literal": "Ĕ"
               },
               {
                 "Expr": {
@@ -59,7 +59,7 @@ expression: json
           "kind": {
             "ShellExec": [
               {
-                "Literal": "\\u{1F602}"
+                "Literal": "😂"
               },
               {
                 "Expr": {

--- a/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_scalar_unicodeescape_2.snap
+++ b/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_scalar_unicodeescape_2.snap
@@ -8,7 +8,7 @@ expression: json
       "kind": {
         "Expression": {
           "kind": {
-            "String": "\\u{0}"
+            "String": "\u0000"
           },
           "span": {
             "start": 7,
@@ -27,7 +27,7 @@ expression: json
           "kind": {
             "InterpolatedString": [
               {
-                "Literal": "\\u{114}"
+                "Literal": "Ĕ"
               },
               {
                 "Expr": {
@@ -59,7 +59,7 @@ expression: json
           "kind": {
             "ShellExec": [
               {
-                "Literal": "\\u{1F602}"
+                "Literal": "😂"
               },
               {
                 "Expr": {

--- a/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_scalar_unicodeescape_3.snap
+++ b/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_scalar_unicodeescape_3.snap
@@ -8,7 +8,7 @@ expression: json
       "kind": {
         "Expression": {
           "kind": {
-            "String": "\\u{FFFFFFFFFFFFFFFF}"
+            "InterpolatedString": []
           },
           "span": {
             "start": 6,

--- a/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_stmt_generator_basic.snap
+++ b/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_stmt_generator_basic.snap
@@ -16,7 +16,8 @@ expression: json
                   "kind": {
                     "Yield": {
                       "key": null,
-                      "value": null
+                      "value": null,
+                      "is_from": false
                     }
                   },
                   "span": {
@@ -44,7 +45,8 @@ expression: json
                           "start": 63,
                           "end": 69
                         }
-                      }
+                      },
+                      "is_from": false
                     }
                   },
                   "span": {
@@ -80,7 +82,8 @@ expression: json
                           "start": 89,
                           "end": 95
                         }
-                      }
+                      },
+                      "is_from": false
                     }
                   },
                   "span": {
@@ -113,7 +116,8 @@ expression: json
                         "kind": {
                           "Yield": {
                             "key": null,
-                            "value": null
+                            "value": null,
+                            "is_from": false
                           }
                         },
                         "span": {
@@ -163,7 +167,8 @@ expression: json
                                     "start": 155,
                                     "end": 161
                                   }
-                                }
+                                },
+                                "is_from": false
                               }
                             },
                             "span": {
@@ -227,7 +232,8 @@ expression: json
                                     "start": 191,
                                     "end": 197
                                   }
-                                }
+                                },
+                                "is_from": false
                               }
                             },
                             "span": {
@@ -269,7 +275,8 @@ expression: json
                             "start": 278,
                             "end": 282
                           }
-                        }
+                        },
+                        "is_from": false
                       }
                     },
                     "span": {
@@ -298,7 +305,8 @@ expression: json
                                 "start": 299,
                                 "end": 303
                               }
-                            }
+                            },
+                            "is_from": false
                           }
                         },
                         "span": {
@@ -342,7 +350,8 @@ expression: json
                             "start": 320,
                             "end": 324
                           }
-                        }
+                        },
+                        "is_from": false
                       }
                     },
                     "span": {
@@ -373,7 +382,8 @@ expression: json
                                 "start": 341,
                                 "end": 345
                               }
-                            }
+                            },
+                            "is_from": false
                           }
                         },
                         "span": {
@@ -419,7 +429,8 @@ expression: json
                             "start": 372,
                             "end": 376
                           }
-                        }
+                        },
+                        "is_from": false
                       }
                     },
                     "span": {
@@ -465,7 +476,8 @@ expression: json
                             "start": 402,
                             "end": 406
                           }
-                        }
+                        },
+                        "is_from": false
                       }
                     },
                     "span": {
@@ -495,7 +507,8 @@ expression: json
                             "start": 427,
                             "end": 431
                           }
-                        }
+                        },
+                        "is_from": false
                       }
                     },
                     "span": {
@@ -527,7 +540,8 @@ expression: json
                               "start": 450,
                               "end": 454
                             }
-                          }
+                          },
+                          "is_from": false
                         }
                       },
                       "span": {
@@ -576,7 +590,8 @@ expression: json
                                     "start": 504,
                                     "end": 508
                                   }
-                                }
+                                },
+                                "is_from": false
                               }
                             },
                             "span": {
@@ -643,7 +658,8 @@ expression: json
                                     "start": 532,
                                     "end": 536
                                   }
-                                }
+                                },
+                                "is_from": false
                               }
                             },
                             "span": {
@@ -701,7 +717,8 @@ expression: json
                                     "start": 557,
                                     "end": 561
                                   }
-                                }
+                                },
+                                "is_from": false
                               }
                             },
                             "span": {
@@ -744,7 +761,8 @@ expression: json
                           "start": 580,
                           "end": 584
                         }
-                      }
+                      },
+                      "is_from": true
                     }
                   },
                   "span": {
@@ -789,7 +807,8 @@ expression: json
                                       "start": 621,
                                       "end": 625
                                     }
-                                  }
+                                  },
+                                  "is_from": true
                                 }
                               },
                               "span": {
@@ -803,7 +822,8 @@ expression: json
                           "start": 601,
                           "end": 625
                         }
-                      }
+                      },
+                      "is_from": true
                     }
                   },
                   "span": {
@@ -851,7 +871,8 @@ expression: json
                           "start": 642,
                           "end": 653
                         }
-                      }
+                      },
+                      "is_from": true
                     }
                   },
                   "span": {

--- a/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_stmt_generator_yieldprecedence.snap
+++ b/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_stmt_generator_yieldprecedence.snap
@@ -44,7 +44,8 @@ expression: json
                           "start": 34,
                           "end": 43
                         }
-                      }
+                      },
+                      "is_from": false
                     }
                   },
                   "span": {
@@ -92,7 +93,8 @@ expression: json
                           "start": 55,
                           "end": 65
                         }
-                      }
+                      },
+                      "is_from": false
                     }
                   },
                   "span": {
@@ -148,7 +150,8 @@ expression: json
                           "start": 84,
                           "end": 93
                         }
-                      }
+                      },
+                      "is_from": false
                     }
                   },
                   "span": {
@@ -204,7 +207,8 @@ expression: json
                           "start": 112,
                           "end": 122
                         }
-                      }
+                      },
+                      "is_from": false
                     }
                   },
                   "span": {
@@ -280,7 +284,8 @@ expression: json
                                             "start": 151,
                                             "end": 160
                                           }
-                                        }
+                                        },
+                                        "is_from": false
                                       }
                                     },
                                     "span": {
@@ -380,21 +385,24 @@ expression: json
                                       "start": 202,
                                       "end": 211
                                     }
-                                  }
+                                  },
+                                  "is_from": false
                                 }
                               },
                               "span": {
                                 "start": 188,
                                 "end": 211
                               }
-                            }
+                            },
+                            "is_from": false
                           }
                         },
                         "span": {
                           "start": 174,
                           "end": 211
                         }
-                      }
+                      },
+                      "is_from": false
                     }
                   },
                   "span": {
@@ -439,7 +447,8 @@ expression: json
                                           "start": 244,
                                           "end": 248
                                         }
-                                      }
+                                      },
+                                      "is_from": false
                                     }
                                   },
                                   "span": {
@@ -452,7 +461,8 @@ expression: json
                                 "start": 237,
                                 "end": 250
                               }
-                            }
+                            },
+                            "is_from": false
                           }
                         },
                         "span": {
@@ -488,7 +498,8 @@ expression: json
                           "start": 253,
                           "end": 262
                         }
-                      }
+                      },
+                      "is_from": false
                     }
                   },
                   "span": {
@@ -576,14 +587,16 @@ expression: json
                                                   "start": 306,
                                                   "end": 315
                                                 }
-                                              }
+                                              },
+                                              "is_from": false
                                             }
                                           },
                                           "span": {
                                             "start": 292,
                                             "end": 315
                                           }
-                                        }
+                                        },
+                                        "is_from": false
                                       }
                                     },
                                     "span": {
@@ -672,7 +685,8 @@ expression: json
                                                       "start": 354,
                                                       "end": 358
                                                     }
-                                                  }
+                                                  },
+                                                  "is_from": false
                                                 }
                                               },
                                               "span": {
@@ -685,7 +699,8 @@ expression: json
                                             "start": 347,
                                             "end": 360
                                           }
-                                        }
+                                        },
+                                        "is_from": false
                                       }
                                     },
                                     "span": {

--- a/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_stmt_generator_yieldunaryprecedence.snap
+++ b/crates/php-parser/tests/snapshots/nikic_integration_tests__nikic_stmt_generator_yieldunaryprecedence.snap
@@ -35,7 +35,8 @@ expression: json
                           "start": 34,
                           "end": 36
                         }
-                      }
+                      },
+                      "is_from": false
                     }
                   },
                   "span": {
@@ -74,7 +75,8 @@ expression: json
                           "start": 48,
                           "end": 50
                         }
-                      }
+                      },
+                      "is_from": false
                     }
                   },
                   "span": {
@@ -97,7 +99,8 @@ expression: json
                         "kind": {
                           "Yield": {
                             "key": null,
-                            "value": null
+                            "value": null,
+                            "is_from": false
                           }
                         },
                         "span": {


### PR DESCRIPTION
Four correctness bugs identified in static analysis:

1. \u{XXXX} unicode escapes not decoded PHP 7.0+ requires "\u{1F602}" to produce the Unicode codepoint. The escape handler in both parse_interpolated_parts and parse_interpolated_parts_indented had no b'u' case, so \u{114} was kept as raw bytes. Added \u{HHHH} decoding via char::from_u32.

2. yield from loses delegation semantics in AST YieldExpr had no way to distinguish `yield $val` from `yield from $gen`. Added is_from: bool field; the yield-from path sets it true, all plain yield paths set it false. Updated 11 snapshots.

3. Negative integer array index in simple string interpolation "$arr[-1]" fell through to the bare-string-key branch and was stored as String("-1") instead of Int(-1). Extracted a parse_simple_index helper that handles the negative case via strip_prefix('-'), used in both interpolation functions.

4. ${varname} deprecated interpolation syntax not parsed "${foo}" was kept as a literal string in the AST. This form (deprecated in PHP 8.2) is valid in PHP 5-8.1. Added a b'$' followed by b'{' branch: ${varname} -> Variable, ${varname[idx]} -> ArrayAccess, ${$var} -> VariableVariable (via sub-parser).