### PR TITLE
fix: increase float literal parse buffer from 128 to 256 bytes

### DIFF
--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -2594,8 +2594,9 @@ fn parse_int_no_alloc(bytes: &[u8], base: i64, _skip: usize) -> i64 {
 
 /// Parse a float literal, skipping underscores, using a fixed-size stack buffer.
 fn parse_float_no_alloc(text: &str) -> f64 {
-    // Float literals are bounded in length; 128 bytes is more than sufficient.
-    let mut buf = [0u8; 128];
+    // 256 bytes covers the longest realistic PHP float literal (significant digits +
+    // exponent) with room to spare; underscores are stripped before copying.
+    let mut buf = [0u8; 256];
     let mut len = 0;
     for &b in text.as_bytes() {
         if b != b'_' && len < buf.len() {


### PR DESCRIPTION
## Summary

- Float literal parsing used a fixed 128-byte stack buffer; bytes beyond that limit were silently dropped, producing a different float value than the source intended.
- Increase buffer to 256 bytes, which is more than sufficient for any realistic PHP float literal (PHP only guarantees ~14 significant decimal digits anyway).

## Test plan

- [ ] Existing tests pass unchanged.
- [ ] Manual verification: a float literal with many digits and underscores (e.g. `1_234_567_890_123_456.789_012_345_678_901e+100`) parses to the correct value.