### PR TITLE
test: expand coverage for edge cases across PHP 8.0–8.5

### DIFF
--- a/crates/php-parser/build.rs
+++ b/crates/php-parser/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(php_available)");
+    println!("cargo::rustc-check-cfg=cfg(php_min_81)");
     println!("cargo::rustc-check-cfg=cfg(php_min_82)");
     println!("cargo::rustc-check-cfg=cfg(php_min_83)");
     println!("cargo::rustc-check-cfg=cfg(php_min_84)");
@@ -19,6 +20,9 @@ fn main() {
     let Ok(maj) = maj.parse::<u32>() else { return };
     let Ok(min) = min.parse::<u32>() else { return };
     println!("cargo:rustc-cfg=php_available");
+    if (maj, min) >= (8, 1) {
+        println!("cargo:rustc-cfg=php_min_81");
+    }
     if (maj, min) >= (8, 2) {
         println!("cargo:rustc-cfg=php_min_82");
     }

--- a/crates/php-parser/src/parser.rs
+++ b/crates/php-parser/src/parser.rs
@@ -533,6 +533,18 @@ impl<'arena, 'src> Parser<'arena, 'src> {
                 types.push(self.parse_type_element());
             }
             let span = Span::new(start, types.last().unwrap().span.end);
+            let has_true = types
+                .iter()
+                .any(|t| matches!(t.kind, TypeHintKind::Keyword(BuiltinType::True, _)));
+            let has_false = types
+                .iter()
+                .any(|t| matches!(t.kind, TypeHintKind::Keyword(BuiltinType::False, _)));
+            if has_true && has_false {
+                self.error(ParseError::Forbidden {
+                    message: "Type contains both true and false, bool must be used instead".into(),
+                    span,
+                });
+            }
             return TypeHint {
                 kind: TypeHintKind::Union(types),
                 span,

--- a/crates/php-parser/tests/inline_cases.rs
+++ b/crates/php-parser/tests/inline_cases.rs
@@ -350,10 +350,11 @@ pub const CASES: &[Case] = &[
     case!("type_hints", "void return", "<?php function f(): void {}"),
     case!("type_hints", "iterable type", "<?php function f(iterable $x): iterable {}"),
     case!("type_hints", "callable type", "<?php function f(callable $x) {}"),
-    case!("type_hints", "true false null union", "<?php function f(): true|false|null {}", min: MinPhp::Php82),
     case!("type_hints", "three intersection", "<?php function f(Countable&Traversable&ArrayAccess $x): void {}"),
     case!("type_hints", "standalone true", "<?php function f(): true { return true; }", min: MinPhp::Php82),
     case!("type_hints", "standalone false", "<?php function f(): false { return false; }", min: MinPhp::Php82),
+    case!("type_hints", "true null union", "<?php function f(): true|null { return null; }", min: MinPhp::Php82),
+    case!("type_hints", "false null union", "<?php function f(): false|null { return null; }", min: MinPhp::Php82),
 
     // attributes
     case!("attributes", "attr qualified name", "<?php #[\\App\\Attr] function foo() {}"),

--- a/crates/php-parser/tests/inline_cases.rs
+++ b/crates/php-parser/tests/inline_cases.rs
@@ -16,6 +16,7 @@
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MinPhp {
     Any,
+    Php81,
     Php82,
     Php83,
     Php84,
@@ -105,6 +106,8 @@ pub const CASES: &[Case] = &[
     case!("declare", "declare strict", "<?php declare(strict_types=1);"),
     case!("declare", "declare with block", "<?php declare(ticks=1) { foo(); bar(); }"),
     case!("declare", "declare ticks value 100", "<?php declare(ticks=100);"),
+    case!("declare", "declare alternative syntax", "<?php declare(ticks=1): echo 'tick'; enddeclare;"),
+    case!("declare", "declare nested", "<?php declare(ticks=1) { declare(ticks=2); }"),
 
     // magic_constants
     case!("magic_constants", "all magic consts", "<?php echo __LINE__, __FILE__, __DIR__, __FUNCTION__, __CLASS__, __TRAIT__, __METHOD__, __NAMESPACE__;"),
@@ -190,6 +193,11 @@ pub const CASES: &[Case] = &[
     case!("dynamic_access", "dynamic static method", "<?php $class::$method();"),
     case!("dynamic_access", "variable class new", "<?php new $className();"),
     case!("dynamic_access", "variable class static", "<?php $class::CONST_NAME;"),
+    case!("dynamic_access", "quadruple var-var", r#"<?php $$$$quad = 1;"#),
+    case!("dynamic_access", "var-var as array key", r#"<?php $arr[$$key] = 1;"#),
+    case!("dynamic_access", "obj prop as var-var expr", r#"<?php ${$obj->name} = 'x';"#),
+    case!("dynamic_access", "var-var in isset", r#"<?php isset($$name);"#),
+    case!("dynamic_access", "var-var in unset", r#"<?php unset($$name);"#),
 
     // destructuring
     case!("destructuring", "nested array destruct", "<?php [[$a, $b], [$c, $d]] = $arr;"),
@@ -213,6 +221,10 @@ pub const CASES: &[Case] = &[
     case!("control_flow", "multiple braced ns", "<?php namespace A { function foo() {} } namespace B { function bar() {} }"),
     case!("control_flow", "empty braced ns", "<?php namespace A { }"),
     case!("control_flow", "global ns block", "<?php namespace { function main() {} }"),
+    case!("control_flow", "for multi condition", "<?php for ($i=0; $a, $b; $i++) {}"),
+    case!("control_flow", "for three init exprs", "<?php for ($a=0, $b=1, $c=2; $a < 10; $a++) {}"),
+    case!("control_flow", "for complex update", "<?php for ($i=0; $i<10; $i++, $j--, $k+=2) {}"),
+    case!("control_flow", "for all empty", "<?php for (;;) { break; }"),
 
     // try_catch
     case!("try_catch", "multi catch types", "<?php try { foo(); } catch (TypeError | ValueError $e) { echo $e; }"),
@@ -242,6 +254,14 @@ pub const CASES: &[Case] = &[
     case!("named_args", "named with spread", "<?php foo(...$extra, name: 'test');"),
     case!("named_args", "named in new", "<?php new Foo(x: 1, y: 2);"),
     case!("named_args", "named in method", "<?php $obj->method(key: 'val');"),
+    case!("named_args", "keyword name fn", "<?php foo(fn: $x);"),
+    case!("named_args", "keyword name list", "<?php foo(list: $x);"),
+    case!("named_args", "keyword name null", "<?php foo(null: $x);"),
+    case!("named_args", "keyword name true", "<?php foo(true: $x);"),
+    case!("named_args", "keyword name false", "<?php foo(false: $x);"),
+    case!("named_args", "keyword name for", "<?php foo(for: $x);"),
+    case!("named_args", "keyword name while", "<?php foo(while: $x);"),
+    case!("named_args", "named only spread", r#"<?php foo(...['name' => $x]);"#),
 
     // closure
     case!("closure", "static arrow", "<?php $fn = static fn($x) => $x * 2;"),
@@ -330,6 +350,10 @@ pub const CASES: &[Case] = &[
     case!("type_hints", "void return", "<?php function f(): void {}"),
     case!("type_hints", "iterable type", "<?php function f(iterable $x): iterable {}"),
     case!("type_hints", "callable type", "<?php function f(callable $x) {}"),
+    case!("type_hints", "true false null union", "<?php function f(): true|false|null {}", min: MinPhp::Php82),
+    case!("type_hints", "three intersection", "<?php function f(Countable&Traversable&ArrayAccess $x): void {}"),
+    case!("type_hints", "standalone true", "<?php function f(): true { return true; }", min: MinPhp::Php82),
+    case!("type_hints", "standalone false", "<?php function f(): false { return false; }", min: MinPhp::Php82),
 
     // attributes
     case!("attributes", "attr qualified name", "<?php #[\\App\\Attr] function foo() {}"),
@@ -338,6 +362,34 @@ pub const CASES: &[Case] = &[
     case!("attributes", "attr on enum case", "<?php enum Suit { #[Description('Hearts')] case Hearts; }"),
     case!("attributes", "stacked attrs", "<?php #[A] #[B] #[C] class Foo {}"),
     case!("attributes", "grouped attrs", "<?php #[A, B, C] class Foo {}"),
+
+    // string_interp_edge
+    case!("string_interp_edge", "array key identifier in string", r#"<?php $x = "$arr[foo] here";"#),
+    case!("string_interp_edge", "empty double-quoted", r#"<?php $x = "";"#),
+    case!("string_interp_edge", "empty heredoc", "<?php $x = <<<EOT\nEOT;\n"),
+    case!("string_interp_edge", "only escape sequences", r#"<?php $x = "\n\r\t\v\e\f\\\$\"";"#),
+    case!("string_interp_edge", "unicode max codepoint", r#"<?php $x = "\u{10FFFF}";"#),
+    case!("string_interp_edge", "var with bracket index in string", r#"<?php $x = "$arr[0] end";"#),
+    case!("string_interp_edge", "var then text then var", r#"<?php $x = "$a-$b";"#),
+
+    // trait_use
+    case!("trait_use", "alias visibility only", "<?php class C { use T { foo as protected; } }"),
+    case!("trait_use", "alias qualified method", "<?php class C { use T { T::foo as bar; } }"),
+    case!("trait_use", "alias qualified with visibility", "<?php class C { use T { T::foo as protected baz; } }"),
+    case!("trait_use", "multiple traits", "<?php class C { use A, B, C; }"),
+    case!("trait_use", "insteadof multi", "<?php class C { use A, B { A::m insteadof B; } }"),
+    case!("trait_use", "multiple adaptations", "<?php class C { use A, B { A::m insteadof B; B::n as public nAlias; } }"),
+
+    // numeric_literals
+    case!("numeric_literals", "explicit octal", "<?php $x = 0o777;", min: MinPhp::Php81),
+    case!("numeric_literals", "hex with underscores", "<?php $x = 0xFFFF_FFFF;"),
+    case!("numeric_literals", "leading zero float", "<?php $x = 0.001;"),
+    case!("numeric_literals", "negative exponent float", "<?php $x = 1.5e-10;"),
+    case!("numeric_literals", "int max", "<?php $x = 9223372036854775807;"),
+    case!("numeric_literals", "binary with underscores", "<?php $x = 0b1111_0000;"),
+    case!("numeric_literals", "float no leading zero", "<?php $x = .5;"),
+    case!("numeric_literals", "zero literal", "<?php $x = 0;"),
+    case!("numeric_literals", "positive exponent float", "<?php $x = 2.5e+3;"),
 
     // builtins
     case!("builtins", "list assign", "<?php list($a, $b) = $arr;"),

--- a/crates/php-parser/tests/integration.rs
+++ b/crates/php-parser/tests/integration.rs
@@ -4440,6 +4440,18 @@ class Foo {
 }
 
 // =============================================================================
+// Type Validation: true|false in union
+// =============================================================================
+
+#[test]
+fn test_true_false_union_is_invalid() {
+    // PHP rejects true|false: "Type contains both true and false, bool must be used instead"
+    assert_has_errors("<?php function f(): true|false {}");
+    assert_has_errors("<?php function f(): true|false|null {}");
+    assert_has_errors("<?php function f(true|false $x): void {}");
+}
+
+// =============================================================================
 // Version Gate: Explicit Octal (PHP 8.1+)
 // =============================================================================
 

--- a/crates/php-parser/tests/integration.rs
+++ b/crates/php-parser/tests/integration.rs
@@ -2926,6 +2926,27 @@ fn test_builtin_constructs() {
 }
 
 #[test]
+fn test_string_interp_edge_cases() {
+    for case in category("string_interp_edge") {
+        assert_parses_ok(case.label, case.source);
+    }
+}
+
+#[test]
+fn test_trait_use_adaptations() {
+    for case in category("trait_use") {
+        assert_parses_ok(case.label, case.source);
+    }
+}
+
+#[test]
+fn test_numeric_literals_variants() {
+    for case in category("numeric_literals") {
+        assert_parses_ok(case.label, case.source);
+    }
+}
+
+#[test]
 fn test_slash_comment_terminated_by_close_tag() {
     // `// comment ?>` must produce a CloseTag so the HTML is InlineHtml, not garbage.
     let result = parse_php("<?php // comment ?>\n<div>html</div>\n<?php $x = 1;");
@@ -4166,4 +4187,269 @@ fn test_arg_by_ref_preserved_in_ast() {
     let arg = &call.args[0];
     assert!(arg.by_ref, "by_ref should be true for &$a argument");
     assert!(!arg.unpack, "unpack should be false");
+}
+
+// =============================================================================
+// Shell Exec: Complex Interpolation
+// =============================================================================
+
+#[test]
+fn test_shell_exec_complex_interpolation() {
+    let source = r#"<?php
+$a = `ls {$dirs['home']}`;
+$b = `{$obj->getCommand()} --flag=$value`;
+$c = `echo $arr[0]`;
+"#;
+    let result = parse_php(source);
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+#[test]
+fn test_shell_exec_empty() {
+    let result = parse_php("<?php $x = ``;");
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+// =============================================================================
+// Heredoc/Nowdoc: Edge Cases
+// =============================================================================
+
+#[test]
+fn test_indented_heredoc_with_interpolation() {
+    let source = "<?php\n$x = <<<END\n    Hello {$obj->name}!\n    $arr[0] items\n    END;\n";
+    let result = parse_php(source);
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+#[test]
+fn test_heredoc_in_array_value() {
+    let source = "<?php\n$arr = [\n    'key' => <<<EOT\n    value\n    EOT,\n];\n";
+    let result = parse_php(source);
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+#[test]
+fn test_nowdoc_in_match_arm() {
+    let source = "<?php\n$r = match(true) {\n    default => <<<'NOW'\n    literal\n    NOW,\n};\n";
+    let result = parse_php(source);
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+#[test]
+fn test_heredoc_as_default_param() {
+    let source = "<?php\nfunction f($s = <<<'EOT'\nhello\nEOT\n) {}\n";
+    let result = parse_php(source);
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+// =============================================================================
+// Goto: Multiple Labels and Backward Jumps
+// =============================================================================
+
+#[test]
+fn test_goto_backward_jump() {
+    let source = r#"<?php
+start:
+if ($count++ < 3) {
+    goto start;
+}
+"#;
+    let result = parse_php(source);
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+#[test]
+fn test_goto_multiple_labels() {
+    let source = r#"<?php
+if ($a) goto labelA;
+if ($b) goto labelB;
+labelA:
+echo 'A';
+goto end;
+labelB:
+echo 'B';
+end:
+echo 'done';
+"#;
+    let result = parse_php(source);
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+#[test]
+fn test_goto_inside_switch() {
+    let source = r#"<?php
+switch ($x) {
+    case 1:
+        goto done;
+    case 2:
+        echo 'two';
+}
+done:
+echo 'done';
+"#;
+    let result = parse_php(source);
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+// =============================================================================
+// Variable Variables: Deep Nesting
+// =============================================================================
+
+#[test]
+fn test_variable_variable_as_dynamic_method() {
+    // curly-brace form is needed for var-var in method position
+    let result = parse_php("<?php $obj->{$$method}();");
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+// =============================================================================
+// Constructor Promoted Parameters with Hooks
+// =============================================================================
+
+#[test]
+fn test_constructor_promoted_param_with_hooks() {
+    let source = r#"<?php
+class Foo {
+    public function __construct(
+        public string $name {
+            get => strtoupper($this->name);
+            set(string $value) { $this->name = trim($value); }
+        },
+    ) {}
+}
+"#;
+    let result = parse_php(source);
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+#[test]
+fn test_interface_property_hooks() {
+    let source = r#"<?php
+interface HasName {
+    public string $name { get; }
+}
+"#;
+    let result = parse_php(source);
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+// =============================================================================
+// __halt_compiler(): Data Capture Edge Cases
+// =============================================================================
+
+#[test]
+fn test_halt_compiler_empty_remainder() {
+    let result = parse_php("<?php __halt_compiler();");
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+#[test]
+fn test_halt_compiler_with_statements_before() {
+    let result = parse_php("<?php echo 'before'; __halt_compiler(); raw data here");
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+// =============================================================================
+// Attributes: Remaining Targets
+// =============================================================================
+
+#[test]
+fn test_attribute_on_class_constant() {
+    let result = parse_php("<?php class A { #[Deprecated] const FOO = 1; }");
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+#[test]
+fn test_attribute_on_interface_method() {
+    let result = parse_php("<?php interface I { #[Pure] public function foo(): void; }");
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+#[test]
+fn test_attribute_on_trait_property() {
+    let result = parse_php("<?php trait T { #[Inject] public string $dep; }");
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+#[test]
+fn test_attribute_on_enum_method() {
+    let result = parse_php("<?php enum E { case A; #[Override] public function foo(): void {} }");
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+#[test]
+fn test_attribute_with_new_expression_arg() {
+    let result = parse_php("<?php #[Attr(new Config(debug: false))] function f() {}");
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+// =============================================================================
+// list() By-Reference Destructuring
+// =============================================================================
+
+#[test]
+fn test_list_by_reference_destructuring() {
+    let source = r#"<?php
+[&$a, &$b] = $arr;
+list(&$x, &$y) = $pair;
+[&$first, $second] = $mixed;
+"#;
+    let result = parse_php(source);
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+// =============================================================================
+// __PROPERTY__ in Hook Body
+// =============================================================================
+
+#[test]
+fn test_magic_property_in_hook_body() {
+    let source = r#"<?php
+class Foo {
+    public string $name {
+        get {
+            echo __PROPERTY__;
+            return $this->name;
+        }
+    }
+}
+"#;
+    let result = parse_php(source);
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+// =============================================================================
+// Version Gate: Explicit Octal (PHP 8.1+)
+// =============================================================================
+
+#[test]
+fn test_explicit_octal_valid_on_81() {
+    let result = parse_php_versioned("<?php $x = 0o777;", php_rs_parser::PhpVersion::Php81);
+    assert!(
+        result.errors.is_empty(),
+        "explicit octal should be valid on PHP 8.1: {:?}",
+        result.errors
+    );
+    insta::assert_snapshot!(to_json(&result.program));
 }

--- a/crates/php-parser/tests/php_syntax.rs
+++ b/crates/php-parser/tests/php_syntax.rs
@@ -35,6 +35,7 @@ fn assert_php_syntax(code: &str) {
 #[cfg_attr(not(php_available), ignore)]
 #[test]
 fn inline_cases_are_valid_php() {
+    const MIN_81: bool = cfg!(php_min_81);
     const MIN_82: bool = cfg!(php_min_82);
     const MIN_83: bool = cfg!(php_min_83);
     const MIN_84: bool = cfg!(php_min_84);
@@ -43,6 +44,7 @@ fn inline_cases_are_valid_php() {
     for case in inline_cases::CASES {
         let min_ok = match case.min_php {
             inline_cases::MinPhp::Any => true,
+            inline_cases::MinPhp::Php81 => MIN_81,
             inline_cases::MinPhp::Php82 => MIN_82,
             inline_cases::MinPhp::Php83 => MIN_83,
             inline_cases::MinPhp::Php84 => MIN_84,

--- a/crates/php-parser/tests/snapshots/integration__attribute_on_class_constant.snap
+++ b/crates/php-parser/tests/snapshots/integration__attribute_on_class_constant.snap
@@ -1,0 +1,73 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "A",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "ClassConst": {
+                  "name": "FOO",
+                  "visibility": null,
+                  "value": {
+                    "kind": {
+                      "Int": 1
+                    },
+                    "span": {
+                      "start": 42,
+                      "end": 43
+                    }
+                  },
+                  "attributes": [
+                    {
+                      "name": {
+                        "parts": [
+                          "Deprecated"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 18,
+                          "end": 28
+                        }
+                      },
+                      "args": [],
+                      "span": {
+                        "start": 18,
+                        "end": 28
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 16,
+                "end": 45
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 46
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 46
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__attribute_on_enum_method.snap
+++ b/crates/php-parser/tests/snapshots/integration__attribute_on_enum_method.snap
@@ -1,0 +1,96 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Enum": {
+          "name": "E",
+          "scalar_type": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Case": {
+                  "name": "A",
+                  "value": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 15,
+                "end": 23
+              }
+            },
+            {
+              "kind": {
+                "Method": {
+                  "name": "foo",
+                  "visibility": "Public",
+                  "is_static": false,
+                  "is_abstract": false,
+                  "is_final": false,
+                  "by_ref": false,
+                  "params": [],
+                  "return_type": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "void"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 58,
+                          "end": 62
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 58,
+                      "end": 62
+                    }
+                  },
+                  "body": [],
+                  "attributes": [
+                    {
+                      "name": {
+                        "parts": [
+                          "Override"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 25,
+                          "end": 33
+                        }
+                      },
+                      "args": [],
+                      "span": {
+                        "start": 25,
+                        "end": 33
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 35,
+                "end": 66
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 67
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 67
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__attribute_on_interface_method.snap
+++ b/crates/php-parser/tests/snapshots/integration__attribute_on_interface_method.snap
@@ -1,0 +1,82 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Interface": {
+          "name": "I",
+          "extends": [],
+          "members": [
+            {
+              "kind": {
+                "Method": {
+                  "name": "foo",
+                  "visibility": "Public",
+                  "is_static": false,
+                  "is_abstract": false,
+                  "is_final": false,
+                  "by_ref": false,
+                  "params": [],
+                  "return_type": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "void"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 51,
+                          "end": 55
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 51,
+                      "end": 55
+                    }
+                  },
+                  "body": null,
+                  "attributes": [
+                    {
+                      "name": {
+                        "parts": [
+                          "Pure"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 22,
+                          "end": 26
+                        }
+                      },
+                      "args": [],
+                      "span": {
+                        "start": 22,
+                        "end": 26
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 20,
+                "end": 57
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 58
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 58
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__attribute_on_trait_property.snap
+++ b/crates/php-parser/tests/snapshots/integration__attribute_on_trait_property.snap
@@ -1,0 +1,79 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Trait": {
+          "name": "T",
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "dep",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "string"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 33,
+                          "end": 39
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 33,
+                      "end": 39
+                    }
+                  },
+                  "default": null,
+                  "attributes": [
+                    {
+                      "name": {
+                        "parts": [
+                          "Inject"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 18,
+                          "end": 24
+                        }
+                      },
+                      "args": [],
+                      "span": {
+                        "start": 18,
+                        "end": 24
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 16,
+                "end": 44
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 47
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 47
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__attribute_with_new_expression_arg.snap
+++ b/crates/php-parser/tests/snapshots/integration__attribute_with_new_expression_arg.snap
@@ -1,0 +1,95 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Function": {
+          "name": "f",
+          "params": [],
+          "body": [],
+          "return_type": null,
+          "by_ref": false,
+          "attributes": [
+            {
+              "name": {
+                "parts": [
+                  "Attr"
+                ],
+                "kind": "Unqualified",
+                "span": {
+                  "start": 8,
+                  "end": 12
+                }
+              },
+              "args": [
+                {
+                  "name": null,
+                  "value": {
+                    "kind": {
+                      "New": {
+                        "class": {
+                          "kind": {
+                            "Identifier": "Config"
+                          },
+                          "span": {
+                            "start": 17,
+                            "end": 23
+                          }
+                        },
+                        "args": [
+                          {
+                            "name": "debug",
+                            "value": {
+                              "kind": {
+                                "Bool": false
+                              },
+                              "span": {
+                                "start": 31,
+                                "end": 36
+                              }
+                            },
+                            "unpack": false,
+                            "by_ref": false,
+                            "span": {
+                              "start": 24,
+                              "end": 36
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "span": {
+                      "start": 13,
+                      "end": 37
+                    }
+                  },
+                  "unpack": false,
+                  "by_ref": false,
+                  "span": {
+                    "start": 13,
+                    "end": 37
+                  }
+                }
+              ],
+              "span": {
+                "start": 8,
+                "end": 38
+              }
+            }
+          ]
+        }
+      },
+      "span": {
+        "start": 40,
+        "end": 55
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 55
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__constructor_promoted_param_with_hooks.snap
+++ b/crates/php-parser/tests/snapshots/integration__constructor_promoted_param_with_hooks.snap
@@ -1,0 +1,295 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Method": {
+                  "name": "__construct",
+                  "visibility": "Public",
+                  "is_static": false,
+                  "is_abstract": false,
+                  "is_final": false,
+                  "by_ref": false,
+                  "params": [
+                    {
+                      "name": "name",
+                      "type_hint": {
+                        "kind": {
+                          "Named": {
+                            "parts": [
+                              "string"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 66,
+                              "end": 72
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 66,
+                          "end": 72
+                        }
+                      },
+                      "default": null,
+                      "by_ref": false,
+                      "variadic": false,
+                      "is_readonly": false,
+                      "is_final": false,
+                      "visibility": "Public",
+                      "set_visibility": null,
+                      "attributes": [],
+                      "hooks": [
+                        {
+                          "kind": "Get",
+                          "body": {
+                            "Expression": {
+                              "kind": {
+                                "FunctionCall": {
+                                  "name": {
+                                    "kind": {
+                                      "Identifier": "strtoupper"
+                                    },
+                                    "span": {
+                                      "start": 100,
+                                      "end": 110
+                                    }
+                                  },
+                                  "args": [
+                                    {
+                                      "name": null,
+                                      "value": {
+                                        "kind": {
+                                          "PropertyAccess": {
+                                            "object": {
+                                              "kind": {
+                                                "Variable": "this"
+                                              },
+                                              "span": {
+                                                "start": 111,
+                                                "end": 116
+                                              }
+                                            },
+                                            "property": {
+                                              "kind": {
+                                                "Identifier": "name"
+                                              },
+                                              "span": {
+                                                "start": 118,
+                                                "end": 122
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "span": {
+                                          "start": 111,
+                                          "end": 122
+                                        }
+                                      },
+                                      "unpack": false,
+                                      "by_ref": false,
+                                      "span": {
+                                        "start": 111,
+                                        "end": 122
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "span": {
+                                "start": 100,
+                                "end": 123
+                              }
+                            }
+                          },
+                          "is_final": false,
+                          "by_ref": false,
+                          "params": [],
+                          "attributes": [],
+                          "span": {
+                            "start": 93,
+                            "end": 137
+                          }
+                        },
+                        {
+                          "kind": "Set",
+                          "body": {
+                            "Block": [
+                              {
+                                "kind": {
+                                  "Expression": {
+                                    "kind": {
+                                      "Assign": {
+                                        "target": {
+                                          "kind": {
+                                            "PropertyAccess": {
+                                              "object": {
+                                                "kind": {
+                                                  "Variable": "this"
+                                                },
+                                                "span": {
+                                                  "start": 158,
+                                                  "end": 163
+                                                }
+                                              },
+                                              "property": {
+                                                "kind": {
+                                                  "Identifier": "name"
+                                                },
+                                                "span": {
+                                                  "start": 165,
+                                                  "end": 169
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "span": {
+                                            "start": 158,
+                                            "end": 169
+                                          }
+                                        },
+                                        "op": "Assign",
+                                        "value": {
+                                          "kind": {
+                                            "FunctionCall": {
+                                              "name": {
+                                                "kind": {
+                                                  "Identifier": "trim"
+                                                },
+                                                "span": {
+                                                  "start": 172,
+                                                  "end": 176
+                                                }
+                                              },
+                                              "args": [
+                                                {
+                                                  "name": null,
+                                                  "value": {
+                                                    "kind": {
+                                                      "Variable": "value"
+                                                    },
+                                                    "span": {
+                                                      "start": 177,
+                                                      "end": 183
+                                                    }
+                                                  },
+                                                  "unpack": false,
+                                                  "by_ref": false,
+                                                  "span": {
+                                                    "start": 177,
+                                                    "end": 183
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "span": {
+                                            "start": 172,
+                                            "end": 184
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "span": {
+                                      "start": 158,
+                                      "end": 184
+                                    }
+                                  }
+                                },
+                                "span": {
+                                  "start": 158,
+                                  "end": 186
+                                }
+                              }
+                            ]
+                          },
+                          "is_final": false,
+                          "by_ref": false,
+                          "params": [
+                            {
+                              "name": "value",
+                              "type_hint": {
+                                "kind": {
+                                  "Named": {
+                                    "parts": [
+                                      "string"
+                                    ],
+                                    "kind": "Unqualified",
+                                    "span": {
+                                      "start": 141,
+                                      "end": 147
+                                    }
+                                  }
+                                },
+                                "span": {
+                                  "start": 141,
+                                  "end": 147
+                                }
+                              },
+                              "default": null,
+                              "by_ref": false,
+                              "variadic": false,
+                              "is_readonly": false,
+                              "is_final": false,
+                              "visibility": null,
+                              "set_visibility": null,
+                              "attributes": [],
+                              "span": {
+                                "start": 141,
+                                "end": 154
+                              }
+                            }
+                          ],
+                          "attributes": [],
+                          "span": {
+                            "start": 137,
+                            "end": 196
+                          }
+                        }
+                      ],
+                      "span": {
+                        "start": 59,
+                        "end": 197
+                      }
+                    }
+                  ],
+                  "return_type": null,
+                  "body": [],
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 22,
+                "end": 208
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 209
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 209
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__explicit_octal_valid_on_81.snap
+++ b/crates/php-parser/tests/snapshots/integration__explicit_octal_valid_on_81.snap
@@ -1,0 +1,49 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Int": 511
+                },
+                "span": {
+                  "start": 11,
+                  "end": 16
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 16
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 17
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 17
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__goto_backward_jump.snap
+++ b/crates/php-parser/tests/snapshots/integration__goto_backward_jump.snap
@@ -1,0 +1,92 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Label": "start"
+      },
+      "span": {
+        "start": 6,
+        "end": 13
+      }
+    },
+    {
+      "kind": {
+        "If": {
+          "condition": {
+            "kind": {
+              "Binary": {
+                "left": {
+                  "kind": {
+                    "UnaryPostfix": {
+                      "operand": {
+                        "kind": {
+                          "Variable": "count"
+                        },
+                        "span": {
+                          "start": 17,
+                          "end": 23
+                        }
+                      },
+                      "op": "PostIncrement"
+                    }
+                  },
+                  "span": {
+                    "start": 17,
+                    "end": 25
+                  }
+                },
+                "op": "Less",
+                "right": {
+                  "kind": {
+                    "Int": 3
+                  },
+                  "span": {
+                    "start": 28,
+                    "end": 29
+                  }
+                }
+              }
+            },
+            "span": {
+              "start": 17,
+              "end": 29
+            }
+          },
+          "then_branch": {
+            "kind": {
+              "Block": [
+                {
+                  "kind": {
+                    "Goto": "start"
+                  },
+                  "span": {
+                    "start": 37,
+                    "end": 49
+                  }
+                }
+              ]
+            },
+            "span": {
+              "start": 31,
+              "end": 50
+            }
+          },
+          "elseif_branches": [],
+          "else_branch": null
+        }
+      },
+      "span": {
+        "start": 13,
+        "end": 50
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 50
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__goto_inside_switch.snap
+++ b/crates/php-parser/tests/snapshots/integration__goto_inside_switch.snap
@@ -1,0 +1,123 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Switch": {
+          "expr": {
+            "kind": {
+              "Variable": "x"
+            },
+            "span": {
+              "start": 14,
+              "end": 16
+            }
+          },
+          "cases": [
+            {
+              "value": {
+                "kind": {
+                  "Int": 1
+                },
+                "span": {
+                  "start": 29,
+                  "end": 30
+                }
+              },
+              "body": [
+                {
+                  "kind": {
+                    "Goto": "done"
+                  },
+                  "span": {
+                    "start": 40,
+                    "end": 55
+                  }
+                }
+              ],
+              "span": {
+                "start": 24,
+                "end": 55
+              }
+            },
+            {
+              "value": {
+                "kind": {
+                  "Int": 2
+                },
+                "span": {
+                  "start": 60,
+                  "end": 61
+                }
+              },
+              "body": [
+                {
+                  "kind": {
+                    "Echo": [
+                      {
+                        "kind": {
+                          "String": "two"
+                        },
+                        "span": {
+                          "start": 76,
+                          "end": 81
+                        }
+                      }
+                    ]
+                  },
+                  "span": {
+                    "start": 71,
+                    "end": 83
+                  }
+                }
+              ],
+              "span": {
+                "start": 55,
+                "end": 83
+              }
+            }
+          ]
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 85
+      }
+    },
+    {
+      "kind": {
+        "Label": "done"
+      },
+      "span": {
+        "start": 85,
+        "end": 91
+      }
+    },
+    {
+      "kind": {
+        "Echo": [
+          {
+            "kind": {
+              "String": "done"
+            },
+            "span": {
+              "start": 96,
+              "end": 102
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 91,
+        "end": 104
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 104
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__goto_multiple_labels.snap
+++ b/crates/php-parser/tests/snapshots/integration__goto_multiple_labels.snap
@@ -1,0 +1,165 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "If": {
+          "condition": {
+            "kind": {
+              "Variable": "a"
+            },
+            "span": {
+              "start": 10,
+              "end": 12
+            }
+          },
+          "then_branch": {
+            "kind": {
+              "Goto": "labelA"
+            },
+            "span": {
+              "start": 14,
+              "end": 27
+            }
+          },
+          "elseif_branches": [],
+          "else_branch": null
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 27
+      }
+    },
+    {
+      "kind": {
+        "If": {
+          "condition": {
+            "kind": {
+              "Variable": "b"
+            },
+            "span": {
+              "start": 31,
+              "end": 33
+            }
+          },
+          "then_branch": {
+            "kind": {
+              "Goto": "labelB"
+            },
+            "span": {
+              "start": 35,
+              "end": 48
+            }
+          },
+          "elseif_branches": [],
+          "else_branch": null
+        }
+      },
+      "span": {
+        "start": 27,
+        "end": 48
+      }
+    },
+    {
+      "kind": {
+        "Label": "labelA"
+      },
+      "span": {
+        "start": 48,
+        "end": 56
+      }
+    },
+    {
+      "kind": {
+        "Echo": [
+          {
+            "kind": {
+              "String": "A"
+            },
+            "span": {
+              "start": 61,
+              "end": 64
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 56,
+        "end": 66
+      }
+    },
+    {
+      "kind": {
+        "Goto": "end"
+      },
+      "span": {
+        "start": 66,
+        "end": 76
+      }
+    },
+    {
+      "kind": {
+        "Label": "labelB"
+      },
+      "span": {
+        "start": 76,
+        "end": 84
+      }
+    },
+    {
+      "kind": {
+        "Echo": [
+          {
+            "kind": {
+              "String": "B"
+            },
+            "span": {
+              "start": 89,
+              "end": 92
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 84,
+        "end": 94
+      }
+    },
+    {
+      "kind": {
+        "Label": "end"
+      },
+      "span": {
+        "start": 94,
+        "end": 99
+      }
+    },
+    {
+      "kind": {
+        "Echo": [
+          {
+            "kind": {
+              "String": "done"
+            },
+            "span": {
+              "start": 104,
+              "end": 110
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 99,
+        "end": 112
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 112
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__halt_compiler_empty_remainder.snap
+++ b/crates/php-parser/tests/snapshots/integration__halt_compiler_empty_remainder.snap
@@ -1,0 +1,21 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "HaltCompiler": ""
+      },
+      "span": {
+        "start": 6,
+        "end": 24
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 24
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__halt_compiler_with_statements_before.snap
+++ b/crates/php-parser/tests/snapshots/integration__halt_compiler_with_statements_before.snap
@@ -1,0 +1,40 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Echo": [
+          {
+            "kind": {
+              "String": "before"
+            },
+            "span": {
+              "start": 11,
+              "end": 19
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 6,
+        "end": 21
+      }
+    },
+    {
+      "kind": {
+        "HaltCompiler": "raw data here"
+      },
+      "span": {
+        "start": 21,
+        "end": 53
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 53
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__heredoc_as_default_param.snap
+++ b/crates/php-parser/tests/snapshots/integration__heredoc_as_default_param.snap
@@ -1,0 +1,56 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Function": {
+          "name": "f",
+          "params": [
+            {
+              "name": "s",
+              "type_hint": null,
+              "default": {
+                "kind": {
+                  "Nowdoc": {
+                    "label": "EOT",
+                    "value": "hello"
+                  }
+                },
+                "span": {
+                  "start": 22,
+                  "end": 40
+                }
+              },
+              "by_ref": false,
+              "variadic": false,
+              "is_readonly": false,
+              "is_final": false,
+              "visibility": null,
+              "set_visibility": null,
+              "attributes": [],
+              "span": {
+                "start": 17,
+                "end": 40
+              }
+            }
+          ],
+          "body": [],
+          "return_type": null,
+          "by_ref": false,
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 45
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 45
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__heredoc_in_array_value.snap
+++ b/crates/php-parser/tests/snapshots/integration__heredoc_in_array_value.snap
@@ -1,0 +1,82 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "arr"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 10
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Array": [
+                    {
+                      "key": {
+                        "kind": {
+                          "String": "key"
+                        },
+                        "span": {
+                          "start": 19,
+                          "end": 24
+                        }
+                      },
+                      "value": {
+                        "kind": {
+                          "Heredoc": {
+                            "label": "EOT",
+                            "parts": [
+                              {
+                                "Literal": "value"
+                              }
+                            ]
+                          }
+                        },
+                        "span": {
+                          "start": 28,
+                          "end": 52
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 19,
+                        "end": 52
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 13,
+                  "end": 55
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 55
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 57
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 57
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__indented_heredoc_with_interpolation.snap
+++ b/crates/php-parser/tests/snapshots/integration__indented_heredoc_with_interpolation.snap
@@ -1,0 +1,122 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Heredoc": {
+                    "label": "END",
+                    "parts": [
+                      {
+                        "Literal": "Hello "
+                      },
+                      {
+                        "Expr": {
+                          "kind": {
+                            "PropertyAccess": {
+                              "object": {
+                                "kind": {
+                                  "Variable": "obj"
+                                },
+                                "span": {
+                                  "start": 29,
+                                  "end": 33
+                                }
+                              },
+                              "property": {
+                                "kind": {
+                                  "Identifier": "name"
+                                },
+                                "span": {
+                                  "start": 35,
+                                  "end": 39
+                                }
+                              }
+                            }
+                          },
+                          "span": {
+                            "start": 29,
+                            "end": 39
+                          }
+                        }
+                      },
+                      {
+                        "Literal": "!\n"
+                      },
+                      {
+                        "Expr": {
+                          "kind": {
+                            "ArrayAccess": {
+                              "array": {
+                                "kind": {
+                                  "Variable": "arr"
+                                },
+                                "span": {
+                                  "start": 46,
+                                  "end": 50
+                                }
+                              },
+                              "index": {
+                                "kind": {
+                                  "Int": 0
+                                },
+                                "span": {
+                                  "start": 51,
+                                  "end": 52
+                                }
+                              }
+                            }
+                          },
+                          "span": {
+                            "start": 46,
+                            "end": 53
+                          }
+                        }
+                      },
+                      {
+                        "Literal": " items"
+                      }
+                    ]
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 67
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 67
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 69
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 69
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__interface_property_hooks.snap
+++ b/crates/php-parser/tests/snapshots/integration__interface_property_hooks.snap
@@ -1,0 +1,76 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Interface": {
+          "name": "HasName",
+          "extends": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "name",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "string"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 37,
+                          "end": 43
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 37,
+                      "end": 43
+                    }
+                  },
+                  "default": null,
+                  "attributes": [],
+                  "hooks": [
+                    {
+                      "kind": "Get",
+                      "body": "Abstract",
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [],
+                      "attributes": [],
+                      "span": {
+                        "start": 52,
+                        "end": 57
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 30,
+                "end": 59
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 60
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 60
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__list_by_reference_destructuring.snap
+++ b/crates/php-parser/tests/snapshots/integration__list_by_reference_destructuring.snap
@@ -1,0 +1,228 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Array": [
+                    {
+                      "key": null,
+                      "value": {
+                        "kind": {
+                          "Variable": "a"
+                        },
+                        "span": {
+                          "start": 8,
+                          "end": 10
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 7,
+                        "end": 10
+                      }
+                    },
+                    {
+                      "key": null,
+                      "value": {
+                        "kind": {
+                          "Variable": "b"
+                        },
+                        "span": {
+                          "start": 13,
+                          "end": 15
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 12,
+                        "end": 15
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 6,
+                  "end": 16
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Variable": "arr"
+                },
+                "span": {
+                  "start": 19,
+                  "end": 23
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 23
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 25
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Array": [
+                    {
+                      "key": null,
+                      "value": {
+                        "kind": {
+                          "Variable": "x"
+                        },
+                        "span": {
+                          "start": 31,
+                          "end": 33
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 30,
+                        "end": 33
+                      }
+                    },
+                    {
+                      "key": null,
+                      "value": {
+                        "kind": {
+                          "Variable": "y"
+                        },
+                        "span": {
+                          "start": 36,
+                          "end": 38
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 35,
+                        "end": 38
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 25,
+                  "end": 39
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Variable": "pair"
+                },
+                "span": {
+                  "start": 42,
+                  "end": 47
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 25,
+            "end": 47
+          }
+        }
+      },
+      "span": {
+        "start": 25,
+        "end": 49
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Array": [
+                    {
+                      "key": null,
+                      "value": {
+                        "kind": {
+                          "Variable": "first"
+                        },
+                        "span": {
+                          "start": 51,
+                          "end": 57
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 50,
+                        "end": 57
+                      }
+                    },
+                    {
+                      "key": null,
+                      "value": {
+                        "kind": {
+                          "Variable": "second"
+                        },
+                        "span": {
+                          "start": 59,
+                          "end": 66
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 59,
+                        "end": 66
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 49,
+                  "end": 67
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Variable": "mixed"
+                },
+                "span": {
+                  "start": 70,
+                  "end": 76
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 49,
+            "end": 76
+          }
+        }
+      },
+      "span": {
+        "start": 49,
+        "end": 78
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 78
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__magic_property_in_hook_body.snap
+++ b/crates/php-parser/tests/snapshots/integration__magic_property_in_hook_body.snap
@@ -1,0 +1,140 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "name",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "string"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 29,
+                          "end": 35
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 29,
+                      "end": 35
+                    }
+                  },
+                  "default": null,
+                  "attributes": [],
+                  "hooks": [
+                    {
+                      "kind": "Get",
+                      "body": {
+                        "Block": [
+                          {
+                            "kind": {
+                              "Echo": [
+                                {
+                                  "kind": {
+                                    "MagicConst": "Property"
+                                  },
+                                  "span": {
+                                    "start": 75,
+                                    "end": 87
+                                  }
+                                }
+                              ]
+                            },
+                            "span": {
+                              "start": 70,
+                              "end": 101
+                            }
+                          },
+                          {
+                            "kind": {
+                              "Return": {
+                                "kind": {
+                                  "PropertyAccess": {
+                                    "object": {
+                                      "kind": {
+                                        "Variable": "this"
+                                      },
+                                      "span": {
+                                        "start": 108,
+                                        "end": 113
+                                      }
+                                    },
+                                    "property": {
+                                      "kind": {
+                                        "Identifier": "name"
+                                      },
+                                      "span": {
+                                        "start": 115,
+                                        "end": 119
+                                      }
+                                    }
+                                  }
+                                },
+                                "span": {
+                                  "start": 108,
+                                  "end": 119
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 101,
+                              "end": 129
+                            }
+                          }
+                        ]
+                      },
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [],
+                      "attributes": [],
+                      "span": {
+                        "start": 52,
+                        "end": 135
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 22,
+                "end": 137
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 138
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 138
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__nowdoc_in_match_arm.snap
+++ b/crates/php-parser/tests/snapshots/integration__nowdoc_in_match_arm.snap
@@ -1,0 +1,80 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "r"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Match": {
+                    "subject": {
+                      "kind": {
+                        "Bool": true
+                      },
+                      "span": {
+                        "start": 17,
+                        "end": 21
+                      }
+                    },
+                    "arms": [
+                      {
+                        "conditions": null,
+                        "body": {
+                          "kind": {
+                            "Nowdoc": {
+                              "label": "NOW",
+                              "value": "literal"
+                            }
+                          },
+                          "span": {
+                            "start": 40,
+                            "end": 68
+                          }
+                        },
+                        "span": {
+                          "start": 29,
+                          "end": 68
+                        }
+                      }
+                    ]
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 71
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 71
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 73
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 73
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__shell_exec_complex_interpolation.snap
+++ b/crates/php-parser/tests/snapshots/integration__shell_exec_complex_interpolation.snap
@@ -1,0 +1,237 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "a"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "ShellExec": [
+                    {
+                      "Literal": "ls "
+                    },
+                    {
+                      "Expr": {
+                        "kind": {
+                          "ArrayAccess": {
+                            "array": {
+                              "kind": {
+                                "Variable": "dirs"
+                              },
+                              "span": {
+                                "start": 16,
+                                "end": 21
+                              }
+                            },
+                            "index": {
+                              "kind": {
+                                "String": "home"
+                              },
+                              "span": {
+                                "start": 22,
+                                "end": 28
+                              }
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 16,
+                          "end": 29
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 31
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 31
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 33
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "b"
+                },
+                "span": {
+                  "start": 33,
+                  "end": 35
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "ShellExec": [
+                    {
+                      "Expr": {
+                        "kind": {
+                          "MethodCall": {
+                            "object": {
+                              "kind": {
+                                "Variable": "obj"
+                              },
+                              "span": {
+                                "start": 40,
+                                "end": 44
+                              }
+                            },
+                            "method": {
+                              "kind": {
+                                "Identifier": "getCommand"
+                              },
+                              "span": {
+                                "start": 46,
+                                "end": 56
+                              }
+                            },
+                            "args": []
+                          }
+                        },
+                        "span": {
+                          "start": 40,
+                          "end": 58
+                        }
+                      }
+                    },
+                    {
+                      "Literal": " --flag="
+                    },
+                    {
+                      "Expr": {
+                        "kind": {
+                          "Variable": "value"
+                        },
+                        "span": {
+                          "start": 67,
+                          "end": 73
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 38,
+                  "end": 74
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 33,
+            "end": 74
+          }
+        }
+      },
+      "span": {
+        "start": 33,
+        "end": 76
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "c"
+                },
+                "span": {
+                  "start": 76,
+                  "end": 78
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "ShellExec": [
+                    {
+                      "Literal": "echo "
+                    },
+                    {
+                      "Expr": {
+                        "kind": {
+                          "ArrayAccess": {
+                            "array": {
+                              "kind": {
+                                "Variable": "arr"
+                              },
+                              "span": {
+                                "start": 87,
+                                "end": 91
+                              }
+                            },
+                            "index": {
+                              "kind": {
+                                "Int": 0
+                              },
+                              "span": {
+                                "start": 92,
+                                "end": 93
+                              }
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 87,
+                          "end": 94
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 81,
+                  "end": 95
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 76,
+            "end": 95
+          }
+        }
+      },
+      "span": {
+        "start": 76,
+        "end": 97
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 97
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__shell_exec_empty.snap
+++ b/crates/php-parser/tests/snapshots/integration__shell_exec_empty.snap
@@ -1,0 +1,53 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "ShellExec": [
+                    {
+                      "Literal": ""
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 13
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 13
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 14
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 14
+  }
+}

--- a/crates/php-parser/tests/snapshots/integration__variable_variable_as_dynamic_method.snap
+++ b/crates/php-parser/tests/snapshots/integration__variable_variable_as_dynamic_method.snap
@@ -1,0 +1,57 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "MethodCall": {
+              "object": {
+                "kind": {
+                  "Variable": "obj"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 10
+                }
+              },
+              "method": {
+                "kind": {
+                  "VariableVariable": {
+                    "kind": {
+                      "Variable": "method"
+                    },
+                    "span": {
+                      "start": 14,
+                      "end": 21
+                    }
+                  }
+                },
+                "span": {
+                  "start": 13,
+                  "end": 21
+                }
+              },
+              "args": []
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 24
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 25
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 25
+  }
+}


### PR DESCRIPTION
## Summary

- Adds 22 new snapshot tests and ~60 new inline cases targeting PHP constructs with shallow or missing coverage
- Fixes a parser bug: `true|false` in union types was silently accepted; PHP rejects it with "Type contains both true and false, bool must be used instead"
- Extends the `MinPhp` infrastructure to support PHP 8.1 gating (`0o777` explicit octal)
- All new parse-valid tests pass `assert_no_errors` — AST snapshots locked in

## Bug fix

**`src/parser.rs`**: After building a union type, checks if both `true` and `false` are present and emits `ParseError::Forbidden`. Matches PHP's own error message.

**`tests/integration.rs`** (`test_true_false_union_is_invalid`): Covers `true|false`, `true|false|null`, and `true|false` as a parameter type.

## New snapshot tests (`integration.rs`)

| Area | Tests added |
|---|---|
| Shell exec | Complex interpolation (`{$obj->method()}`, array access, `$arr[0]`), empty backtick |
| Heredoc/Nowdoc | Indented+interpolated, in array value, nowdoc in match arm, as default param |
| Goto | Backward jump, multiple labels, goto inside switch |
| Variable variable | `{$$method}()` — curly-brace dynamic method call |
| Property hooks | Constructor promoted param with `get`/`set` hooks; interface abstract `get;` hook |
| `__halt_compiler` | Empty remainder; with preceding statements |
| Attributes | On class constant, interface method, trait property, enum method; `new` in attribute arg |
| Destructuring | `list()` / `[]` by-reference: `[&$a, &$b] = $arr` |
| Magic constants | `__PROPERTY__` inside a property hook body |
| Version gate | Explicit octal `0o777` snapshot (PHP 8.1+) |

## New `inline_cases.rs` categories (validated via `php -l`)

- **`string_interp_edge`** — array key identifier in string, empty strings/heredoc, escape-only string, `\u{10FFFF}`
- **`trait_use`** — all `TraitAdaptationKind::Alias` sub-forms, `insteadof`, multiple trait adaptations
- **`numeric_literals`** — explicit octal (PHP 8.1+), hex/binary with underscores, edge-case floats, `INT_MAX`

## Extended inline categories

- `dynamic_access` — 4-level var-var (`$$$$x`), var-var as array key, `${$obj->name}`, var-var in `isset`/`unset`
- `named_args` — `fn:`, `list:`, `null:`, `true:`, `false:`, `for:`, `while:` as keyword argument names; named-only spread
- `control_flow` — `for` with multiple conditions, multiple init/update expressions, all-empty `for(;;)`
- `declare` — alternative `enddeclare;` syntax, nested declare
- `type_hints` — 3-way intersection, standalone `true`/`false` return types (PHP 8.2+), `true|null`, `false|null`

## Infrastructure

- `build.rs`: adds `php_min_81` cfg flag detection
- `inline_cases.rs`: adds `Php81` variant to `MinPhp` enum
- `php_syntax.rs`: handles `MinPhp::Php81` in `php -l` validation loop

## Test plan

- [x] `cargo nextest run --test integration` — 404 passed, 0 failed
- [x] `cargo nextest run --test nikic_integration_tests` — 268 passed, 0 failed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all` — no changes