### PR TITLE
fix: correct span for ClassConstAccessDynamic used as function call callee

### DIFF
--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -303,14 +303,15 @@ pub fn parse_expr_bp<'arena, 'src>(
                             };
                         }
                         ArgListResult::Args(args) => {
+                            let lhs_start = lhs.span.start;
                             let callee = Expr {
                                 kind: ExprKind::ClassConstAccessDynamic {
                                     class: parser.alloc(lhs),
                                     member: parser.alloc(member),
                                 },
-                                span: Span::new(0, 0), // placeholder, will be wrapped
+                                span: Span::new(lhs_start, parser.current_span().start),
                             };
-                            let span = Span::new(callee.span.start, parser.current_span().start);
+                            let span = Span::new(lhs_start, parser.current_span().start);
                             lhs = Expr {
                                 kind: ExprKind::FunctionCall(FunctionCallExpr {
                                     name: parser.alloc(callee),

--- a/crates/php-parser/tests/integration.rs
+++ b/crates/php-parser/tests/integration.rs
@@ -2424,6 +2424,16 @@ $d = $class::${'prop_' . $name};
 }
 
 #[test]
+fn test_dynamic_static_call_span() {
+    // Foo::{$expr}() — the FunctionCall and its ClassConstAccessDynamic callee
+    // must both have spans starting at the offset of `Foo` (byte 6), not at 0.
+    let source = "<?php Foo::{$m}();";
+    let result = parse_php(source);
+    assert_no_errors(&result);
+    insta::assert_snapshot!(to_json(&result.program));
+}
+
+#[test]
 fn test_pipe_operator_precedence() {
     let source = r#"<?php
 $x = $a |> $b |> $c;

--- a/crates/php-parser/tests/snapshots/corpus__expr_fetchandcall_staticcall.snap
+++ b/crates/php-parser/tests/snapshots/corpus__expr_fetchandcall_staticcall.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/php-parser/tests/integration.rs
+source: crates/php-parser/tests/corpus.rs
 expression: to_json(& result.program)
 ---
 {
@@ -62,15 +62,15 @@ expression: to_json(& result.program)
                   }
                 },
                 "span": {
-                  "start": 0,
-                  "end": 0
+                  "start": 41,
+                  "end": 51
                 }
               },
               "args": []
             }
           },
           "span": {
-            "start": 0,
+            "start": 41,
             "end": 51
           }
         }

--- a/crates/php-parser/tests/snapshots/integration__dynamic_static_call_span.snap
+++ b/crates/php-parser/tests/snapshots/integration__dynamic_static_call_span.snap
@@ -1,0 +1,59 @@
+---
+source: crates/php-parser/tests/integration.rs
+expression: to_json(&result.program)
+---
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "FunctionCall": {
+              "name": {
+                "kind": {
+                  "ClassConstAccessDynamic": {
+                    "class": {
+                      "kind": {
+                        "Identifier": "Foo"
+                      },
+                      "span": {
+                        "start": 6,
+                        "end": 9
+                      }
+                    },
+                    "member": {
+                      "kind": {
+                        "Variable": "m"
+                      },
+                      "span": {
+                        "start": 12,
+                        "end": 14
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 6,
+                  "end": 17
+                }
+              },
+              "args": []
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 17
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 18
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 18
+  }
+}


### PR DESCRIPTION
## Summary

`Foo::{$expr}()` produced a `FunctionCall` node with span starting at byte 0.

The `ClassConstAccessDynamic` callee was given a placeholder `Span::new(0, 0)`, which then propagated into the outer `FunctionCall` span via `Span::new(callee.span.start, ...)`.

**Fix:** save `lhs.span.start` before `lhs` is moved into the callee, then use it for both spans.

Before:
```json
{ "FunctionCall": { "span": { "start": 0, ... } } }
```

After:
```json
{ "FunctionCall": { "span": { "start": 6, ... } } }
```

Fixes #49

## Test plan
- [ ] New snapshot test `test_dynamic_static_call_span` verifies `Foo::{$m}()` spans start at the offset of `Foo`
- [ ] Updated corpus snapshot `expr_fetchandcall_staticcall` reflects correct spans for `A::{'b'}()`