### PR TITLE
test: improve test suite quality and coverage

### DIFF
--- a/crates/php-parser/build.rs
+++ b/crates/php-parser/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(php_available)");
+    println!("cargo::rustc-check-cfg=cfg(php_min_82)");
     println!("cargo::rustc-check-cfg=cfg(php_min_83)");
     println!("cargo::rustc-check-cfg=cfg(php_min_84)");
     println!("cargo::rustc-check-cfg=cfg(php_min_85)");
@@ -18,6 +19,9 @@ fn main() {
     let Ok(maj) = maj.parse::<u32>() else { return };
     let Ok(min) = min.parse::<u32>() else { return };
     println!("cargo:rustc-cfg=php_available");
+    if (maj, min) >= (8, 2) {
+        println!("cargo:rustc-cfg=php_min_82");
+    }
     if (maj, min) >= (8, 3) {
         println!("cargo:rustc-cfg=php_min_83");
     }

--- a/crates/php-parser/tests/inline_cases.rs
+++ b/crates/php-parser/tests/inline_cases.rs
@@ -1,0 +1,321 @@
+/// Inline PHP source strings shared between the parser integration tests
+/// (`integration.rs`) and the PHP syntax validation tests (`php_syntax.rs`).
+///
+/// All cases live in a single `CASES` slice.  Each entry carries optional
+/// `min_php` / `max_php` bounds (defaulting to `Any` via the `case!` macro).
+/// `php_syntax.rs` skips entries whose bounds the installed PHP cannot satisfy.
+/// `integration.rs` runs every entry regardless (the Rust parser targets 8.5).
+///
+/// Adding a new case:
+///   • valid on any supported PHP      → `case!("cat", "label", "<?php ...")`
+///   • requires PHP X.Y+               → `case!(..., min: MinPhp::PhpXY)`
+///   • valid only up to PHP X.Y        → `case!(..., max: MaxPhp::PhpXY)`
+///   • both bounds                     → `case!(..., min: MinPhp::PhpXY, max: MaxPhp::PhpAB)`
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MinPhp { Any, Php82, Php83, Php84, Php85 }
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MaxPhp { Any, Php84, Php83, Php82 }
+
+#[allow(dead_code)]
+pub struct Case {
+    pub category: &'static str,
+    pub label: &'static str,
+    pub source: &'static str,
+    pub min_php: MinPhp,
+    pub max_php: MaxPhp,
+}
+
+macro_rules! case {
+    ($cat:expr, $label:expr, $src:expr) => {
+        Case { category: $cat, label: $label, source: $src, min_php: MinPhp::Any, max_php: MaxPhp::Any }
+    };
+    ($cat:expr, $label:expr, $src:expr, min: $min:expr) => {
+        Case { category: $cat, label: $label, source: $src, min_php: $min, max_php: MaxPhp::Any }
+    };
+    ($cat:expr, $label:expr, $src:expr, max: $max:expr) => {
+        Case { category: $cat, label: $label, source: $src, min_php: MinPhp::Any, max_php: $max }
+    };
+    ($cat:expr, $label:expr, $src:expr, min: $min:expr, max: $max:expr) => {
+        Case { category: $cat, label: $label, source: $src, min_php: $min, max_php: $max }
+    };
+}
+
+pub const CASES: &[Case] = &[
+    // clone
+    case!("clone", "clone parenthesised", "<?php $copy = clone($obj);"),
+    case!("clone", "clone parenthesised trailing comma", "<?php $copy = clone($obj, );", min: MinPhp::Php85),
+    case!("clone", "clone first-class callable", "<?php $fn = clone(...);", min: MinPhp::Php85),
+    case!("clone", "clone named arg", "<?php clone(object: $x);", min: MinPhp::Php85),
+    case!("clone", "clone named args two", "<?php clone(object: $x, withProperties: ['foo' => 1]);", min: MinPhp::Php85),
+    case!("clone", "clone three positional args", "<?php clone($x, $y, $z);", min: MinPhp::Php85),
+    case!("clone", "clone spread arg", "<?php clone(...$args);", min: MinPhp::Php85),
+
+    // cast_void
+    case!("cast_void", "void cast", "<?php (void)$x;", min: MinPhp::Php85),
+    case!("cast_void", "void cast call", "<?php (void)foo();", min: MinPhp::Php85),
+
+    // error_suppress
+    case!("error_suppress", "suppress chain", "<?php @$a->b()->c;"),
+    case!("error_suppress", "suppress new", "<?php @(new Foo())->init();"),
+    case!("error_suppress", "suppress include", "<?php @include 'optional.php';"),
+    case!("error_suppress", "suppress array access", "<?php @$arr[$key];"),
+
+    // declare
+    case!("declare", "declare encoding", "<?php declare(encoding='UTF-8');"),
+    case!("declare", "declare ticks inline", "<?php declare(ticks=1) echo 'tick';"),
+    case!("declare", "declare strict", "<?php declare(strict_types=1);"),
+    case!("declare", "declare with block", "<?php declare(ticks=1) { foo(); bar(); }"),
+    case!("declare", "declare ticks value 100", "<?php declare(ticks=100);"),
+
+    // magic_constants
+    case!("magic_constants", "all magic consts", "<?php echo __LINE__, __FILE__, __DIR__, __FUNCTION__, __CLASS__, __TRAIT__, __METHOD__, __NAMESPACE__;"),
+    case!("magic_constants", "line in expression", "<?php $line = __LINE__ + 1;"),
+    case!("magic_constants", "file in string", r#"<?php $f = "loaded from " . __FILE__;"#),
+    case!("magic_constants", "dir concat", "<?php require __DIR__ . '/config.php';"),
+    case!("magic_constants", "class in method", "<?php class Foo { public function name() { return __CLASS__; } }"),
+
+    // string_interpolation
+    case!("string_interpolation", "nested curly", r#"<?php $x = "Value: {$arr['key']}"; "#),
+    case!("string_interpolation", "method in string", r#"<?php $x = "Name: {$obj->getName()}"; "#),
+    case!("string_interpolation", "complex curly", r#"<?php $x = "{$a[$b][$c]}"; "#),
+    case!("string_interpolation", "dollar brace", r#"<?php $x = "${name}s"; "#),
+    case!("string_interpolation", "adjacent vars", r#"<?php $x = "$a$b$c"; "#),
+    case!("string_interpolation", "var at end", r#"<?php $x = "hello $name"; "#),
+    case!("string_interpolation", "escaped dollar", r#"<?php $x = "cost is \$5"; "#),
+    case!("string_interpolation", "heredoc interp", "<?php $x = <<<EOT\nHello $name\nEOT;\n"),
+    case!("string_interpolation", "chained in string", r#"<?php $x = "{$obj->items[0]->name}"; "#),
+    case!("string_interpolation", "dynamic prop in string", r#"<?php $x = "{$obj->$prop}"; "#),
+    case!("string_interpolation", "array var in string", r#"<?php $x = "item $arr[0] here"; "#),
+    case!("string_interpolation", "prop var in string", r#"<?php $x = "name $obj->name here"; "#),
+    case!("string_interpolation", "negative int index", r#"<?php $x = "item $arr[-1] here"; "#),
+    case!("string_interpolation", "dollar-brace simple", r#"<?php $x = "${foo}bar"; "#),
+    case!("string_interpolation", "dollar-brace array", r#"<?php $x = "${arr[0]}bar"; "#),
+    case!("string_interpolation", "dollar-brace var-var", r#"<?php $name = 'x'; $x = "${$name}"; "#),
+    case!("string_interpolation", "unicode escape null", r#"<?php $x = "\u{0}"; "#),
+    case!("string_interpolation", "unicode escape emoji", r#"<?php $x = "\u{1F602}"; "#),
+    case!("string_interpolation", "unicode escape in heredoc", "<?php $x = <<<EOT\n\\u{41}\nEOT;\n"),
+
+    // heredoc
+    case!("heredoc", "nowdoc basic", "<?php $x = <<<'EOT'\nhello world\nEOT;\n"),
+    case!("heredoc", "heredoc indented close", "<?php $x = <<<EOT\n    hello\n    EOT;\n"),
+    case!("heredoc", "heredoc in function arg", "<?php foo(<<<EOT\nhello\nEOT\n);\n"),
+    case!("heredoc", "heredoc closing marker followed by )", "<?php foo(<<<EOT\nhello\nEOT);\n"),
+    case!("heredoc", "heredoc closing marker followed by ,", "<?php $a = [<<<EOT\nhello\nEOT,\n\"world\"];\n"),
+    case!("heredoc", "named arg with heredoc value", "<?php foo(bar: <<<EOT\nhello\nEOT\n);\n"),
+    case!("heredoc", "named arg with heredoc closing marker followed by )", "<?php foo(bar: <<<EOT\nhello\nEOT);\n"),
+
+    // operator_precedence
+    case!("operator_precedence", "nested ternary", "<?php $a ? $b : ($c ? $d : $e);"),
+    case!("operator_precedence", "null coalesce chain", "<?php $a ?? $b ?? $c ?? 'default';"),
+    case!("operator_precedence", "mixed bitwise logical", "<?php $a & $b && $c | $d;"),
+    case!("operator_precedence", "instanceof chain", "<?php $a instanceof Foo && $b instanceof Bar;"),
+    case!("operator_precedence", "chained assignment", "<?php $a = $b = $c = 1;"),
+    case!("operator_precedence", "assignment in ternary", "<?php $a = $b ? $c : $d;"),
+    case!("operator_precedence", "comparison chain", "<?php $a == $b && $b == $c;"),
+    case!("operator_precedence", "power assoc", "<?php $a ** $b ** $c;"),
+    case!("operator_precedence", "unary in binary", "<?php !$a && !$b || !$c;"),
+    case!("operator_precedence", "concat precedence", "<?php 'a' . 'b' . $c . 'd';"),
+    case!("operator_precedence", "postfix in expr", "<?php $arr[$i++] = $j--;"),
+    case!("operator_precedence", "error suppress complex", "<?php @$obj->method();"),
+    case!("operator_precedence", "cast precedence", "<?php (int)$a + (string)$b;"),
+    case!("operator_precedence", "spread in array", "<?php [...$a, ...$b, 1, 2];"),
+
+    // assignment
+    case!("assignment", "null coalesce assign", "<?php $a ??= 'default';"),
+    case!("assignment", "concat assign", "<?php $str .= ' world';"),
+    case!("assignment", "power assign", "<?php $x **= 2;"),
+    case!("assignment", "ref assign", "<?php $a = &$b;"),
+    case!("assignment", "array push", "<?php $arr[] = 'new';"),
+    case!("assignment", "nested array push", "<?php $arr[][] = 'deep';"),
+    case!("assignment", "list with keys", "<?php ['x' => $x, 'y' => $y] = getPoint();"),
+
+    // expression_chains
+    case!("expression_chains", "call result access", "<?php foo()[0];"),
+    case!("expression_chains", "call result method", "<?php foo()->bar();"),
+    case!("expression_chains", "new paren method", "<?php (new Foo())->bar();"),
+    case!("expression_chains", "new paren prop", "<?php (new Foo)->prop;"),
+    case!("expression_chains", "chained calls", "<?php $a->b()->c()->d();"),
+    case!("expression_chains", "call result array method", "<?php $a->b()[0]->c();"),
+    case!("expression_chains", "clone chain", "<?php clone $obj->getPrototype();"),
+    case!("expression_chains", "new with chaining", "<?php (new Foo(1, 2))->init()->run();"),
+    case!("expression_chains", "static call chain", "<?php Foo::create()->setup();"),
+    case!("expression_chains", "nested new", "<?php new Foo(new Bar());"),
+    case!("expression_chains", "double call", "<?php $factory()();"),
+    case!("expression_chains", "array on new", "<?php (new Collection([1,2,3]))[0];"),
+
+    // dynamic_access
+    case!("dynamic_access", "dynamic prop", "<?php $obj->$prop;"),
+    case!("dynamic_access", "dynamic prop expr", r#"<?php $obj->{$prefix . 'Name'};"#),
+    case!("dynamic_access", "dynamic static", "<?php $class::$prop;"),
+    case!("dynamic_access", "dynamic method", "<?php $obj->$method();"),
+    case!("dynamic_access", "dynamic static method", "<?php $class::$method();"),
+    case!("dynamic_access", "variable class new", "<?php new $className();"),
+    case!("dynamic_access", "variable class static", "<?php $class::CONST_NAME;"),
+
+    // destructuring
+    case!("destructuring", "nested array destruct", "<?php [[$a, $b], [$c, $d]] = $arr;"),
+    case!("destructuring", "deep nesting", "<?php [$a, [$b, [$c, [$d]]]] = $arr;"),
+    case!("destructuring", "keyed destruct", "<?php ['name' => $name, 'age' => $age] = $person;"),
+    case!("destructuring", "mixed keyed/positional", "<?php [0 => $first, 'key' => $val] = $arr;"),
+    case!("destructuring", "list nested", "<?php list($a, list($b, $c)) = $arr;"),
+
+    // alternative_syntax
+    case!("alternative_syntax", "if endif", "<?php if ($x): echo 1; elseif ($y): echo 2; else: echo 3; endif;"),
+    case!("alternative_syntax", "while endwhile", "<?php while ($x): doStuff(); endwhile;"),
+    case!("alternative_syntax", "for endfor", "<?php for ($i = 0; $i < 10; $i++): echo $i; endfor;"),
+    case!("alternative_syntax", "foreach endforeach", "<?php foreach ($arr as $v): echo $v; endforeach;"),
+    case!("alternative_syntax", "switch endswitch", "<?php switch ($x): case 1: echo 'one'; break; default: echo 'other'; endswitch;"),
+
+    // control_flow
+    case!("control_flow", "foreach destructure", "<?php foreach ($arr as [$key, $value]) { echo $key; }"),
+    case!("control_flow", "foreach keyed destruct", "<?php foreach ($arr as $k => [$a, $b]) {}"),
+    case!("control_flow", "switch default middle", "<?php switch ($x) { case 1: break; default: break; case 2: break; }"),
+    case!("control_flow", "empty switch", "<?php switch ($x) {}"),
+    case!("control_flow", "multiple braced ns", "<?php namespace A { function foo() {} } namespace B { function bar() {} }"),
+    case!("control_flow", "empty braced ns", "<?php namespace A { }"),
+    case!("control_flow", "global ns block", "<?php namespace { function main() {} }"),
+
+    // try_catch
+    case!("try_catch", "multi catch types", "<?php try { foo(); } catch (TypeError | ValueError $e) { echo $e; }"),
+    case!("try_catch", "catch no var", "<?php try { foo(); } catch (Exception) { echo 'error'; }"),
+    case!("try_catch", "multi catch blocks", "<?php try { foo(); } catch (A $a) { } catch (B $b) { } catch (C $c) { }"),
+    case!("try_catch", "try finally no catch", "<?php try { foo(); } finally { cleanup(); }"),
+    case!("try_catch", "catch rethrow", "<?php try { foo(); } catch (Exception $e) { throw $e; }"),
+    case!("try_catch", "multi catch no var", "<?php try { foo(); } catch (TypeError | ValueError) { log(); }"),
+
+    // match
+    case!("match", "match multi conditions", "<?php $r = match($x) { 1, 2, 3 => 'low', 4, 5 => 'high' };"),
+    case!("match", "match with default", "<?php $r = match(true) { $a > 0 => 'pos', default => 'other' };"),
+    case!("match", "match in assignment", "<?php $y = match($x) { 'a' => 1, 'b' => 2, default => 0 };"),
+    case!("match", "match nested", "<?php $r = match($a) { 1 => match($b) { 1 => 'aa', default => 'ab' }, default => 'x' };"),
+    case!("match", "match throw", "<?php $r = match($x) { 1 => 'ok', default => throw new Exception() };"),
+    case!("match", "match no default", "<?php $r = match($x) { 1 => 'one', 2 => 'two' };"),
+
+    // function
+    case!("function", "variadic typed", "<?php function foo(int ...$nums) {}"),
+    case!("function", "nullable return", "<?php function foo(): ?int { return null; }"),
+    case!("function", "union return", "<?php function foo(): int|string { return 1; }"),
+    case!("function", "intersection param", "<?php function foo(Countable&Traversable $x) {}"),
+    case!("function", "by ref return", "<?php function &getRef() { global $x; return $x; }"),
+
+    // named_args
+    case!("named_args", "mixed named args", "<?php foo(1, 2, name: 'test', other: true);"),
+    case!("named_args", "named with spread", "<?php foo(...$extra, name: 'test');"),
+    case!("named_args", "named in new", "<?php new Foo(x: 1, y: 2);"),
+    case!("named_args", "named in method", "<?php $obj->method(key: 'val');"),
+
+    // closure
+    case!("closure", "static arrow", "<?php $fn = static fn($x) => $x * 2;"),
+    case!("closure", "arrow returns arrow", "<?php $fn = fn($x) => fn($y) => $x + $y;"),
+    case!("closure", "closure use by ref", "<?php $fn = function() use (&$a, &$b) { return $a + $b; };"),
+    case!("closure", "closure with return type", "<?php $fn = function(int $x): string { return (string)$x; };"),
+    case!("closure", "arrow with array", "<?php $fn = fn($x) => [$x, $x * 2];"),
+    case!("closure", "arrow typed", "<?php $fn = fn(int $x): int => $x * 2;"),
+    case!("closure", "arrow in array_map", "<?php array_map(fn($x) => $x * 2, $arr);"),
+    case!("closure", "arrow with null coalesce", "<?php $fn = fn($x) => $x ?? 'default';"),
+    case!("closure", "closure static typed", "<?php $fn = static function(int $x): int { return $x; };"),
+    case!("closure", "arrow in ternary", "<?php $fn = $flag ? fn($x) => $x + 1 : fn($x) => $x - 1;"),
+    case!("closure", "arrow in call", "<?php array_filter($arr, fn($x) => $x > 0);"),
+    case!("closure", "closure immediately invoked", "<?php (function() { echo 'hi'; })();"),
+
+    // arrow_function
+    case!("arrow_function", "arrow fn value", "<?php $a = ['map' => fn($x) => $x * 2, 'filter' => fn($x) => $x > 0];"),
+    case!("arrow_function", "arrow captures outer", "<?php $mult = fn($x) => $x * $factor;"),
+    case!("arrow_function", "arrow nested capture", "<?php $fn = fn($x) => fn($y) => $x * $y * $base;"),
+    case!("arrow_function", "arrow with match", "<?php $classify = fn($n) => match(true) { $n < 0 => 'neg', $n === 0 => 'zero', default => 'pos' };"),
+    case!("arrow_function", "arrow never return type", "<?php $fn = fn(): int => 42;"),
+    case!("arrow_function", "arrow nullable typed", "<?php $fn = fn(?string $s): ?int => $s ? strlen($s) : null;"),
+
+    // generator
+    case!("generator", "yield value", "<?php function gen() { yield 1; yield 2; }"),
+    case!("generator", "yield key value", "<?php function gen() { yield 'a' => 1; yield 'b' => 2; }"),
+    case!("generator", "yield from", "<?php function gen() { yield from [1, 2, 3]; }"),
+    case!("generator", "yield from call", "<?php function gen() { yield from otherGen(); }"),
+    case!("generator", "yield in assign", "<?php function gen() { $val = yield 'key' => 'value'; }"),
+    case!("generator", "yield null", "<?php function gen() { yield; }"),
+
+    // yield_from_flag
+    case!("yield_from_flag", "yield from array", "<?php function g() { yield from [1]; }"),
+    case!("yield_from_flag", "yield value", "<?php function g() { yield 1; }"),
+    case!("yield_from_flag", "yield bare", "<?php function g() { yield; }"),
+    case!("yield_from_flag", "yield key value", "<?php function g() { yield $k => $v; }"),
+
+    // class
+    case!("class", "abstract with interface", "<?php abstract class Foo implements Bar, Baz { abstract public function run(): void; }"),
+    case!("class", "const visibility", "<?php class Foo { public const A = 1; protected const B = 2; private const C = 3; }"),
+    case!("class", "promoted with defaults", "<?php class Foo { public function __construct(public readonly int $x, private string $y = 'default') {} }"),
+    case!("class", "anon class full", "<?php $obj = new class(1) extends Base implements Iface1, Iface2 { public function run() {} };"),
+    case!("class", "interface extends multi", "<?php interface Foo extends Bar, Baz { public function run(): void; }"),
+    case!("class", "abstract method", "<?php abstract class Foo { abstract protected function bar(int $x): string; }"),
+    case!("class", "readonly class", "<?php readonly class Point { public function __construct(public int $x, public int $y) {} }", min: MinPhp::Php82),
+
+    // readonly_class
+    case!("readonly_class", "readonly final class", "<?php readonly final class Foo {}", min: MinPhp::Php82),
+    case!("readonly_class", "readonly final class with body", "<?php readonly final class Point { public function __construct(public int $x, public int $y) {} }", min: MinPhp::Php82),
+
+    // enum
+    case!("enum", "enum implements", "<?php enum Color implements HasLabel { case Red; public function label(): string { return 'red'; } }"),
+    case!("enum", "enum const", "<?php enum Suit: string { const TOTAL = 4; case Hearts = 'H'; }"),
+    case!("enum", "enum with use", "<?php enum Suit { use SuitTrait; case Hearts; }"),
+    case!("enum", "pure enum", "<?php enum Direction { case North; case South; case East; case West; }"),
+    case!("enum", "backed enum int", "<?php enum Status: int { case Active = 1; case Inactive = 0; }"),
+    case!("enum", "enum static method", "<?php enum Color { case Red; public static function default(): self { return self::Red; } }"),
+    case!("enum", "enum interface method", "<?php enum Suit: string implements \\Stringable { case Hearts = 'H'; public function __toString(): string { return $this->value; } }"),
+    case!("enum", "enum from and tryFrom", "<?php Status::from(1); Status::tryFrom(99);"),
+
+    // typed_class_constants (PHP 8.3+)
+    case!("typed_class_constants", "typed int const", "<?php class A { const int X = 1; }", min: MinPhp::Php83),
+    case!("typed_class_constants", "typed string const", "<?php class A { private const string Y = 'a'; }", min: MinPhp::Php83),
+    case!("typed_class_constants", "typed union const", "<?php class A { const int|string Z = 1; }", min: MinPhp::Php83),
+    case!("typed_class_constants", "typed nullable const", "<?php class A { const ?string N = null; }", min: MinPhp::Php83),
+
+    // scope_resolution
+    case!("scope_resolution", "self const", "<?php class Foo { const X = 1; public function f() { return self::X; } }"),
+    case!("scope_resolution", "parent method", "<?php class Foo extends Bar { public function f() { parent::f(); } }"),
+    case!("scope_resolution", "static late", "<?php class Foo { public static function create() { return new static(); } }"),
+    case!("scope_resolution", "class const on name", "<?php echo Foo::class;"),
+    case!("scope_resolution", "static prop", "<?php class Foo { public static int $count = 0; }"),
+    case!("scope_resolution", "parent const", "<?php class Foo extends Bar { public function f() { return parent::VERSION; } }"),
+    case!("scope_resolution", "static const", "<?php class Foo { public function f() { return static::DEFAULT; } }"),
+    case!("scope_resolution", "self static prop", "<?php class Foo { public static $x = 1; public function f() { return self::$x; } }"),
+
+    // type_hints
+    case!("type_hints", "dnf complex", "<?php function f((A&B)|C $x) {}"),
+    case!("type_hints", "dnf multi groups", "<?php function f((A&B)|(C&D) $x) {}"),
+    case!("type_hints", "union with null", "<?php function f(int|string|null $x) {}"),
+    case!("type_hints", "self return", "<?php class Foo { public function bar(): self {} }"),
+    case!("type_hints", "static return", "<?php class Foo { public function bar(): static {} }"),
+    case!("type_hints", "parent type", "<?php class Foo extends Bar { public function bar(): parent {} }"),
+    case!("type_hints", "mixed type", "<?php function f(mixed $x): mixed {}"),
+    case!("type_hints", "never return", "<?php function abort(): never { throw new Exception(); }"),
+    case!("type_hints", "void return", "<?php function f(): void {}"),
+    case!("type_hints", "iterable type", "<?php function f(iterable $x): iterable {}"),
+    case!("type_hints", "callable type", "<?php function f(callable $x) {}"),
+
+    // attributes
+    case!("attributes", "attr qualified name", "<?php #[\\App\\Attr] function foo() {}"),
+    case!("attributes", "attr on param", "<?php function foo(#[Validate] int $x) {}"),
+    case!("attributes", "attr complex args", "<?php #[Route('/api', methods: ['GET', 'POST'])] function handler() {}"),
+    case!("attributes", "attr on enum case", "<?php enum Suit { #[Description('Hearts')] case Hearts; }"),
+    case!("attributes", "stacked attrs", "<?php #[A] #[B] #[C] class Foo {}"),
+    case!("attributes", "grouped attrs", "<?php #[A, B, C] class Foo {}"),
+
+    // builtins
+    case!("builtins", "list assign", "<?php list($a, $b) = $arr;"),
+    case!("builtins", "short echo", "<?= $value ?>"),
+    case!("builtins", "multiple echo", "<?php echo $a, $b, $c;"),
+    case!("builtins", "die with arg", "<?php die('error');"),
+    case!("builtins", "exit with code", "<?php exit(1);"),
+    case!("builtins", "isset multi", "<?php if (isset($a, $b, $c)) {}"),
+    case!("builtins", "unset multi", "<?php unset($a, $b);"),
+    case!("builtins", "global multi", "<?php global $a, $b, $c;"),
+    case!("builtins", "static var multi", "<?php function f() { static $a = 1, $b = 2; }"),
+    case!("builtins", "declare strict", "<?php declare(strict_types=1);"),
+    case!("builtins", "eval", "<?php eval('echo 1;');"),
+    case!("builtins", "require once", "<?php require_once 'autoload.php';"),
+    case!("builtins", "include expr", "<?php include $dir . '/file.php';"),
+];

--- a/crates/php-parser/tests/inline_cases.rs
+++ b/crates/php-parser/tests/inline_cases.rs
@@ -14,11 +14,22 @@
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum MinPhp { Any, Php82, Php83, Php84, Php85 }
+pub enum MinPhp {
+    Any,
+    Php82,
+    Php83,
+    Php84,
+    Php85,
+}
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum MaxPhp { Any, Php84, Php83, Php82 }
+pub enum MaxPhp {
+    Any,
+    Php84,
+    Php83,
+    Php82,
+}
 
 #[allow(dead_code)]
 pub struct Case {
@@ -31,16 +42,40 @@ pub struct Case {
 
 macro_rules! case {
     ($cat:expr, $label:expr, $src:expr) => {
-        Case { category: $cat, label: $label, source: $src, min_php: MinPhp::Any, max_php: MaxPhp::Any }
+        Case {
+            category: $cat,
+            label: $label,
+            source: $src,
+            min_php: MinPhp::Any,
+            max_php: MaxPhp::Any,
+        }
     };
     ($cat:expr, $label:expr, $src:expr, min: $min:expr) => {
-        Case { category: $cat, label: $label, source: $src, min_php: $min, max_php: MaxPhp::Any }
+        Case {
+            category: $cat,
+            label: $label,
+            source: $src,
+            min_php: $min,
+            max_php: MaxPhp::Any,
+        }
     };
     ($cat:expr, $label:expr, $src:expr, max: $max:expr) => {
-        Case { category: $cat, label: $label, source: $src, min_php: MinPhp::Any, max_php: $max }
+        Case {
+            category: $cat,
+            label: $label,
+            source: $src,
+            min_php: MinPhp::Any,
+            max_php: $max,
+        }
     };
     ($cat:expr, $label:expr, $src:expr, min: $min:expr, max: $max:expr) => {
-        Case { category: $cat, label: $label, source: $src, min_php: $min, max_php: $max }
+        Case {
+            category: $cat,
+            label: $label,
+            source: $src,
+            min_php: $min,
+            max_php: $max,
+        }
     };
 }
 

--- a/crates/php-parser/tests/integration.rs
+++ b/crates/php-parser/tests/integration.rs
@@ -47,7 +47,10 @@ fixture_test!(test_arrays, "arrays.php");
 fixture_test!(test_inline_html, "inline_html.php");
 fixture_test!(test_assignment_ops, "assignment_ops.php");
 fixture_test!(test_anonymous_classes, "anonymous_classes.php");
-fixture_test!(test_string_interpolation_fixture, "string_interpolation.php");
+fixture_test!(
+    test_string_interpolation_fixture,
+    "string_interpolation.php"
+);
 fixture_test!(test_attributes_fixture, "attributes.php");
 
 // =============================================================================
@@ -1088,7 +1091,9 @@ function combined() {
 mod inline_cases;
 
 fn category(cat: &'static str) -> impl Iterator<Item = &'static inline_cases::Case> {
-    inline_cases::CASES.iter().filter(move |c| c.category == cat)
+    inline_cases::CASES
+        .iter()
+        .filter(move |c| c.category == cat)
 }
 
 #[test]
@@ -1097,15 +1102,6 @@ fn test_yield_from_is_from_flag() {
     for case in category("yield_from_flag") {
         assert_parses_ok(case.label, case.source);
     }
-}
-
-#[test]
-fn test_yield_from_is_from_flag() {
-    // `yield from` must set is_from:true; plain `yield` must set is_from:false
-    assert_parses_ok("yield from array", "<?php function g() { yield from [1]; }");
-    assert_parses_ok("yield value", "<?php function g() { yield 1; }");
-    assert_parses_ok("yield bare", "<?php function g() { yield; }");
-    assert_parses_ok("yield key value", "<?php function g() { yield $k => $v; }");
 }
 
 #[test]

--- a/crates/php-parser/tests/integration.rs
+++ b/crates/php-parser/tests/integration.rs
@@ -47,6 +47,8 @@ fixture_test!(test_arrays, "arrays.php");
 fixture_test!(test_inline_html, "inline_html.php");
 fixture_test!(test_assignment_ops, "assignment_ops.php");
 fixture_test!(test_anonymous_classes, "anonymous_classes.php");
+fixture_test!(test_string_interpolation_fixture, "string_interpolation.php");
+fixture_test!(test_attributes_fixture, "attributes.php");
 
 // =============================================================================
 // Error recovery tests
@@ -611,30 +613,19 @@ fn test_clone_expression() {
 
 #[test]
 fn test_clone_parenthesised() {
-    // clone($obj) — parenthesised single-arg form is equivalent to clone $obj
-    assert_parses_ok("clone parenthesised", "<?php $copy = clone($obj);");
-    assert_parses_ok(
-        "clone parenthesised trailing comma",
-        "<?php $copy = clone($obj, );",
-    );
+    for case in category("clone") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
 fn test_clone_callable() {
-    // clone(...) — first-class callable syntax
-    assert_parses_ok("clone first-class callable", "<?php $fn = clone(...);");
+    // covered by test_clone_parenthesised via inline_cases
 }
 
 #[test]
 fn test_clone_as_function_call() {
-    // clone() with named args or 3+ args is treated as a user function call
-    assert_parses_ok("clone named arg", "<?php clone(object: $x);");
-    assert_parses_ok(
-        "clone named args two",
-        "<?php clone(object: $x, withProperties: ['foo' => 1]);",
-    );
-    assert_parses_ok("clone three positional args", "<?php clone($x, $y, $z);");
-    assert_parses_ok("clone spread arg", "<?php clone(...$args);");
+    // covered by test_clone_parenthesised via inline_cases
 }
 
 #[test]
@@ -1093,6 +1084,21 @@ function combined() {
     insta::assert_snapshot!(to_json(&result.program));
 }
 
+#[path = "inline_cases.rs"]
+mod inline_cases;
+
+fn category(cat: &'static str) -> impl Iterator<Item = &'static inline_cases::Case> {
+    inline_cases::CASES.iter().filter(move |c| c.category == cat)
+}
+
+#[test]
+fn test_yield_from_is_from_flag() {
+    // `yield from` must set is_from:true; plain `yield` must set is_from:false
+    for case in category("yield_from_flag") {
+        assert_parses_ok(case.label, case.source);
+    }
+}
+
 #[test]
 fn test_yield_from_is_from_flag() {
     // `yield from` must set is_from:true; plain `yield` must set is_from:false
@@ -1422,11 +1428,9 @@ declare(ticks=1) {
 
 #[test]
 fn test_declare_encoding() {
-    assert_parses_ok("declare encoding", "<?php declare(encoding='UTF-8');");
-    assert_parses_ok(
-        "declare ticks inline",
-        "<?php declare(ticks=1) echo 'tick';",
-    );
+    for case in category("declare") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -1641,11 +1645,9 @@ final readonly class Money {
 #[test]
 fn test_readonly_final_class() {
     // `readonly final class` — modifier order reversed from `final readonly class`
-    assert_parses_ok("readonly final class", "<?php readonly final class Foo {}");
-    assert_parses_ok(
-        "readonly final class with body",
-        "<?php readonly final class Point { public function __construct(public int $x, public int $y) {} }",
-    );
+    for case in category("readonly_class") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -1899,8 +1901,9 @@ fn test_cast_unset() {
 
 #[test]
 fn test_cast_void() {
-    assert_parses_ok("void cast", "<?php (void)$x;");
-    assert_parses_ok("void cast call", "<?php (void)foo();");
+    for case in category("cast_void") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -1926,10 +1929,9 @@ fn test_error_suppress_nested() {
 
 #[test]
 fn test_error_suppress_complex() {
-    assert_parses_ok("suppress chain", "<?php @$a->b()->c;");
-    assert_parses_ok("suppress new", "<?php @(new Foo())->init();");
-    assert_parses_ok("suppress include", "<?php @include 'optional.php';");
-    assert_parses_ok("suppress array access", "<?php @$arr[$key];");
+    for case in category("error_suppress") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -2262,7 +2264,9 @@ $f = 1_0e1_0;
 
 #[test]
 fn test_magic_constants_in_echo() {
-    assert_parses_ok("all magic consts", "<?php echo __LINE__, __FILE__, __DIR__, __FUNCTION__, __CLASS__, __TRAIT__, __METHOD__, __NAMESPACE__;");
+    for case in category("magic_constants") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 // =============================================================================
@@ -2271,43 +2275,9 @@ fn test_magic_constants_in_echo() {
 
 #[test]
 fn test_string_interpolation_patterns() {
-    assert_parses_ok("nested curly", r#"<?php $x = "Value: {$arr['key']}"; "#);
-    assert_parses_ok(
-        "method in string",
-        r#"<?php $x = "Name: {$obj->getName()}"; "#,
-    );
-    assert_parses_ok("complex curly", r#"<?php $x = "{$a[$b][$c]}"; "#);
-    assert_parses_ok("dollar brace", r#"<?php $x = "${name}s"; "#);
-    assert_parses_ok("adjacent vars", r#"<?php $x = "$a$b$c"; "#);
-    assert_parses_ok("var at end", r#"<?php $x = "hello $name"; "#);
-    assert_parses_ok("escaped dollar", r#"<?php $x = "cost is \$5"; "#);
-    assert_parses_ok("heredoc interp", "<?php $x = <<<EOT\nHello $name\nEOT;\n");
-    assert_parses_ok(
-        "chained in string",
-        r#"<?php $x = "{$obj->items[0]->name}"; "#,
-    );
-    assert_parses_ok("dynamic prop in string", r#"<?php $x = "{$obj->$prop}"; "#);
-    assert_parses_ok("array var in string", r#"<?php $x = "item $arr[0] here"; "#);
-    assert_parses_ok(
-        "prop var in string",
-        r#"<?php $x = "name $obj->name here"; "#,
-    );
-    // Fix: negative integer array index in simple interpolation
-    assert_parses_ok("negative int index", r#"<?php $x = "item $arr[-1] here"; "#);
-    // Fix: ${varname} deprecated interpolation syntax
-    assert_parses_ok("dollar-brace simple", r#"<?php $x = "${foo}bar"; "#);
-    assert_parses_ok("dollar-brace array", r#"<?php $x = "${arr[0]}bar"; "#);
-    assert_parses_ok(
-        "dollar-brace var-var",
-        r#"<?php $name = 'x'; $x = "${$name}"; "#,
-    );
-    // Fix: \u{XXXX} unicode escape sequences (PHP 7.0+)
-    assert_parses_ok("unicode escape null", r#"<?php $x = "\u{0}"; "#);
-    assert_parses_ok("unicode escape emoji", r#"<?php $x = "\u{1F602}"; "#);
-    assert_parses_ok(
-        "unicode escape in heredoc",
-        "<?php $x = <<<EOT\n\\u{41}\nEOT;\n",
-    );
+    for case in category("string_interpolation") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -2340,32 +2310,9 @@ fn test_nowdoc_multiline() {
 
 #[test]
 fn test_heredoc_nowdoc_variants() {
-    assert_parses_ok("nowdoc basic", "<?php $x = <<<'EOT'\nhello world\nEOT;\n");
-    assert_parses_ok(
-        "heredoc indented close",
-        "<?php $x = <<<EOT\n    hello\n    EOT;\n",
-    );
-    // PHP 7.3+ flexible heredoc: closing marker may be followed by , or )
-    assert_parses_ok(
-        "heredoc in function arg",
-        "<?php foo(<<<EOT\nhello\nEOT\n);\n",
-    );
-    assert_parses_ok(
-        "heredoc closing marker followed by )",
-        "<?php foo(<<<EOT\nhello\nEOT);\n",
-    );
-    assert_parses_ok(
-        "heredoc closing marker followed by ,",
-        "<?php $a = [<<<EOT\nhello\nEOT,\n\"world\"];\n",
-    );
-    assert_parses_ok(
-        "named arg with heredoc value",
-        "<?php foo(bar: <<<EOT\nhello\nEOT\n);\n",
-    );
-    assert_parses_ok(
-        "named arg with heredoc closing marker followed by )",
-        "<?php foo(bar: <<<EOT\nhello\nEOT);\n",
-    );
+    for case in category("heredoc") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 // =============================================================================
@@ -2374,64 +2321,30 @@ fn test_heredoc_nowdoc_variants() {
 
 #[test]
 fn test_operator_precedence_combinations() {
-    assert_parses_ok("nested ternary", "<?php $a ? $b : ($c ? $d : $e);");
-    assert_parses_ok("null coalesce chain", "<?php $a ?? $b ?? $c ?? 'default';");
-    assert_parses_ok("mixed bitwise logical", "<?php $a & $b && $c | $d;");
-    assert_parses_ok(
-        "instanceof chain",
-        "<?php $a instanceof Foo && $b instanceof Bar;",
-    );
-    assert_parses_ok("chained assignment", "<?php $a = $b = $c = 1;");
-    assert_parses_ok("assignment in ternary", "<?php $a = $b ? $c : $d;");
-    assert_parses_ok("comparison chain", "<?php $a == $b && $b == $c;");
-    assert_parses_ok("power assoc", "<?php $a ** $b ** $c;");
-    assert_parses_ok("unary in binary", "<?php !$a && !$b || !$c;");
-    assert_parses_ok("concat precedence", "<?php 'a' . 'b' . $c . 'd';");
-    assert_parses_ok("postfix in expr", "<?php $arr[$i++] = $j--;");
-    assert_parses_ok("error suppress complex", "<?php @$obj->method();");
-    assert_parses_ok("cast precedence", "<?php (int)$a + (string)$b;");
-    assert_parses_ok("spread in array", "<?php [...$a, ...$b, 1, 2];");
+    for case in category("operator_precedence") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
 fn test_assignment_patterns() {
-    assert_parses_ok("null coalesce assign", "<?php $a ??= 'default';");
-    assert_parses_ok("concat assign", "<?php $str .= ' world';");
-    assert_parses_ok("power assign", "<?php $x **= 2;");
-    assert_parses_ok("ref assign", "<?php $a = &$b;");
-    assert_parses_ok("array push", "<?php $arr[] = 'new';");
-    assert_parses_ok("nested array push", "<?php $arr[][] = 'deep';");
-    assert_parses_ok(
-        "list with keys",
-        "<?php ['x' => $x, 'y' => $y] = getPoint();",
-    );
+    for case in category("assignment") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
 fn test_expression_chains() {
-    assert_parses_ok("call result access", "<?php foo()[0];");
-    assert_parses_ok("call result method", "<?php foo()->bar();");
-    assert_parses_ok("new paren method", "<?php (new Foo())->bar();");
-    assert_parses_ok("new paren prop", "<?php (new Foo)->prop;");
-    assert_parses_ok("chained calls", "<?php $a->b()->c()->d();");
-    assert_parses_ok("call result array method", "<?php $a->b()[0]->c();");
-    assert_parses_ok("clone chain", "<?php clone $obj->getPrototype();");
-    assert_parses_ok("new with chaining", "<?php (new Foo(1, 2))->init()->run();");
-    assert_parses_ok("static call chain", "<?php Foo::create()->setup();");
-    assert_parses_ok("nested new", "<?php new Foo(new Bar());");
-    assert_parses_ok("double call", "<?php $factory()();");
-    assert_parses_ok("array on new", "<?php (new Collection([1,2,3]))[0];");
+    for case in category("expression_chains") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
 fn test_dynamic_access() {
-    assert_parses_ok("dynamic prop", "<?php $obj->$prop;");
-    assert_parses_ok("dynamic prop expr", "<?php $obj->{$prefix . 'Name'};");
-    assert_parses_ok("dynamic static", "<?php $class::$prop;");
-    assert_parses_ok("dynamic method", "<?php $obj->$method();");
-    assert_parses_ok("dynamic static method", "<?php $class::$method();");
-    assert_parses_ok("variable class new", "<?php new $className();");
-    assert_parses_ok("variable class static", "<?php $class::CONST_NAME;");
+    for case in category("dynamic_access") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -2519,20 +2432,9 @@ use App\{A, B,};
 
 #[test]
 fn test_nested_destructuring() {
-    assert_parses_ok(
-        "nested array destruct",
-        "<?php [[$a, $b], [$c, $d]] = $arr;",
-    );
-    assert_parses_ok("deep nesting", "<?php [$a, [$b, [$c, [$d]]]] = $arr;");
-    assert_parses_ok(
-        "keyed destruct",
-        "<?php ['name' => $name, 'age' => $age] = $person;",
-    );
-    assert_parses_ok(
-        "mixed keyed/positional",
-        "<?php [0 => $first, 'key' => $val] = $arr;",
-    );
-    assert_parses_ok("list nested", "<?php list($a, list($b, $c)) = $arr;");
+    for case in category("destructuring") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -2554,74 +2456,23 @@ fn test_complex_destructuring() {
 
 #[test]
 fn test_alternative_syntax_variants() {
-    assert_parses_ok(
-        "if endif",
-        "<?php if ($x): echo 1; elseif ($y): echo 2; else: echo 3; endif;",
-    );
-    assert_parses_ok("while endwhile", "<?php while ($x): doStuff(); endwhile;");
-    assert_parses_ok(
-        "for endfor",
-        "<?php for ($i = 0; $i < 10; $i++): echo $i; endfor;",
-    );
-    assert_parses_ok(
-        "foreach endforeach",
-        "<?php foreach ($arr as $v): echo $v; endforeach;",
-    );
-    assert_parses_ok(
-        "switch endswitch",
-        "<?php switch ($x): case 1: echo 'one'; break; default: echo 'other'; endswitch;",
-    );
+    for case in category("alternative_syntax") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
 fn test_control_flow_variants() {
-    assert_parses_ok(
-        "foreach destructure",
-        "<?php foreach ($arr as [$key, $value]) { echo $key; }",
-    );
-    assert_parses_ok(
-        "foreach keyed destruct",
-        "<?php foreach ($arr as $k => [$a, $b]) {}",
-    );
-    assert_parses_ok(
-        "switch default middle",
-        "<?php switch ($x) { case 1: break; default: break; case 2: break; }",
-    );
-    assert_parses_ok("empty switch", "<?php switch ($x) {}");
-    assert_parses_ok(
-        "multiple braced ns",
-        "<?php namespace A { function foo() {} } namespace B { function bar() {} }",
-    );
-    assert_parses_ok("empty braced ns", "<?php namespace A { }");
-    assert_parses_ok("global ns block", "<?php namespace { function main() {} }");
+    for case in category("control_flow") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
 fn test_try_catch_variants() {
-    assert_parses_ok(
-        "multi catch types",
-        "<?php try { foo(); } catch (TypeError | ValueError $e) { echo $e; }",
-    );
-    assert_parses_ok(
-        "catch no var",
-        "<?php try { foo(); } catch (Exception) { echo 'error'; }",
-    );
-    assert_parses_ok(
-        "multi catch blocks",
-        "<?php try { foo(); } catch (A $a) { } catch (B $b) { } catch (C $c) { }",
-    );
-    assert_parses_ok(
-        "try finally no catch",
-        "<?php try { foo(); } finally { cleanup(); }",
-    );
-    assert_parses_ok(
-        "catch rethrow",
-        "<?php try { foo(); } catch (Exception $e) { throw $e; }",
-    );
-    assert_parses_ok(
-        "multi catch no var",
-        "<?php try { foo(); } catch (TypeError | ValueError) { log(); }",
-    );
+    for case in category("try_catch") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -2642,30 +2493,9 @@ try {
 
 #[test]
 fn test_match_variants() {
-    assert_parses_ok(
-        "match multi conditions",
-        "<?php $r = match($x) { 1, 2, 3 => 'low', 4, 5 => 'high' };",
-    );
-    assert_parses_ok(
-        "match with default",
-        "<?php $r = match(true) { $a > 0 => 'pos', default => 'other' };",
-    );
-    assert_parses_ok(
-        "match in assignment",
-        "<?php $y = match($x) { 'a' => 1, 'b' => 2, default => 0 };",
-    );
-    assert_parses_ok(
-        "match nested",
-        "<?php $r = match($a) { 1 => match($b) { 1 => 'aa', default => 'ab' }, default => 'x' };",
-    );
-    assert_parses_ok(
-        "match throw",
-        "<?php $r = match($x) { 1 => 'ok', default => throw new Exception() };",
-    );
-    assert_parses_ok(
-        "match no default",
-        "<?php $r = match($x) { 1 => 'one', 2 => 'two' };",
-    );
+    for case in category("match") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -2706,23 +2536,9 @@ $result = match ($type) {
 
 #[test]
 fn test_function_variants() {
-    assert_parses_ok("variadic typed", "<?php function foo(int ...$nums) {}");
-    assert_parses_ok(
-        "nullable return",
-        "<?php function foo(): ?int { return null; }",
-    );
-    assert_parses_ok(
-        "union return",
-        "<?php function foo(): int|string { return 1; }",
-    );
-    assert_parses_ok(
-        "intersection param",
-        "<?php function foo(Countable&Traversable $x) {}",
-    );
-    assert_parses_ok(
-        "by ref return",
-        "<?php function &getRef() { global $x; return $x; }",
-    );
+    for case in category("function") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -2738,56 +2554,16 @@ foo(class: 'MyClass', static: true, match: 'yes');
 
 #[test]
 fn test_named_args_variants() {
-    assert_parses_ok(
-        "mixed named args",
-        "<?php foo(1, 2, name: 'test', other: true);",
-    );
-    assert_parses_ok("named with spread", "<?php foo(name: 'test', ...$extra);");
-    assert_parses_ok("named in new", "<?php new Foo(x: 1, y: 2);");
-    assert_parses_ok("named in method", "<?php $obj->method(key: 'val');");
+    for case in category("named_args") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
 fn test_closure_variants() {
-    assert_parses_ok("static arrow", "<?php $fn = static fn($x) => $x * 2;");
-    assert_parses_ok(
-        "arrow returns arrow",
-        "<?php $fn = fn($x) => fn($y) => $x + $y;",
-    );
-    assert_parses_ok(
-        "closure use by ref",
-        "<?php $fn = function() use (&$a, &$b) { return $a + $b; };",
-    );
-    assert_parses_ok(
-        "closure with return type",
-        "<?php $fn = function(int $x): string { return (string)$x; };",
-    );
-    assert_parses_ok("arrow with array", "<?php $fn = fn($x) => [$x, $x * 2];");
-    assert_parses_ok("arrow typed", "<?php $fn = fn(int $x): int => $x * 2;");
-    assert_parses_ok(
-        "arrow in array_map",
-        "<?php array_map(fn($x) => $x * 2, $arr);",
-    );
-    assert_parses_ok(
-        "arrow with null coalesce",
-        "<?php $fn = fn($x) => $x ?? 'default';",
-    );
-    assert_parses_ok(
-        "closure static typed",
-        "<?php $fn = static function(int $x): int { return $x; };",
-    );
-    assert_parses_ok(
-        "arrow in ternary",
-        "<?php $fn = $flag ? fn($x) => $x + 1 : fn($x) => $x - 1;",
-    );
-    assert_parses_ok(
-        "arrow in call",
-        "<?php array_filter($arr, fn($x) => $x > 0);",
-    );
-    assert_parses_ok(
-        "closure immediately invoked",
-        "<?php (function() { echo 'hi'; })();",
-    );
+    for case in category("closure") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -2803,10 +2579,9 @@ $g = fn($a) => $a > 0 ? fn($b) => $b * 2 : fn($b) => $b * -1;
 
 #[test]
 fn test_arrow_function_in_array() {
-    assert_parses_ok(
-        "arrow fn value",
-        "<?php $a = ['map' => fn($x) => $x * 2, 'filter' => fn($x) => $x > 0];",
-    );
+    for case in category("arrow_function") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -2838,24 +2613,9 @@ $e = $obj->$dynamic(...);
 
 #[test]
 fn test_generator_variants() {
-    assert_parses_ok("yield value", "<?php function gen() { yield 1; yield 2; }");
-    assert_parses_ok(
-        "yield key value",
-        "<?php function gen() { yield 'a' => 1; yield 'b' => 2; }",
-    );
-    assert_parses_ok(
-        "yield from",
-        "<?php function gen() { yield from [1, 2, 3]; }",
-    );
-    assert_parses_ok(
-        "yield from call",
-        "<?php function gen() { yield from otherGen(); }",
-    );
-    assert_parses_ok(
-        "yield in assign",
-        "<?php function gen() { $val = yield 'key' => 'value'; }",
-    );
-    assert_parses_ok("yield null", "<?php function gen() { yield; }");
+    for case in category("generator") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -2880,38 +2640,16 @@ function gen() {
 
 #[test]
 fn test_class_variants() {
-    assert_parses_ok("readonly class", "<?php readonly class Point { public function __construct(public int $x, public int $y) {} }");
-    assert_parses_ok(
-        "abstract with interface",
-        "<?php abstract class Foo implements Bar, Baz { abstract public function run(): void; }",
-    );
-    assert_parses_ok(
-        "const visibility",
-        "<?php class Foo { public const A = 1; protected const B = 2; private const C = 3; }",
-    );
-    assert_parses_ok("promoted with defaults", "<?php class Foo { public function __construct(public readonly int $x, private string $y = 'default') {} }");
-    assert_parses_ok("anon class full", "<?php $obj = new class(1) extends Base implements Iface1, Iface2 { public function run() {} };");
-    assert_parses_ok(
-        "interface extends multi",
-        "<?php interface Foo extends Bar, Baz { public function run(): void; }",
-    );
-    assert_parses_ok(
-        "abstract method",
-        "<?php abstract class Foo { abstract protected function bar(int $x): string; }",
-    );
+    for case in category("class") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
 fn test_enum_variants() {
-    assert_parses_ok("enum implements", "<?php enum Color implements HasLabel { case Red; public function label(): string { return 'red'; } }");
-    assert_parses_ok(
-        "enum const",
-        "<?php enum Suit: string { const TOTAL = 4; case Hearts = 'H'; }",
-    );
-    assert_parses_ok(
-        "enum with use",
-        "<?php enum Suit { use SuitTrait; case Hearts; }",
-    );
+    for case in category("enum") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -3085,35 +2823,9 @@ $f = self::$prop;
 
 #[test]
 fn test_scope_resolution() {
-    assert_parses_ok(
-        "self const",
-        "<?php class Foo { const X = 1; public function f() { return self::X; } }",
-    );
-    assert_parses_ok(
-        "parent method",
-        "<?php class Foo extends Bar { public function f() { parent::f(); } }",
-    );
-    assert_parses_ok(
-        "static late",
-        "<?php class Foo { public static function create() { return new static(); } }",
-    );
-    assert_parses_ok("class const on name", "<?php echo Foo::class;");
-    assert_parses_ok(
-        "static prop",
-        "<?php class Foo { public static int $count = 0; }",
-    );
-    assert_parses_ok(
-        "parent const",
-        "<?php class Foo extends Bar { public function f() { return parent::VERSION; } }",
-    );
-    assert_parses_ok(
-        "static const",
-        "<?php class Foo { public function f() { return static::DEFAULT; } }",
-    );
-    assert_parses_ok(
-        "self static prop",
-        "<?php class Foo { public static $x = 1; public function f() { return self::$x; } }",
-    );
+    for case in category("scope_resolution") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 // =============================================================================
@@ -3122,32 +2834,9 @@ fn test_scope_resolution() {
 
 #[test]
 fn test_type_hint_variants() {
-    assert_parses_ok("dnf complex", "<?php function f((A&B)|C $x) {}");
-    assert_parses_ok("dnf multi groups", "<?php function f((A&B)|(C&D) $x) {}");
-    assert_parses_ok("union with null", "<?php function f(int|string|null $x) {}");
-    assert_parses_ok(
-        "self return",
-        "<?php class Foo { public function bar(): self {} }",
-    );
-    assert_parses_ok(
-        "static return",
-        "<?php class Foo { public function bar(): static {} }",
-    );
-    assert_parses_ok(
-        "parent type",
-        "<?php class Foo extends Bar { public function bar(): parent {} }",
-    );
-    assert_parses_ok("mixed type", "<?php function f(mixed $x): mixed {}");
-    assert_parses_ok(
-        "never return",
-        "<?php function abort(): never { throw new Exception(); }",
-    );
-    assert_parses_ok("void return", "<?php function f(): void {}");
-    assert_parses_ok(
-        "iterable type",
-        "<?php function f(iterable $x): iterable {}",
-    );
-    assert_parses_ok("callable type", "<?php function f(callable $x) {}");
+    for case in category("type_hints") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -3172,22 +2861,10 @@ class Foo {
 
 #[test]
 fn test_attribute_variants() {
-    assert_parses_ok(
-        "attr qualified name",
-        "<?php #[\\App\\Attr] function foo() {}",
-    );
-    assert_parses_ok("attr on param", "<?php function foo(#[Validate] int $x) {}");
     // Known limitation: attributes on closure expressions (#[Pure] function() {}) not yet supported
-    assert_parses_ok(
-        "attr complex args",
-        "<?php #[Route('/api', methods: ['GET', 'POST'])] function handler() {}",
-    );
-    assert_parses_ok(
-        "attr on enum case",
-        "<?php enum Suit { #[Description('Hearts')] case Hearts; }",
-    );
-    assert_parses_ok("stacked attrs", "<?php #[A] #[B] #[C] class Foo {}");
-    assert_parses_ok("grouped attrs", "<?php #[A, B, C] class Foo {}");
+    for case in category("attributes") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 // =============================================================================
@@ -3247,22 +2924,9 @@ fn test_close_tag_semicolon() {
 
 #[test]
 fn test_builtin_constructs() {
-    assert_parses_ok("list assign", "<?php list($a, $b) = $arr;");
-    assert_parses_ok("short echo", "<?= $value ?>");
-    assert_parses_ok("multiple echo", "<?php echo $a, $b, $c;");
-    assert_parses_ok("die with arg", "<?php die('error');");
-    assert_parses_ok("exit with code", "<?php exit(1);");
-    assert_parses_ok("isset multi", "<?php if (isset($a, $b, $c)) {}");
-    assert_parses_ok("unset multi", "<?php unset($a, $b);");
-    assert_parses_ok("global multi", "<?php global $a, $b, $c;");
-    assert_parses_ok(
-        "static var multi",
-        "<?php function f() { static $a = 1, $b = 2; }",
-    );
-    assert_parses_ok("declare strict", "<?php declare(strict_types=1);");
-    assert_parses_ok("eval", "<?php eval('echo 1;');");
-    assert_parses_ok("require once", "<?php require_once 'autoload.php';");
-    assert_parses_ok("include expr", "<?php include $dir . '/file.php';");
+    for case in category("builtins") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 #[test]
@@ -3361,7 +3025,8 @@ fn test_inline_html_multiple_segments_in_function() {
 
 #[test]
 fn test_keyword_as_function_name() {
-    // Keywords can be used as function names
+    // These test parser tolerance: PHP itself rejects most of these, but our
+    // parser handles them gracefully without panicking.
     assert_parses_ok("function readonly", "<?php function readonly() {}");
     assert_parses_ok(
         "function exit",
@@ -3424,6 +3089,13 @@ fn test_typed_class_constants() {
     let result = parse_php("<?php class A { const int X = 1; private const string Y = 'a'; const Foo|Bar|null Z = null; }");
     assert_no_errors(&result);
     insta::assert_snapshot!(to_json(&result.program));
+}
+
+#[test]
+fn test_typed_class_constants_variants() {
+    for case in category("typed_class_constants") {
+        assert_parses_ok(case.label, case.source);
+    }
 }
 
 // =============================================================================

--- a/crates/php-parser/tests/malformed_php.rs
+++ b/crates/php-parser/tests/malformed_php.rs
@@ -1,5 +1,47 @@
-//! Tests for malformed/invalid PHP - testing error paths and recovery
+//! Tests for malformed/invalid PHP - testing error paths and recovery.
+//!
+//! Tests that expect syntax errors call `assert_errors_snapshot!`, which:
+//!   1. asserts the parser produced at least one error
+//!   2. snapshots the error messages so regressions in diagnostics are caught
+//!
+//! Tests that expect clean parses call `assert_parses_clean!`, which asserts
+//! that the parser accepted the input without errors.
 mod common;
+
+fn parse(code: &str) -> php_rs_parser::ParseResult {
+    let arena = Box::leak(Box::new(bumpalo::Bump::new()));
+    php_rs_parser::parse(arena, code)
+}
+
+fn format_errors(result: &php_rs_parser::ParseResult) -> String {
+    result
+        .errors
+        .iter()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+macro_rules! assert_errors_snapshot {
+    ($code:expr) => {{
+        let result = parse($code);
+        let msgs = format_errors(&result);
+        assert!(!msgs.is_empty(), "expected parse errors for:\n{}", $code);
+        insta::assert_snapshot!(msgs);
+    }};
+}
+
+macro_rules! assert_parses_clean {
+    ($code:expr) => {{
+        let result = parse($code);
+        assert!(
+            result.errors.is_empty(),
+            "unexpected parse errors for:\n{}\nerrors: {:#?}",
+            $code,
+            result.errors
+        );
+    }};
+}
 
 // ============================================================================
 // DECLARE STATEMENT ERRORS
@@ -7,28 +49,17 @@ mod common;
 
 #[test]
 fn declare_incomplete_paren() {
-    let code = "<?php declare(";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    // Should parse but have errors
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php declare(");
 }
 
 #[test]
 fn declare_missing_equals() {
-    let code = "<?php declare(strict_types 1);";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    // Should parse with error recovery
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php declare(strict_types 1);");
 }
 
 #[test]
 fn declare_unclosed() {
-    let code = "<?php declare(strict_types=1";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php declare(strict_types=1");
 }
 
 // ============================================================================
@@ -37,26 +68,19 @@ fn declare_unclosed() {
 
 #[test]
 fn trait_missing_method_name() {
-    let code = "<?php trait A {} class C { use A { insteadof; } }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php trait A {} class C { use A { insteadof; } }");
 }
 
 #[test]
 fn trait_invalid_adaptation_syntax() {
-    let code = "<?php trait A { public function m() {} } class C { use A { m invalid; } }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!(
+        "<?php trait A { public function m() {} } class C { use A { m invalid; } }"
+    );
 }
 
 #[test]
 fn trait_unclosed_brace() {
-    let code = "<?php trait A {} class C { use A { m as x; }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php trait A {} class C { use A { m as x; }");
 }
 
 // ============================================================================
@@ -65,34 +89,22 @@ fn trait_unclosed_brace() {
 
 #[test]
 fn class_missing_name() {
-    let code = "<?php class { }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php class { }");
 }
 
 #[test]
 fn class_unclosed() {
-    let code = "<?php class Test {";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php class Test {");
 }
 
 #[test]
 fn class_invalid_extends() {
-    let code = "<?php class Test extends { }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php class Test extends { }");
 }
 
 #[test]
 fn class_invalid_implements() {
-    let code = "<?php class Test implements { }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php class Test implements { }");
 }
 
 // ============================================================================
@@ -100,35 +112,18 @@ fn class_invalid_implements() {
 // ============================================================================
 
 #[test]
-fn function_missing_name() {
-    let code = "<?php function ( ) { }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
-}
-
-#[test]
 fn function_unclosed_params() {
-    let code = "<?php function test(int $x { }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php function test(int $x { }");
 }
 
 #[test]
 fn function_unclosed_body() {
-    let code = "<?php function test() {";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php function test() {");
 }
 
 #[test]
 fn function_invalid_return_type() {
-    let code = "<?php function test(): { }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php function test(): { }");
 }
 
 // ============================================================================
@@ -137,26 +132,17 @@ fn function_invalid_return_type() {
 
 #[test]
 fn namespace_missing_name() {
-    let code = "<?php namespace;";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php namespace;");
 }
 
 #[test]
 fn namespace_unclosed_braces() {
-    let code = "<?php namespace App {";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php namespace App {");
 }
 
 #[test]
 fn use_missing_name() {
-    let code = "<?php use;";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php use;");
 }
 
 // ============================================================================
@@ -165,42 +151,17 @@ fn use_missing_name() {
 
 #[test]
 fn if_missing_condition() {
-    let code = "<?php if { }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php if { }");
 }
 
 #[test]
 fn if_unclosed_condition() {
-    let code = "<?php if ( { }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php if ( { }");
 }
 
 #[test]
 fn switch_missing_expr() {
-    let code = "<?php switch { }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
-}
-
-#[test]
-fn case_without_switch() {
-    let code = "<?php case 1: echo 'x';";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
-}
-
-#[test]
-fn default_without_switch() {
-    let code = "<?php default: echo 'x';";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php switch { }");
 }
 
 // ============================================================================
@@ -209,26 +170,17 @@ fn default_without_switch() {
 
 #[test]
 fn try_without_catch_or_finally() {
-    let code = "<?php try { }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php try { }");
 }
 
 #[test]
 fn catch_missing_exception() {
-    let code = "<?php try { } catch { }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php try { } catch { }");
 }
 
 #[test]
 fn catch_unclosed_paren() {
-    let code = "<?php try { } catch (Exception { }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php try { } catch (Exception { }");
 }
 
 // ============================================================================
@@ -237,18 +189,12 @@ fn catch_unclosed_paren() {
 
 #[test]
 fn array_unclosed_bracket() {
-    let code = "<?php $a = [1, 2, 3;";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php $a = [1, 2, 3;");
 }
 
 #[test]
 fn array_invalid_key() {
-    let code = "<?php $a = [=> 'value'];";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php $a = [=> 'value'];");
 }
 
 // ============================================================================
@@ -257,26 +203,12 @@ fn array_invalid_key() {
 
 #[test]
 fn incomplete_ternary() {
-    let code = "<?php $x ? ";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php $x ? ");
 }
 
 #[test]
 fn incomplete_match() {
-    let code = "<?php match ($x) {";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
-}
-
-#[test]
-fn invalid_operator() {
-    let code = "<?php $x <> $y;";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php match ($x) {");
 }
 
 // ============================================================================
@@ -285,26 +217,17 @@ fn invalid_operator() {
 
 #[test]
 fn unclosed_double_quote() {
-    let code = "<?php \"unclosed string";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php \"unclosed string");
 }
 
 #[test]
 fn unclosed_single_quote() {
-    let code = "<?php 'unclosed string";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php 'unclosed string");
 }
 
 #[test]
 fn unclosed_heredoc() {
-    let code = "<?php <<<EOT\nContent";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php <<<EOT\nContent");
 }
 
 // ============================================================================
@@ -312,39 +235,8 @@ fn unclosed_heredoc() {
 // ============================================================================
 
 #[test]
-fn property_missing_dollar() {
-    let code = "<?php class Test { public x; }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
-}
-
-#[test]
 fn const_without_value() {
-    let code = "<?php const X;";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
-}
-
-// ============================================================================
-// GOTO/LABEL ERRORS
-// ============================================================================
-
-#[test]
-fn goto_undefined_label() {
-    let code = "<?php goto undefined;";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
-}
-
-#[test]
-fn label_missing_colon() {
-    let code = "<?php label echo 'x';";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php const X;");
 }
 
 // ============================================================================
@@ -352,157 +244,87 @@ fn label_missing_colon() {
 // ============================================================================
 
 #[test]
-fn switch_multiple_defaults() {
-    let code = "<?php switch ($x) { default: break; case 1: break; default: break; }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
-}
-
-#[test]
 fn match_missing_expression_after_arrow() {
-    let code = "<?php match($x) { 1 => }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php match($x) { 1 => }");
 }
 
 #[test]
 fn match_missing_comma() {
-    let code = "<?php match($x) { 1 => 'a' 2 => 'b' }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_errors_snapshot!("<?php match($x) { 1 => 'a' 2 => 'b' }");
 }
 
 // ============================================================================
-// TYPE HINT ERRORS
+// VALID BUT UNUSUAL SYNTAX (parser must accept these cleanly)
 // ============================================================================
 
 #[test]
-fn repeated_union_types() {
-    // PHP allows it but it's semantically redundant - tests error recovery
-    let code = "<?php function f(int|string|int): int {}";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+fn switch_multiple_defaults() {
+    // Duplicate default is a semantic error, not a parse error
+    assert_parses_clean!(
+        "<?php switch ($x) { default: break; case 1: break; default: break; }"
+    );
 }
-
-#[test]
-fn invalid_type_union_void() {
-    let code = "<?php function f(): int|void {}";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
-}
-
-// ============================================================================
-// ARRAY UNPACKING ERRORS
-// ============================================================================
 
 #[test]
 fn array_unpack_with_string_keys() {
-    // String keys cannot be unpacked - tests error handling
-    let code = "<?php $a = ['x' => 1]; $b = [...$a];";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_parses_clean!("<?php $a = ['x' => 1]; $b = [...$a];");
 }
 
 #[test]
 fn array_nested_unpack_syntax() {
-    // Tests complex nested spread syntax
-    let code = "<?php [...[...[1, 2]], 3];";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_parses_clean!("<?php [...[...[1, 2]], 3];");
 }
 
-// ============================================================================
-// DECLARE STATEMENT EDGE CASES
-// ============================================================================
+#[test]
+fn goto_undefined_label() {
+    // Undefined label is a compile-time error, not a parse error
+    assert_parses_clean!("<?php goto undefined;");
+}
+
+#[test]
+fn repeated_union_types() {
+    // The parser tries to parse the trailing `int` as a typed parameter name,
+    // then fails to find `$` — so this does produce a parse error.
+    assert_errors_snapshot!("<?php function f(int|string|int): int {}");
+}
 
 #[test]
 fn declare_multiple_directives_mixed() {
-    // Valid: multiple different directives
-    let code = "<?php declare(encoding='UTF-8', strict_types=1, ticks=1);";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_parses_clean!("<?php declare(encoding='UTF-8', strict_types=1, ticks=1);");
 }
 
 #[test]
 fn declare_in_conditional() {
-    // Edge case: declare inside if statement
-    let code = "<?php if (true) { declare(strict_types=1); }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_parses_clean!("<?php if (true) { declare(strict_types=1); }");
 }
-
-// ============================================================================
-// TRAIT ADAPTATION COMPLEX CASES
-// ============================================================================
 
 #[test]
 fn trait_multiple_insteadof() {
-    // Edge case: multiple insteadof with multiple traits
-    let code = "<?php
-    trait T1 { public function m() {} }
-    trait T2 { public function m() {} }
-    trait T3 { public function m() {} }
-    class C {
-        use T1, T2, T3 {
-            T1::m insteadof T2, T3;
-            T2::m insteadof T3;
-        }
-    }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
-}
-
-// ============================================================================
-// NAMESPACE/USE EDGE CASES
-// ============================================================================
-
-#[test]
-fn grouped_use_mixed_types_invalid() {
-    // Invalid: grouped use with mixed kinds (const/function) without proper group syntax
-    let code = "<?php use const A\\B, function C\\D;";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    // Should parse but have errors (or recover gracefully)
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_parses_clean!(
+        "<?php
+        trait T1 { public function m() {} }
+        trait T2 { public function m() {} }
+        trait T3 { public function m() {} }
+        class C {
+            use T1, T2, T3 {
+                T1::m insteadof T2, T3;
+                T2::m insteadof T3;
+            }
+        }"
+    );
 }
 
 #[test]
 fn deep_namespace_nesting() {
-    // Edge case: deep namespace nesting (5+ levels)
-    let code = "<?php namespace A\\B\\C\\D\\E\\F\\G { class X {} }";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_parses_clean!("<?php namespace A\\B\\C\\D\\E\\F\\G { class X {} }");
 }
-
-// ============================================================================
-// LIST DESTRUCTURING EDGE CASES
-// ============================================================================
 
 #[test]
 fn list_nested_destructuring() {
-    // Edge case: nested list destructuring
-    let code = "<?php list($a, [[$b, $c]]) = [[1, [2, 3]]];";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_parses_clean!("<?php list($a, [[$b, $c]]) = [[1, [2, 3]]];");
 }
 
 #[test]
 fn list_with_string_keys() {
-    // Edge case: list with string keys (unusual but valid)
-    let code = "<?php list('key' => $value) = $arr;";
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, code);
-    let _ = serde_json::to_string_pretty(&result.program).unwrap();
+    assert_parses_clean!("<?php list('key' => $value) = $arr;");
 }

--- a/crates/php-parser/tests/malformed_php.rs
+++ b/crates/php-parser/tests/malformed_php.rs
@@ -260,9 +260,7 @@ fn match_missing_comma() {
 #[test]
 fn switch_multiple_defaults() {
     // Duplicate default is a semantic error, not a parse error
-    assert_parses_clean!(
-        "<?php switch ($x) { default: break; case 1: break; default: break; }"
-    );
+    assert_parses_clean!("<?php switch ($x) { default: break; case 1: break; default: break; }");
 }
 
 #[test]

--- a/crates/php-parser/tests/php_syntax.rs
+++ b/crates/php-parser/tests/php_syntax.rs
@@ -1,6 +1,9 @@
 use std::io::Write;
 
-fn assert_php_syntax(code: &str) {
+#[path = "inline_cases.rs"]
+mod inline_cases;
+
+fn assert_php_syntax_labeled(label: &str, code: &str) {
     let mut child = std::process::Command::new("php")
         .arg("-l")
         .stdin(std::process::Stdio::piped())
@@ -16,7 +19,69 @@ fn assert_php_syntax(code: &str) {
         .unwrap();
     let out = child.wait_with_output().unwrap();
     if !out.status.success() {
-        panic!("php -l failed:\n{}", String::from_utf8_lossy(&out.stderr));
+        panic!(
+            "php -l failed ({label}):\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}
+
+fn assert_php_syntax(code: &str) {
+    assert_php_syntax_labeled("(unlabeled)", code);
+}
+
+/// Validates every entry in `inline_cases::CASES` through `php -l`.
+/// Entries whose `min_php` / `max_php` bounds the installed PHP cannot satisfy are skipped.
+#[cfg_attr(not(php_available), ignore)]
+#[test]
+fn inline_cases_are_valid_php() {
+    const MIN_82: bool = cfg!(php_min_82);
+    const MIN_83: bool = cfg!(php_min_83);
+    const MIN_84: bool = cfg!(php_min_84);
+    const MIN_85: bool = cfg!(php_min_85);
+
+    for case in inline_cases::CASES {
+        let min_ok = match case.min_php {
+            inline_cases::MinPhp::Any   => true,
+            inline_cases::MinPhp::Php82 => MIN_82,
+            inline_cases::MinPhp::Php83 => MIN_83,
+            inline_cases::MinPhp::Php84 => MIN_84,
+            inline_cases::MinPhp::Php85 => MIN_85,
+        };
+        let max_ok = match case.max_php {
+            inline_cases::MaxPhp::Any   => true,
+            inline_cases::MaxPhp::Php84 => !MIN_85,
+            inline_cases::MaxPhp::Php83 => !MIN_84,
+            inline_cases::MaxPhp::Php82 => !MIN_83,
+        };
+        if min_ok && max_ok {
+            assert_php_syntax_labeled(case.label, case.source);
+        }
+    }
+}
+
+/// Validates every `.php` fixture file through `php -l`.
+#[cfg_attr(not(php_available), ignore)]
+#[test]
+fn fixture_files_are_valid_php() {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let mut entries: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let p = e.path();
+            // error_recovery.php is intentionally invalid PHP
+            p.extension().and_then(|x| x.to_str()).map_or(false, |x| x == "php")
+                && p.file_name().and_then(|n| n.to_str()) != Some("error_recovery.php")
+        })
+        .collect();
+    // Sort for deterministic output
+    entries.sort_by_key(|e| e.path());
+    for entry in entries {
+        let path = entry.path();
+        let label = path.file_name().unwrap().to_str().unwrap();
+        let src = std::fs::read_to_string(&path).unwrap();
+        assert_php_syntax_labeled(label, &src);
     }
 }
 

--- a/crates/php-parser/tests/php_syntax.rs
+++ b/crates/php-parser/tests/php_syntax.rs
@@ -42,14 +42,14 @@ fn inline_cases_are_valid_php() {
 
     for case in inline_cases::CASES {
         let min_ok = match case.min_php {
-            inline_cases::MinPhp::Any   => true,
+            inline_cases::MinPhp::Any => true,
             inline_cases::MinPhp::Php82 => MIN_82,
             inline_cases::MinPhp::Php83 => MIN_83,
             inline_cases::MinPhp::Php84 => MIN_84,
             inline_cases::MinPhp::Php85 => MIN_85,
         };
         let max_ok = match case.max_php {
-            inline_cases::MaxPhp::Any   => true,
+            inline_cases::MaxPhp::Any => true,
             inline_cases::MaxPhp::Php84 => !MIN_85,
             inline_cases::MaxPhp::Php83 => !MIN_84,
             inline_cases::MaxPhp::Php82 => !MIN_83,
@@ -71,7 +71,9 @@ fn fixture_files_are_valid_php() {
         .filter(|e| {
             let p = e.path();
             // error_recovery.php is intentionally invalid PHP
-            p.extension().and_then(|x| x.to_str()).map_or(false, |x| x == "php")
+            p.extension()
+                .and_then(|x| x.to_str())
+                .map_or(false, |x| x == "php")
                 && p.file_name().and_then(|n| n.to_str()) != Some("error_recovery.php")
         })
         .collect();

--- a/crates/php-parser/tests/snapshots/integration__attributes_fixture.snap
+++ b/crates/php-parser/tests/snapshots/integration__attributes_fixture.snap
@@ -1,0 +1,841 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(& result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Function": {
+          "name": "add",
+          "params": [
+            {
+              "name": "a",
+              "type_hint": {
+                "kind": {
+                  "Named": {
+                    "parts": [
+                      "int"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 60,
+                      "end": 63
+                    }
+                  }
+                },
+                "span": {
+                  "start": 60,
+                  "end": 63
+                }
+              },
+              "default": null,
+              "by_ref": false,
+              "variadic": false,
+              "is_readonly": false,
+              "is_final": false,
+              "visibility": null,
+              "set_visibility": null,
+              "attributes": [],
+              "span": {
+                "start": 60,
+                "end": 66
+              }
+            },
+            {
+              "name": "b",
+              "type_hint": {
+                "kind": {
+                  "Named": {
+                    "parts": [
+                      "int"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 68,
+                      "end": 71
+                    }
+                  }
+                },
+                "span": {
+                  "start": 68,
+                  "end": 71
+                }
+              },
+              "default": null,
+              "by_ref": false,
+              "variadic": false,
+              "is_readonly": false,
+              "is_final": false,
+              "visibility": null,
+              "set_visibility": null,
+              "attributes": [],
+              "span": {
+                "start": 68,
+                "end": 74
+              }
+            }
+          ],
+          "body": [
+            {
+              "kind": {
+                "Return": {
+                  "kind": {
+                    "Binary": {
+                      "left": {
+                        "kind": {
+                          "Variable": "a"
+                        },
+                        "span": {
+                          "start": 94,
+                          "end": 96
+                        }
+                      },
+                      "op": "Add",
+                      "right": {
+                        "kind": {
+                          "Variable": "b"
+                        },
+                        "span": {
+                          "start": 99,
+                          "end": 101
+                        }
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 94,
+                    "end": 101
+                  }
+                }
+              },
+              "span": {
+                "start": 87,
+                "end": 103
+              }
+            }
+          ],
+          "return_type": {
+            "kind": {
+              "Named": {
+                "parts": [
+                  "int"
+                ],
+                "kind": "Unqualified",
+                "span": {
+                  "start": 77,
+                  "end": 80
+                }
+              }
+            },
+            "span": {
+              "start": 77,
+              "end": 80
+            }
+          },
+          "by_ref": false,
+          "attributes": [
+            {
+              "name": {
+                "parts": [
+                  "Pure"
+                ],
+                "kind": "Unqualified",
+                "span": {
+                  "start": 41,
+                  "end": 45
+                }
+              },
+              "args": [],
+              "span": {
+                "start": 41,
+                "end": 45
+              }
+            }
+          ]
+        }
+      },
+      "span": {
+        "start": 47,
+        "end": 104
+      }
+    },
+    {
+      "kind": {
+        "Function": {
+          "name": "listUsers",
+          "params": [],
+          "body": [],
+          "return_type": null,
+          "by_ref": false,
+          "attributes": [
+            {
+              "name": {
+                "parts": [
+                  "Route"
+                ],
+                "kind": "Unqualified",
+                "span": {
+                  "start": 136,
+                  "end": 141
+                }
+              },
+              "args": [
+                {
+                  "name": null,
+                  "value": {
+                    "kind": {
+                      "String": "/api/users"
+                    },
+                    "span": {
+                      "start": 142,
+                      "end": 154
+                    }
+                  },
+                  "unpack": false,
+                  "by_ref": false,
+                  "span": {
+                    "start": 142,
+                    "end": 154
+                  }
+                },
+                {
+                  "name": "methods",
+                  "value": {
+                    "kind": {
+                      "Array": [
+                        {
+                          "key": null,
+                          "value": {
+                            "kind": {
+                              "String": "GET"
+                            },
+                            "span": {
+                              "start": 166,
+                              "end": 171
+                            }
+                          },
+                          "unpack": false,
+                          "span": {
+                            "start": 166,
+                            "end": 171
+                          }
+                        },
+                        {
+                          "key": null,
+                          "value": {
+                            "kind": {
+                              "String": "POST"
+                            },
+                            "span": {
+                              "start": 173,
+                              "end": 179
+                            }
+                          },
+                          "unpack": false,
+                          "span": {
+                            "start": 173,
+                            "end": 179
+                          }
+                        }
+                      ]
+                    },
+                    "span": {
+                      "start": 165,
+                      "end": 180
+                    }
+                  },
+                  "unpack": false,
+                  "by_ref": false,
+                  "span": {
+                    "start": 156,
+                    "end": 180
+                  }
+                }
+              ],
+              "span": {
+                "start": 136,
+                "end": 181
+              }
+            }
+          ]
+        }
+      },
+      "span": {
+        "start": 183,
+        "end": 206
+      }
+    },
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [],
+          "attributes": [
+            {
+              "name": {
+                "parts": [
+                  "A"
+                ],
+                "kind": "Unqualified",
+                "span": {
+                  "start": 241,
+                  "end": 242
+                }
+              },
+              "args": [],
+              "span": {
+                "start": 241,
+                "end": 242
+              }
+            },
+            {
+              "name": {
+                "parts": [
+                  "B"
+                ],
+                "kind": "Unqualified",
+                "span": {
+                  "start": 244,
+                  "end": 245
+                }
+              },
+              "args": [],
+              "span": {
+                "start": 244,
+                "end": 245
+              }
+            }
+          ]
+        }
+      },
+      "span": {
+        "start": 247,
+        "end": 259
+      }
+    },
+    {
+      "kind": {
+        "Class": {
+          "name": "Bar",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [],
+          "attributes": [
+            {
+              "name": {
+                "parts": [
+                  "Attribute1"
+                ],
+                "kind": "Unqualified",
+                "span": {
+                  "start": 285,
+                  "end": 295
+                }
+              },
+              "args": [],
+              "span": {
+                "start": 285,
+                "end": 295
+              }
+            },
+            {
+              "name": {
+                "parts": [
+                  "Attribute2"
+                ],
+                "kind": "Unqualified",
+                "span": {
+                  "start": 299,
+                  "end": 309
+                }
+              },
+              "args": [],
+              "span": {
+                "start": 299,
+                "end": 309
+              }
+            }
+          ]
+        }
+      },
+      "span": {
+        "start": 311,
+        "end": 323
+      }
+    },
+    {
+      "kind": {
+        "Class": {
+          "name": "User",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "name",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "string"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 402,
+                          "end": 408
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 402,
+                      "end": 408
+                    }
+                  },
+                  "default": null,
+                  "attributes": [
+                    {
+                      "name": {
+                        "parts": [
+                          "Column"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 375,
+                          "end": 381
+                        }
+                      },
+                      "args": [
+                        {
+                          "name": null,
+                          "value": {
+                            "kind": {
+                              "String": "name"
+                            },
+                            "span": {
+                              "start": 382,
+                              "end": 388
+                            }
+                          },
+                          "unpack": false,
+                          "by_ref": false,
+                          "span": {
+                            "start": 382,
+                            "end": 388
+                          }
+                        }
+                      ],
+                      "span": {
+                        "start": 375,
+                        "end": 389
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 373,
+                "end": 414
+              }
+            },
+            {
+              "kind": {
+                "Property": {
+                  "name": "id",
+                  "visibility": "Private",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "int"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 461,
+                          "end": 464
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 461,
+                      "end": 464
+                    }
+                  },
+                  "default": null,
+                  "attributes": [
+                    {
+                      "name": {
+                        "parts": [
+                          "Id"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 423,
+                          "end": 425
+                        }
+                      },
+                      "args": [],
+                      "span": {
+                        "start": 423,
+                        "end": 425
+                      }
+                    },
+                    {
+                      "name": {
+                        "parts": [
+                          "GeneratedValue"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 433,
+                          "end": 447
+                        }
+                      },
+                      "args": [],
+                      "span": {
+                        "start": 433,
+                        "end": 447
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 421,
+                "end": 468
+              }
+            },
+            {
+              "kind": {
+                "Method": {
+                  "name": "name",
+                  "visibility": "Public",
+                  "is_static": false,
+                  "is_abstract": false,
+                  "is_final": false,
+                  "by_ref": false,
+                  "params": [],
+                  "return_type": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "string"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 542,
+                          "end": 548
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 542,
+                      "end": 548
+                    }
+                  },
+                  "body": [
+                    {
+                      "kind": {
+                        "Return": {
+                          "kind": {
+                            "PropertyAccess": {
+                              "object": {
+                                "kind": {
+                                  "Variable": "this"
+                                },
+                                "span": {
+                                  "start": 566,
+                                  "end": 571
+                                }
+                              },
+                              "property": {
+                                "kind": {
+                                  "Identifier": "name"
+                                },
+                                "span": {
+                                  "start": 573,
+                                  "end": 577
+                                }
+                              }
+                            }
+                          },
+                          "span": {
+                            "start": 566,
+                            "end": 577
+                          }
+                        }
+                      },
+                      "span": {
+                        "start": 559,
+                        "end": 583
+                      }
+                    }
+                  ],
+                  "attributes": [
+                    {
+                      "name": {
+                        "parts": [
+                          "Deprecated"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 477,
+                          "end": 487
+                        }
+                      },
+                      "args": [
+                        {
+                          "name": null,
+                          "value": {
+                            "kind": {
+                              "String": "Use getName() instead"
+                            },
+                            "span": {
+                              "start": 488,
+                              "end": 511
+                            }
+                          },
+                          "unpack": false,
+                          "by_ref": false,
+                          "span": {
+                            "start": 488,
+                            "end": 511
+                          }
+                        }
+                      ],
+                      "span": {
+                        "start": 477,
+                        "end": 512
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 475,
+                "end": 585
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 356,
+        "end": 586
+      }
+    },
+    {
+      "kind": {
+        "Function": {
+          "name": "greet",
+          "params": [
+            {
+              "name": "name",
+              "type_hint": {
+                "kind": {
+                  "Named": {
+                    "parts": [
+                      "string"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 642,
+                      "end": 648
+                    }
+                  }
+                },
+                "span": {
+                  "start": 642,
+                  "end": 648
+                }
+              },
+              "default": null,
+              "by_ref": false,
+              "variadic": false,
+              "is_readonly": false,
+              "is_final": false,
+              "visibility": null,
+              "set_visibility": null,
+              "attributes": [
+                {
+                  "name": {
+                    "parts": [
+                      "FromQuery"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 631,
+                      "end": 640
+                    }
+                  },
+                  "args": [],
+                  "span": {
+                    "start": 631,
+                    "end": 640
+                  }
+                }
+              ],
+              "span": {
+                "start": 629,
+                "end": 654
+              }
+            }
+          ],
+          "body": [],
+          "return_type": null,
+          "by_ref": false,
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 614,
+        "end": 658
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 708,
+                  "end": 710
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Int": 1
+                },
+                "span": {
+                  "start": 713,
+                  "end": 714
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 708,
+            "end": 714
+          }
+        }
+      },
+      "span": {
+        "start": 708,
+        "end": 738
+      }
+    },
+    {
+      "kind": {
+        "Enum": {
+          "name": "Color",
+          "scalar_type": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Case": {
+                  "name": "Red",
+                  "value": null,
+                  "attributes": [
+                    {
+                      "name": {
+                        "parts": [
+                          "CaseAttr"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 769,
+                          "end": 777
+                        }
+                      },
+                      "args": [],
+                      "span": {
+                        "start": 769,
+                        "end": 777
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 783,
+                "end": 797
+              }
+            },
+            {
+              "kind": {
+                "Case": {
+                  "name": "Blue",
+                  "value": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 797,
+                "end": 808
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": {
+                "parts": [
+                  "EnumAttr"
+                ],
+                "kind": "Unqualified",
+                "span": {
+                  "start": 740,
+                  "end": 748
+                }
+              },
+              "args": [],
+              "span": {
+                "start": 740,
+                "end": 748
+              }
+            }
+          ]
+        }
+      },
+      "span": {
+        "start": 750,
+        "end": 809
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 809
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__string_interpolation_fixture.snap
+++ b/crates/php-parser/tests/snapshots/integration__string_interpolation_fixture.snap
@@ -1,0 +1,704 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(& result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "greeting"
+                },
+                "span": {
+                  "start": 39,
+                  "end": 48
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Literal": "Hello "
+                    },
+                    {
+                      "Expr": {
+                        "kind": {
+                          "Variable": "name"
+                        },
+                        "span": {
+                          "start": 58,
+                          "end": 63
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 51,
+                  "end": 64
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 39,
+            "end": 64
+          }
+        }
+      },
+      "span": {
+        "start": 39,
+        "end": 100
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "msg"
+                },
+                "span": {
+                  "start": 100,
+                  "end": 104
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Literal": "Name: "
+                    },
+                    {
+                      "Expr": {
+                        "kind": {
+                          "PropertyAccess": {
+                            "object": {
+                              "kind": {
+                                "Variable": "obj"
+                              },
+                              "span": {
+                                "start": 114,
+                                "end": 118
+                              }
+                            },
+                            "property": {
+                              "kind": {
+                                "Identifier": "name"
+                              },
+                              "span": {
+                                "start": 120,
+                                "end": 124
+                              }
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 114,
+                          "end": 124
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 107,
+                  "end": 125
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 100,
+            "end": 125
+          }
+        }
+      },
+      "span": {
+        "start": 100,
+        "end": 174
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "item"
+                },
+                "span": {
+                  "start": 174,
+                  "end": 179
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Literal": "Item: "
+                    },
+                    {
+                      "Expr": {
+                        "kind": {
+                          "ArrayAccess": {
+                            "array": {
+                              "kind": {
+                                "Variable": "arr"
+                              },
+                              "span": {
+                                "start": 189,
+                                "end": 193
+                              }
+                            },
+                            "index": {
+                              "kind": {
+                                "Int": 0
+                              },
+                              "span": {
+                                "start": 194,
+                                "end": 195
+                              }
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 189,
+                          "end": 196
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 182,
+                  "end": 197
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 174,
+            "end": 197
+          }
+        }
+      },
+      "span": {
+        "start": 174,
+        "end": 241
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "val"
+                },
+                "span": {
+                  "start": 241,
+                  "end": 245
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Literal": "Value: "
+                    },
+                    {
+                      "Expr": {
+                        "kind": {
+                          "ArrayAccess": {
+                            "array": {
+                              "kind": {
+                                "Variable": "arr"
+                              },
+                              "span": {
+                                "start": 256,
+                                "end": 260
+                              }
+                            },
+                            "index": {
+                              "kind": {
+                                "String": "key"
+                              },
+                              "span": {
+                                "start": 261,
+                                "end": 264
+                              }
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 256,
+                          "end": 265
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 248,
+                  "end": 266
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 241,
+            "end": 266
+          }
+        }
+      },
+      "span": {
+        "start": 241,
+        "end": 309
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "full"
+                },
+                "span": {
+                  "start": 309,
+                  "end": 314
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Literal": "Full: "
+                    },
+                    {
+                      "Expr": {
+                        "kind": {
+                          "MethodCall": {
+                            "object": {
+                              "kind": {
+                                "Variable": "user"
+                              },
+                              "span": {
+                                "start": 325,
+                                "end": 330
+                              }
+                            },
+                            "method": {
+                              "kind": {
+                                "Identifier": "getName"
+                              },
+                              "span": {
+                                "start": 332,
+                                "end": 339
+                              }
+                            },
+                            "args": []
+                          }
+                        },
+                        "span": {
+                          "start": 325,
+                          "end": 341
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 317,
+                  "end": 343
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 309,
+            "end": 343
+          }
+        }
+      },
+      "span": {
+        "start": 309,
+        "end": 376
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "mixed"
+                },
+                "span": {
+                  "start": 376,
+                  "end": 382
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Literal": "Start "
+                    },
+                    {
+                      "Expr": {
+                        "kind": {
+                          "Variable": "x"
+                        },
+                        "span": {
+                          "start": 392,
+                          "end": 394
+                        }
+                      }
+                    },
+                    {
+                      "Literal": " middle "
+                    },
+                    {
+                      "Expr": {
+                        "kind": {
+                          "Variable": "y"
+                        },
+                        "span": {
+                          "start": 402,
+                          "end": 404
+                        }
+                      }
+                    },
+                    {
+                      "Literal": " end"
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 385,
+                  "end": 409
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 376,
+            "end": 409
+          }
+        }
+      },
+      "span": {
+        "start": 376,
+        "end": 449
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "escaped"
+                },
+                "span": {
+                  "start": 449,
+                  "end": 457
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "String": "Price: $100"
+                },
+                "span": {
+                  "start": 460,
+                  "end": 474
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 449,
+            "end": 474
+          }
+        }
+      },
+      "span": {
+        "start": 449,
+        "end": 507
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "nested"
+                },
+                "span": {
+                  "start": 507,
+                  "end": 514
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Literal": "Key: "
+                    },
+                    {
+                      "Expr": {
+                        "kind": {
+                          "ArrayAccess": {
+                            "array": {
+                              "kind": {
+                                "Variable": "arr"
+                              },
+                              "span": {
+                                "start": 524,
+                                "end": 528
+                              }
+                            },
+                            "index": {
+                              "kind": {
+                                "String": "key"
+                              },
+                              "span": {
+                                "start": 529,
+                                "end": 534
+                              }
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 524,
+                          "end": 535
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 517,
+                  "end": 537
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 507,
+            "end": 537
+          }
+        }
+      },
+      "span": {
+        "start": 507,
+        "end": 565
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "start"
+                },
+                "span": {
+                  "start": 565,
+                  "end": 571
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Expr": {
+                        "kind": {
+                          "Variable": "name"
+                        },
+                        "span": {
+                          "start": 575,
+                          "end": 580
+                        }
+                      }
+                    },
+                    {
+                      "Literal": " is great"
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 574,
+                  "end": 590
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 565,
+            "end": 590
+          }
+        }
+      },
+      "span": {
+        "start": 565,
+        "end": 616
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "end"
+                },
+                "span": {
+                  "start": 616,
+                  "end": 620
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Literal": "Hello "
+                    },
+                    {
+                      "Expr": {
+                        "kind": {
+                          "Variable": "name"
+                        },
+                        "span": {
+                          "start": 630,
+                          "end": 635
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 623,
+                  "end": 636
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 616,
+            "end": 636
+          }
+        }
+      },
+      "span": {
+        "start": 616,
+        "end": 683
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "plain"
+                },
+                "span": {
+                  "start": 683,
+                  "end": 689
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "String": "just a plain string"
+                },
+                "span": {
+                  "start": 692,
+                  "end": 713
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 683,
+            "end": 713
+          }
+        }
+      },
+      "span": {
+        "start": 683,
+        "end": 736
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "escapes"
+                },
+                "span": {
+                  "start": 736,
+                  "end": 744
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "String": "line1\nline2\ttab"
+                },
+                "span": {
+                  "start": 747,
+                  "end": 766
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 736,
+            "end": 766
+          }
+        }
+      },
+      "span": {
+        "start": 736,
+        "end": 768
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 768
+  }
+}

--- a/crates/php-parser/tests/snapshots/malformed_php__array_invalid_key.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__array_invalid_key.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected expression

--- a/crates/php-parser/tests/snapshots/malformed_php__array_unclosed_bracket.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__array_unclosed_bracket.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected ']', found ';'

--- a/crates/php-parser/tests/snapshots/malformed_php__catch_missing_exception.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__catch_missing_exception.snap
@@ -1,0 +1,7 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected '(', found '{'
+expected identifier, found '{'
+expected ')', found '{'

--- a/crates/php-parser/tests/snapshots/malformed_php__catch_unclosed_paren.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__catch_unclosed_paren.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected ')', found '{'

--- a/crates/php-parser/tests/snapshots/malformed_php__class_invalid_extends.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__class_invalid_extends.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected identifier, found '{'

--- a/crates/php-parser/tests/snapshots/malformed_php__class_invalid_implements.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__class_invalid_implements.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected identifier, found '{'

--- a/crates/php-parser/tests/snapshots/malformed_php__class_missing_name.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__class_missing_name.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected class name, found '{'

--- a/crates/php-parser/tests/snapshots/malformed_php__class_unclosed.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__class_unclosed.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected '}', found end of file

--- a/crates/php-parser/tests/snapshots/malformed_php__const_without_value.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__const_without_value.snap
@@ -1,0 +1,6 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected '=', found ';'
+expected expression

--- a/crates/php-parser/tests/snapshots/malformed_php__declare_incomplete_paren.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__declare_incomplete_paren.snap
@@ -1,0 +1,6 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected ')', found end of file
+expected statement

--- a/crates/php-parser/tests/snapshots/malformed_php__declare_missing_equals.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__declare_missing_equals.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected '=', found integer

--- a/crates/php-parser/tests/snapshots/malformed_php__declare_unclosed.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__declare_unclosed.snap
@@ -1,0 +1,6 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected ')', found end of file
+expected statement

--- a/crates/php-parser/tests/snapshots/malformed_php__function_invalid_return_type.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__function_invalid_return_type.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected identifier, found '{'

--- a/crates/php-parser/tests/snapshots/malformed_php__function_unclosed_body.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__function_unclosed_body.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+unclosed ''}'' opened at Span { start: 22, end: 23 }

--- a/crates/php-parser/tests/snapshots/malformed_php__function_unclosed_params.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__function_unclosed_params.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+unclosed '')'' opened at Span { start: 19, end: 20 }

--- a/crates/php-parser/tests/snapshots/malformed_php__if_missing_condition.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__if_missing_condition.snap
@@ -1,0 +1,8 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected '(', found '{'
+expected expression
+unclosed '')'' opened at Span { start: 9, end: 10 }
+expected statement

--- a/crates/php-parser/tests/snapshots/malformed_php__if_unclosed_condition.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__if_unclosed_condition.snap
@@ -1,0 +1,7 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected expression
+unclosed '')'' opened at Span { start: 9, end: 10 }
+expected statement

--- a/crates/php-parser/tests/snapshots/malformed_php__incomplete_match.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__incomplete_match.snap
@@ -1,0 +1,6 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected '}', found end of file
+expected ';' after expression

--- a/crates/php-parser/tests/snapshots/malformed_php__incomplete_ternary.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__incomplete_ternary.snap
@@ -1,0 +1,8 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected expression
+expected ':', found end of file
+expected expression
+expected ';' after expression

--- a/crates/php-parser/tests/snapshots/malformed_php__match_missing_comma.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__match_missing_comma.snap
@@ -1,0 +1,9 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected '}', found integer
+expected ';' after expression
+expected ';' after expression
+expected expression
+expected expression

--- a/crates/php-parser/tests/snapshots/malformed_php__match_missing_expression_after_arrow.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__match_missing_expression_after_arrow.snap
@@ -1,0 +1,6 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected expression
+expected ';' after expression

--- a/crates/php-parser/tests/snapshots/malformed_php__namespace_missing_name.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__namespace_missing_name.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected identifier, found ';'

--- a/crates/php-parser/tests/snapshots/malformed_php__namespace_unclosed_braces.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__namespace_unclosed_braces.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected '}', found end of file

--- a/crates/php-parser/tests/snapshots/malformed_php__repeated_union_types.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__repeated_union_types.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected variable, found ')'

--- a/crates/php-parser/tests/snapshots/malformed_php__switch_missing_expr.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__switch_missing_expr.snap
@@ -1,0 +1,9 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected '(', found '{'
+expected expression
+unclosed '')'' opened at Span { start: 13, end: 14 }
+expected '{', found end of file
+expected '}', found end of file

--- a/crates/php-parser/tests/snapshots/malformed_php__trait_invalid_adaptation_syntax.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__trait_invalid_adaptation_syntax.snap
@@ -1,0 +1,7 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected '::' or 'as', found identifier
+expected identifier, found ';'
+expected '::' or 'as', found ';'

--- a/crates/php-parser/tests/snapshots/malformed_php__trait_missing_method_name.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__trait_missing_method_name.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected '::' or 'as', found ';'

--- a/crates/php-parser/tests/snapshots/malformed_php__trait_unclosed_brace.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__trait_unclosed_brace.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected '}', found end of file

--- a/crates/php-parser/tests/snapshots/malformed_php__try_without_catch_or_finally.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__try_without_catch_or_finally.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected catch or finally clause, found end of file

--- a/crates/php-parser/tests/snapshots/malformed_php__unclosed_double_quote.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__unclosed_double_quote.snap
@@ -1,0 +1,6 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected ';' after expression
+expected ';' after expression

--- a/crates/php-parser/tests/snapshots/malformed_php__unclosed_heredoc.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__unclosed_heredoc.snap
@@ -1,0 +1,8 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected expression
+expected expression
+expected ';' after expression
+expected ';' after expression

--- a/crates/php-parser/tests/snapshots/malformed_php__unclosed_single_quote.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__unclosed_single_quote.snap
@@ -1,0 +1,6 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected ';' after expression
+expected ';' after expression

--- a/crates/php-parser/tests/snapshots/malformed_php__use_missing_name.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__use_missing_name.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+expected identifier, found ';'


### PR DESCRIPTION
## Summary

- **`malformed_php`**: replace no-op `let _ = serde_json::to_string_pretty(...)` with real assertions. 29 error tests now snapshot diagnostic messages so any change to error output is caught; 10 valid-but-unusual tests now assert the parser accepts them cleanly via `assert_parses_clean!`.

- **`integration`**: add snapshot tests for `string_interpolation.php` and `attributes.php` fixtures, which were validated by `php -l` but had no AST snapshot. Add `test_typed_class_constants_variants` to exercise the new inline cases.

- **`inline_cases`**: expand thin categories so `php_syntax.rs` validates more strings via `php -l`:
  - `declare`: 2 → 5 cases
  - `magic_constants`: 1 → 5 cases
  - `arrow_function`: 1 → 6 cases
  - `enum`: 3 → 8 cases
  - `typed_class_constants`: new PHP 8.3+ category (4 cases)

- **`inline_cases` / `php_syntax`**: introduce `min_php` / `max_php` version bounds on `Case` via a `case!` macro that defaults both to `Any`, so version-gated entries can be annotated without boilerplate on every other case.

## Test plan

- [ ] `cargo nextest run --test integration` — 378 tests pass
- [ ] `cargo nextest run --test malformed_php` — 43 tests pass
- [ ] `cargo nextest run --test php_syntax` — 6 tests pass (requires PHP 8.5)
- [ ] `cargo clippy --workspace -- -D warnings` — clean