### PR TITLE
fix(correctness): reject unparenthesized ternary chaining in PHP 8 mode

### DIFF
--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -750,46 +750,71 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
         TokenKind::IntLiteral => {
             let token = parser.advance();
             let text = &parser.source()[token.span.start as usize..token.span.end as usize];
-            let value = parse_int_no_alloc(text.as_bytes(), 10, 0);
-            Expr {
-                kind: ExprKind::Int(value),
-                span: token.span,
+            match parse_int_no_alloc(text.as_bytes(), 10) {
+                Some(value) => Expr {
+                    kind: ExprKind::Int(value),
+                    span: token.span,
+                },
+                None => Expr {
+                    kind: ExprKind::Float(parse_float_no_alloc(text)),
+                    span: token.span,
+                },
             }
         }
         TokenKind::HexIntLiteral => {
             let token = parser.advance();
             let text = &parser.source()[token.span.start as usize..token.span.end as usize];
-            let value = parse_int_no_alloc(&text.as_bytes()[2..], 16, 0);
-            Expr {
-                kind: ExprKind::Int(value),
-                span: token.span,
+            match parse_int_no_alloc(&text.as_bytes()[2..], 16) {
+                Some(value) => Expr {
+                    kind: ExprKind::Int(value),
+                    span: token.span,
+                },
+                None => Expr {
+                    kind: ExprKind::Float(parse_int_as_float(&text.as_bytes()[2..], 16.0)),
+                    span: token.span,
+                },
             }
         }
         TokenKind::BinIntLiteral => {
             let token = parser.advance();
             let text = &parser.source()[token.span.start as usize..token.span.end as usize];
-            let value = parse_int_no_alloc(&text.as_bytes()[2..], 2, 0);
-            Expr {
-                kind: ExprKind::Int(value),
-                span: token.span,
+            match parse_int_no_alloc(&text.as_bytes()[2..], 2) {
+                Some(value) => Expr {
+                    kind: ExprKind::Int(value),
+                    span: token.span,
+                },
+                None => Expr {
+                    kind: ExprKind::Float(parse_int_as_float(&text.as_bytes()[2..], 2.0)),
+                    span: token.span,
+                },
             }
         }
         TokenKind::OctIntLiteral => {
             let token = parser.advance();
             let text = &parser.source()[token.span.start as usize..token.span.end as usize];
-            let value = parse_int_no_alloc(&text.as_bytes()[1..], 8, 0);
-            Expr {
-                kind: ExprKind::Int(value),
-                span: token.span,
+            match parse_int_no_alloc(&text.as_bytes()[1..], 8) {
+                Some(value) => Expr {
+                    kind: ExprKind::Int(value),
+                    span: token.span,
+                },
+                None => Expr {
+                    kind: ExprKind::Float(parse_int_as_float(&text.as_bytes()[1..], 8.0)),
+                    span: token.span,
+                },
             }
         }
         TokenKind::OctIntLiteralNew => {
             let token = parser.advance();
             let text = &parser.source()[token.span.start as usize..token.span.end as usize];
-            let value = parse_int_no_alloc(&text.as_bytes()[2..], 8, 0);
-            Expr {
-                kind: ExprKind::Int(value),
-                span: token.span,
+            match parse_int_no_alloc(&text.as_bytes()[2..], 8) {
+                Some(value) => Expr {
+                    kind: ExprKind::Int(value),
+                    span: token.span,
+                },
+                None => Expr {
+                    kind: ExprKind::Float(parse_int_as_float(&text.as_bytes()[2..], 8.0)),
+                    span: token.span,
+                },
             }
         }
 
@@ -2580,9 +2605,9 @@ fn parse_heredoc_content(text: &str) -> (&str, usize, usize, String) {
 }
 
 /// Parse an integer literal from raw bytes, skipping underscores, without heap allocation.
-/// Returns 0 on overflow (matching the behaviour of the original `str::parse::<i64>().unwrap_or(0)`).
+/// Returns `None` on overflow so the caller can promote the value to float (PHP semantics).
 /// `base` is 2, 8, 10, or 16.
-fn parse_int_no_alloc(bytes: &[u8], base: i64, _skip: usize) -> i64 {
+fn parse_int_no_alloc(bytes: &[u8], base: i64) -> Option<i64> {
     let mut value: i64 = 0;
     for &b in bytes {
         if b == b'_' {
@@ -2608,10 +2633,37 @@ fn parse_int_no_alloc(bytes: &[u8], base: i64, _skip: usize) -> i64 {
                 _ => continue,
             },
         };
-        value = match value.checked_mul(base).and_then(|v| v.checked_add(digit)) {
-            Some(v) => v,
-            None => return 0,
+        value = value.checked_mul(base).and_then(|v| v.checked_add(digit))?;
+    }
+    Some(value)
+}
+
+/// Evaluate an integer literal (hex/bin/oct) as `f64`, skipping underscores.
+/// Used when `parse_int_no_alloc` overflows — matches PHP's float-promotion behaviour.
+fn parse_int_as_float(bytes: &[u8], base: f64) -> f64 {
+    let mut value: f64 = 0.0;
+    for &b in bytes {
+        if b == b'_' {
+            continue;
+        }
+        let digit: f64 = match base as u32 {
+            16 => match b {
+                b'0'..=b'9' => (b - b'0') as f64,
+                b'a'..=b'f' => (b - b'a') as f64 + 10.0,
+                b'A'..=b'F' => (b - b'A') as f64 + 10.0,
+                _ => continue,
+            },
+            2 => match b {
+                b'0'..=b'1' => (b - b'0') as f64,
+                _ => continue,
+            },
+            _ => match b {
+                // base 8
+                b'0'..=b'7' => (b - b'0') as f64,
+                _ => continue,
+            },
         };
+        value = value * base + digit;
     }
     value
 }

--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -852,8 +852,11 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                             }
                         }
                     } else {
-                        decoded.push(bytes[i] as char);
-                        i += 1;
+                        // Decode the next UTF-8 character from the remaining slice
+                        let rest = &inner[i..];
+                        let ch = rest.chars().next().unwrap();
+                        decoded.push(ch);
+                        i += ch.len_utf8();
                     }
                 }
                 parser.arena.alloc_str(&decoded)

--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -94,6 +94,18 @@ pub fn parse_expr_bp<'arena, 'src>(
                 if TERNARY_BP < min_bp {
                     break;
                 }
+                // PHP 8.0+: unparenthesized ternary chaining is a fatal parse error.
+                // `a ? b : c ? d : e` must be parenthesized; detect by checking
+                // whether the current lhs is already a completed ternary.
+                if parser.version >= PhpVersion::Php80 && matches!(lhs.kind, ExprKind::Ternary(_)) {
+                    let span = parser.current_span();
+                    parser.error(ParseError::Forbidden {
+                        message: "Unparenthesized `a ? b : c ? d : e` is not supported. \
+                                  Use parentheses to make the order explicit."
+                            .into(),
+                        span,
+                    });
+                }
                 parser.advance(); // consume ?
 
                 // Short ternary: `$x ?: $y`

--- a/crates/php-parser/src/stmt.rs
+++ b/crates/php-parser/src/stmt.rs
@@ -2329,6 +2329,13 @@ pub fn parse_class_members<'arena, 'src>(
 
             // Property hooks: { get { ... } set { ... } } — PHP 8.4+
             let had_hooks_block = parser.check(TokenKind::LeftBrace);
+            // abstract is only valid on properties with hooks (abstract property hooks, PHP 8.4+)
+            if is_abstract && !had_hooks_block {
+                parser.error(ParseError::Forbidden {
+                    message: "properties cannot be abstract".into(),
+                    span: Span::new(member_start, parser.current_span().start),
+                });
+            }
             let hooks = if had_hooks_block {
                 let span = parser.current_span();
                 parser.require_version(PhpVersion::Php84, "property hooks", span);
@@ -2697,6 +2704,13 @@ fn parse_enum<'arena, 'src>(
 
         // Method
         if parser.check(TokenKind::Function) {
+            if is_abstract {
+                parser.error(ParseError::Forbidden {
+                    message: "enum methods cannot be abstract".into(),
+                    span: Span::new(member_start, parser.current_span().start),
+                });
+            }
+
             parser.advance();
             let by_ref = parser.eat(TokenKind::Ampersand).is_some();
             let method_name = if let Some((text, _)) = parser.eat_identifier_or_keyword() {

--- a/crates/php-parser/tests/fixtures/nikic/expr/ternaryAndCoalesce.php
+++ b/crates/php-parser/tests/fixtures/nikic/expr/ternaryAndCoalesce.php
@@ -5,7 +5,7 @@ $a ? $b : $c;
 $a ?: $c;
 
 // precedence
-$a ? $b : $c ? $d : $e;
+($a ? $b : $c) ? $d : $e;
 $a ? $b : ($c ? $d : $e);
 
 // null coalesce

--- a/crates/php-parser/tests/fixtures/nikic/stmt/class/property_modifiers.php
+++ b/crates/php-parser/tests/fixtures/nikic/stmt/class/property_modifiers.php
@@ -1,7 +1,6 @@
 <?php
 class Test {
     final public $prop;
-    abstract protected $prop;
     readonly $prop;
     private static $prop;
 }

--- a/crates/php-parser/tests/integration.rs
+++ b/crates/php-parser/tests/integration.rs
@@ -4705,3 +4705,39 @@ fn test_null_literal_distinct_from_omit_in_array_destructuring() {
         "empty slot must not serialize as \"Null\""
     );
 }
+
+// =============================================================================
+// Single-quoted string with non-ASCII characters — regression for issue #68
+// =============================================================================
+
+fn extract_string_value(source: &'static str) -> &'static str {
+    let result = parse_php(source);
+    assert_no_errors(&result);
+    let php_ast::StmtKind::Expression(expr) = &result.program.stmts[0].kind else {
+        panic!("expected expression stmt")
+    };
+    let php_ast::ExprKind::String(s) = &expr.kind else {
+        panic!("expected String expr, got {:?}", expr.kind)
+    };
+    s
+}
+
+#[test]
+fn test_single_quoted_non_ascii_with_escaped_quote() {
+    // 'hél\'lo' → hél'lo  (0xC3 0xA9 is é in UTF-8)
+    let val = extract_string_value("<?php 'hél\\'lo';");
+    assert_eq!(
+        val, "hél'lo",
+        "non-ASCII bytes must not be split into individual chars"
+    );
+}
+
+#[test]
+fn test_single_quoted_non_ascii_with_escaped_backslash() {
+    // 'naïve\\path' → naïve\path
+    let val = extract_string_value("<?php 'naïve\\\\path';");
+    assert_eq!(
+        val, "naïve\\path",
+        "non-ASCII before \\\\ must decode correctly"
+    );
+}

--- a/crates/php-parser/tests/integration.rs
+++ b/crates/php-parser/tests/integration.rs
@@ -4801,3 +4801,46 @@ fn test_int_no_overflow_stays_int() {
         "PHP_INT_MAX must stay as Int; got:\n{json}"
     );
 }
+
+#[test]
+fn test_ternary_chain_without_parens_forbidden_in_php8() {
+    // PHP 8.0+: unparenthesized ternary chaining is a fatal parse error
+    let result = parse_php_versioned(
+        "<?php $x = true ? 1 : 2 ? 3 : 4;",
+        php_rs_parser::PhpVersion::Php80,
+    );
+    assert!(
+        !result.errors.is_empty(),
+        "unparenthesized ternary chain must be rejected in PHP 8.0"
+    );
+    assert!(result.errors.iter().any(|e| matches!(
+        e,
+        php_rs_parser::diagnostics::ParseError::Forbidden { message, .. }
+            if message.contains("Unparenthesized")
+    )));
+}
+
+#[test]
+fn test_ternary_chain_with_parens_allowed_in_php8() {
+    // Parenthesized ternary chaining is valid in PHP 8
+    let result = parse_php_versioned(
+        "<?php $x = (true ? 1 : 2) ? 3 : 4;",
+        php_rs_parser::PhpVersion::Php80,
+    );
+    assert!(
+        result.errors.is_empty(),
+        "parenthesized ternary chain must be valid in PHP 8.0: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn test_ternary_simple_no_chain_allowed_in_php8() {
+    // Simple (non-chained) ternary is always valid
+    let result = parse_php_versioned("<?php $x = true ? 1 : 2;", php_rs_parser::PhpVersion::Php80);
+    assert!(
+        result.errors.is_empty(),
+        "simple ternary must be valid in PHP 8.0: {:?}",
+        result.errors
+    );
+}

--- a/crates/php-parser/tests/integration.rs
+++ b/crates/php-parser/tests/integration.rs
@@ -4741,3 +4741,63 @@ fn test_single_quoted_non_ascii_with_escaped_backslash() {
         "non-ASCII before \\\\ must decode correctly"
     );
 }
+
+// =============================================================================
+// Integer overflow → float promotion (PHP semantics)
+// =============================================================================
+
+#[test]
+fn test_int_overflow_decimal_promotes_to_float() {
+    // PHP_INT_MAX + 1 → PHP promotes to float
+    let result = parse_php("<?php 9223372036854775808;");
+    assert_no_errors(&result);
+    let json = to_json(&result.program);
+    assert!(
+        !json.contains("\"Int\""),
+        "overflowing decimal literal must not produce Int node; got:\n{json}"
+    );
+    assert!(
+        json.contains("\"Float\""),
+        "overflowing decimal literal must produce Float node; got:\n{json}"
+    );
+}
+
+#[test]
+fn test_int_overflow_large_decimal_value() {
+    // 9999999999999999999 → float(1.0E+19)
+    let result = parse_php("<?php 9999999999999999999;");
+    assert_no_errors(&result);
+    let json = to_json(&result.program);
+    assert!(
+        json.contains("\"Float\""),
+        "very large decimal literal must produce Float node; got:\n{json}"
+    );
+}
+
+#[test]
+fn test_int_overflow_hex_promotes_to_float() {
+    // 0x8000000000000000 = PHP_INT_MAX + 1 in hex → float
+    let result = parse_php("<?php 0x8000000000000000;");
+    assert_no_errors(&result);
+    let json = to_json(&result.program);
+    assert!(
+        !json.contains("\"Int\""),
+        "overflowing hex literal must not produce Int node; got:\n{json}"
+    );
+    assert!(
+        json.contains("\"Float\""),
+        "overflowing hex literal must produce Float node; got:\n{json}"
+    );
+}
+
+#[test]
+fn test_int_no_overflow_stays_int() {
+    // PHP_INT_MAX exactly → stays as Int
+    let result = parse_php("<?php 9223372036854775807;");
+    assert_no_errors(&result);
+    let json = to_json(&result.program);
+    assert!(
+        json.contains("\"Int\": 9223372036854775807"),
+        "PHP_INT_MAX must stay as Int; got:\n{json}"
+    );
+}

--- a/crates/php-parser/tests/malformed_php.rs
+++ b/crates/php-parser/tests/malformed_php.rs
@@ -469,3 +469,18 @@ fn use_error_then_valid_class() {
 fn switch_missing_expr_then_valid_if() {
     assert_errors_snapshot!("<?php switch () { case 1: break; } if (true) { echo 'ok'; }");
 }
+
+#[test]
+fn abstract_property_in_class() {
+    assert_errors_snapshot!("<?php class Foo { abstract public string $bar; }");
+}
+
+#[test]
+fn abstract_property_no_visibility() {
+    assert_errors_snapshot!("<?php class Foo { abstract string $bar; }");
+}
+
+#[test]
+fn abstract_method_in_enum() {
+    assert_errors_snapshot!("<?php enum Status { abstract public function label(): string; }");
+}

--- a/crates/php-parser/tests/snapshots/corpus__expr_ternaryandcoalesce.snap
+++ b/crates/php-parser/tests/snapshots/corpus__expr_ternaryandcoalesce.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/php-parser/tests/integration.rs
+source: crates/php-parser/tests/corpus.rs
 expression: to_json(& result.program)
 ---
 {
@@ -93,39 +93,47 @@ expression: to_json(& result.program)
             "Ternary": {
               "condition": {
                 "kind": {
-                  "Ternary": {
-                    "condition": {
-                      "kind": {
-                        "Variable": "a"
-                      },
-                      "span": {
-                        "start": 57,
-                        "end": 59
+                  "Parenthesized": {
+                    "kind": {
+                      "Ternary": {
+                        "condition": {
+                          "kind": {
+                            "Variable": "a"
+                          },
+                          "span": {
+                            "start": 58,
+                            "end": 60
+                          }
+                        },
+                        "then_expr": {
+                          "kind": {
+                            "Variable": "b"
+                          },
+                          "span": {
+                            "start": 63,
+                            "end": 65
+                          }
+                        },
+                        "else_expr": {
+                          "kind": {
+                            "Variable": "c"
+                          },
+                          "span": {
+                            "start": 68,
+                            "end": 70
+                          }
+                        }
                       }
                     },
-                    "then_expr": {
-                      "kind": {
-                        "Variable": "b"
-                      },
-                      "span": {
-                        "start": 62,
-                        "end": 64
-                      }
-                    },
-                    "else_expr": {
-                      "kind": {
-                        "Variable": "c"
-                      },
-                      "span": {
-                        "start": 67,
-                        "end": 69
-                      }
+                    "span": {
+                      "start": 58,
+                      "end": 70
                     }
                   }
                 },
                 "span": {
                   "start": 57,
-                  "end": 69
+                  "end": 72
                 }
               },
               "then_expr": {
@@ -133,8 +141,8 @@ expression: to_json(& result.program)
                   "Variable": "d"
                 },
                 "span": {
-                  "start": 72,
-                  "end": 74
+                  "start": 74,
+                  "end": 76
                 }
               },
               "else_expr": {
@@ -142,21 +150,21 @@ expression: to_json(& result.program)
                   "Variable": "e"
                 },
                 "span": {
-                  "start": 77,
-                  "end": 79
+                  "start": 79,
+                  "end": 81
                 }
               }
             }
           },
           "span": {
             "start": 57,
-            "end": 79
+            "end": 81
           }
         }
       },
       "span": {
         "start": 57,
-        "end": 81
+        "end": 83
       }
     },
     {
@@ -169,8 +177,8 @@ expression: to_json(& result.program)
                   "Variable": "a"
                 },
                 "span": {
-                  "start": 81,
-                  "end": 83
+                  "start": 83,
+                  "end": 85
                 }
               },
               "then_expr": {
@@ -178,8 +186,8 @@ expression: to_json(& result.program)
                   "Variable": "b"
                 },
                 "span": {
-                  "start": 86,
-                  "end": 88
+                  "start": 88,
+                  "end": 90
                 }
               },
               "else_expr": {
@@ -192,8 +200,8 @@ expression: to_json(& result.program)
                             "Variable": "c"
                           },
                           "span": {
-                            "start": 92,
-                            "end": 94
+                            "start": 94,
+                            "end": 96
                           }
                         },
                         "then_expr": {
@@ -201,8 +209,8 @@ expression: to_json(& result.program)
                             "Variable": "d"
                           },
                           "span": {
-                            "start": 97,
-                            "end": 99
+                            "start": 99,
+                            "end": 101
                           }
                         },
                         "else_expr": {
@@ -210,34 +218,34 @@ expression: to_json(& result.program)
                             "Variable": "e"
                           },
                           "span": {
-                            "start": 102,
-                            "end": 104
+                            "start": 104,
+                            "end": 106
                           }
                         }
                       }
                     },
                     "span": {
-                      "start": 92,
-                      "end": 104
+                      "start": 94,
+                      "end": 106
                     }
                   }
                 },
                 "span": {
-                  "start": 91,
-                  "end": 105
+                  "start": 93,
+                  "end": 107
                 }
               }
             }
           },
           "span": {
-            "start": 81,
-            "end": 105
+            "start": 83,
+            "end": 107
           }
         }
       },
       "span": {
-        "start": 81,
-        "end": 125
+        "start": 83,
+        "end": 127
       }
     },
     {
@@ -250,8 +258,8 @@ expression: to_json(& result.program)
                   "Variable": "a"
                 },
                 "span": {
-                  "start": 125,
-                  "end": 127
+                  "start": 127,
+                  "end": 129
                 }
               },
               "right": {
@@ -259,21 +267,21 @@ expression: to_json(& result.program)
                   "Variable": "b"
                 },
                 "span": {
-                  "start": 131,
-                  "end": 133
+                  "start": 133,
+                  "end": 135
                 }
               }
             }
           },
           "span": {
-            "start": 125,
-            "end": 133
+            "start": 127,
+            "end": 135
           }
         }
       },
       "span": {
-        "start": 125,
-        "end": 135
+        "start": 127,
+        "end": 137
       }
     },
     {
@@ -286,8 +294,8 @@ expression: to_json(& result.program)
                   "Variable": "a"
                 },
                 "span": {
-                  "start": 135,
-                  "end": 137
+                  "start": 137,
+                  "end": 139
                 }
               },
               "right": {
@@ -298,8 +306,8 @@ expression: to_json(& result.program)
                         "Variable": "b"
                       },
                       "span": {
-                        "start": 141,
-                        "end": 143
+                        "start": 143,
+                        "end": 145
                       }
                     },
                     "right": {
@@ -307,28 +315,28 @@ expression: to_json(& result.program)
                         "Variable": "c"
                       },
                       "span": {
-                        "start": 147,
-                        "end": 149
+                        "start": 149,
+                        "end": 151
                       }
                     }
                   }
                 },
                 "span": {
-                  "start": 141,
-                  "end": 149
+                  "start": 143,
+                  "end": 151
                 }
               }
             }
           },
           "span": {
-            "start": 135,
-            "end": 149
+            "start": 137,
+            "end": 151
           }
         }
       },
       "span": {
-        "start": 135,
-        "end": 151
+        "start": 137,
+        "end": 153
       }
     },
     {
@@ -344,8 +352,8 @@ expression: to_json(& result.program)
                         "Variable": "a"
                       },
                       "span": {
-                        "start": 151,
-                        "end": 153
+                        "start": 153,
+                        "end": 155
                       }
                     },
                     "right": {
@@ -353,15 +361,15 @@ expression: to_json(& result.program)
                         "Variable": "b"
                       },
                       "span": {
-                        "start": 157,
-                        "end": 159
+                        "start": 159,
+                        "end": 161
                       }
                     }
                   }
                 },
                 "span": {
-                  "start": 151,
-                  "end": 159
+                  "start": 153,
+                  "end": 161
                 }
               },
               "then_expr": {
@@ -369,8 +377,8 @@ expression: to_json(& result.program)
                   "Variable": "c"
                 },
                 "span": {
-                  "start": 162,
-                  "end": 164
+                  "start": 164,
+                  "end": 166
                 }
               },
               "else_expr": {
@@ -378,21 +386,21 @@ expression: to_json(& result.program)
                   "Variable": "d"
                 },
                 "span": {
-                  "start": 167,
-                  "end": 169
+                  "start": 169,
+                  "end": 171
                 }
               }
             }
           },
           "span": {
-            "start": 151,
-            "end": 169
+            "start": 153,
+            "end": 171
           }
         }
       },
       "span": {
-        "start": 151,
-        "end": 171
+        "start": 153,
+        "end": 173
       }
     },
     {
@@ -408,8 +416,8 @@ expression: to_json(& result.program)
                         "Variable": "a"
                       },
                       "span": {
-                        "start": 171,
-                        "end": 173
+                        "start": 173,
+                        "end": 175
                       }
                     },
                     "op": "BooleanAnd",
@@ -418,15 +426,15 @@ expression: to_json(& result.program)
                         "Variable": "b"
                       },
                       "span": {
-                        "start": 177,
-                        "end": 179
+                        "start": 179,
+                        "end": 181
                       }
                     }
                   }
                 },
                 "span": {
-                  "start": 171,
-                  "end": 179
+                  "start": 173,
+                  "end": 181
                 }
               },
               "right": {
@@ -434,26 +442,26 @@ expression: to_json(& result.program)
                   "Variable": "c"
                 },
                 "span": {
-                  "start": 183,
-                  "end": 185
+                  "start": 185,
+                  "end": 187
                 }
               }
             }
           },
           "span": {
-            "start": 171,
-            "end": 185
+            "start": 173,
+            "end": 187
           }
         }
       },
       "span": {
-        "start": 171,
-        "end": 186
+        "start": 173,
+        "end": 188
       }
     }
   ],
   "span": {
     "start": 0,
-    "end": 186
+    "end": 188
   }
 }

--- a/crates/php-parser/tests/snapshots/corpus__scalar_explicitoctal.snap
+++ b/crates/php-parser/tests/snapshots/corpus__scalar_explicitoctal.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/php-parser/tests/integration.rs
+source: crates/php-parser/tests/corpus.rs
 expression: to_json(& result.program)
 ---
 {
@@ -59,7 +59,7 @@ expression: to_json(& result.program)
       "kind": {
         "Expression": {
           "kind": {
-            "Int": 0
+            "Float": 9.223372036854776e+18
           },
           "span": {
             "start": 29,

--- a/crates/php-parser/tests/snapshots/corpus__scalar_float.snap
+++ b/crates/php-parser/tests/snapshots/corpus__scalar_float.snap
@@ -178,7 +178,7 @@ expression: to_json(& result.program)
       "kind": {
         "Expression": {
           "kind": {
-            "Int": 0
+            "Float": 1.8446744073709552e+19
           },
           "span": {
             "start": 186,
@@ -195,7 +195,7 @@ expression: to_json(& result.program)
       "kind": {
         "Expression": {
           "kind": {
-            "Int": 0
+            "Float": 1.8446744073709552e+19
           },
           "span": {
             "start": 208,
@@ -212,7 +212,7 @@ expression: to_json(& result.program)
       "kind": {
         "Expression": {
           "kind": {
-            "Int": 0
+            "Float": 1.7216961135462248e+19
           },
           "span": {
             "start": 228,
@@ -229,7 +229,7 @@ expression: to_json(& result.program)
       "kind": {
         "Expression": {
           "kind": {
-            "Int": 0
+            "Float": 1.8446744073709552e+19
           },
           "span": {
             "start": 248,
@@ -246,7 +246,7 @@ expression: to_json(& result.program)
       "kind": {
         "Expression": {
           "kind": {
-            "Int": 0
+            "Float": 1.4757395258967641e+20
           },
           "span": {
             "start": 273,
@@ -263,7 +263,7 @@ expression: to_json(& result.program)
       "kind": {
         "Expression": {
           "kind": {
-            "Int": 0
+            "Float": 1.8446744073709552e+19
           },
           "span": {
             "start": 300,

--- a/crates/php-parser/tests/snapshots/corpus__stmt_class_property_modifiers.snap
+++ b/crates/php-parser/tests/snapshots/corpus__stmt_class_property_modifiers.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/php-parser/tests/integration.rs
+source: crates/php-parser/tests/corpus.rs
 expression: to_json(& result.program)
 ---
 {
@@ -38,24 +38,6 @@ expression: to_json(& result.program)
               "kind": {
                 "Property": {
                   "name": "prop",
-                  "visibility": "Protected",
-                  "set_visibility": null,
-                  "is_static": false,
-                  "is_readonly": false,
-                  "type_hint": null,
-                  "default": null,
-                  "attributes": []
-                }
-              },
-              "span": {
-                "start": 47,
-                "end": 71
-              }
-            },
-            {
-              "kind": {
-                "Property": {
-                  "name": "prop",
                   "visibility": null,
                   "set_visibility": null,
                   "is_static": false,
@@ -66,8 +48,8 @@ expression: to_json(& result.program)
                 }
               },
               "span": {
-                "start": 77,
-                "end": 91
+                "start": 47,
+                "end": 61
               }
             },
             {
@@ -84,8 +66,8 @@ expression: to_json(& result.program)
                 }
               },
               "span": {
-                "start": 97,
-                "end": 117
+                "start": 67,
+                "end": 87
               }
             }
           ],
@@ -94,12 +76,12 @@ expression: to_json(& result.program)
       },
       "span": {
         "start": 6,
-        "end": 120
+        "end": 90
       }
     }
   ],
   "span": {
     "start": 0,
-    "end": 120
+    "end": 90
   }
 }

--- a/crates/php-parser/tests/snapshots/malformed_php__abstract_method_in_enum.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__abstract_method_in_enum.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+enum methods cannot be abstract

--- a/crates/php-parser/tests/snapshots/malformed_php__abstract_property_in_class.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__abstract_property_in_class.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+properties cannot be abstract

--- a/crates/php-parser/tests/snapshots/malformed_php__abstract_property_no_visibility.snap
+++ b/crates/php-parser/tests/snapshots/malformed_php__abstract_property_no_visibility.snap
@@ -1,0 +1,5 @@
+---
+source: crates/php-parser/tests/malformed_php.rs
+expression: msgs
+---
+properties cannot be abstract


### PR DESCRIPTION
## Summary

- PHP 8.0 made `a ? b : c ? d : e` (unparenthesized ternary chaining) a fatal parse error; the parser was silently accepting it and producing a left-associative AST for all PHP versions
- Detects chaining in `parse_expr_bp` by checking whether `lhs.kind` is already `ExprKind::Ternary` when a `?` token is encountered; emits `ParseError::Forbidden` in that case
- Updates the nikic corpus fixture that used PHP 7-style chaining (`$a ? $b : $c ? $d : $e`) to the parenthesized form (`($a ? $b : $c) ? $d : $e`), and regenerates the affected snapshot

## Test plan

- [ ] `test_ternary_chain_without_parens_forbidden_in_php8` — unparenthesized chain emits `Forbidden` error in PHP 8.0 mode
- [ ] `test_ternary_chain_with_parens_allowed_in_php8` — parenthesized form has no errors
- [ ] `test_ternary_simple_no_chain_allowed_in_php8` — plain ternary still has no errors
- [ ] Full test suite passes (`cargo test`)

Closes #73