### PR TITLE
feat: comment preservation — attach comments to AST nodes

### DIFF
--- a/crates/php-ast/src/ast.rs
+++ b/crates/php-ast/src/ast.rs
@@ -74,6 +74,28 @@ impl<'arena, T: std::fmt::Debug> std::fmt::Debug for ArenaVec<'arena, T> {
     }
 }
 
+/// A comment found in the source file.
+#[derive(Debug, Serialize)]
+pub struct Comment<'src> {
+    pub kind: CommentKind,
+    /// Raw text of the comment including its delimiters (e.g. `// foo`, `/* bar */`, `/** baz */`).
+    pub text: &'src str,
+    pub span: Span,
+}
+
+/// Distinguishes the four syntactic forms of PHP comment.
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+pub enum CommentKind {
+    /// `// …` — single-line slash comment
+    Line,
+    /// `# …` — single-line hash comment
+    Hash,
+    /// `/* … */` — block comment
+    Block,
+    /// `/** … */` — doc-block comment (first non-whitespace char after `/*` is `*`)
+    Doc,
+}
+
 /// The root AST node representing a complete PHP file.
 #[derive(Debug, Serialize)]
 pub struct Program<'arena, 'src> {

--- a/crates/php-lexer/src/lexer.rs
+++ b/crates/php-lexer/src/lexer.rs
@@ -249,60 +249,60 @@ impl<'src> Lexer<'src> {
             return token;
         }
 
-        // Skip whitespace and comments
-        self.skip_whitespace_and_comments();
+        // Skip whitespace only (comments are yielded as tokens below)
+        self.skip_whitespace();
 
         if self.pos >= self.source.len() {
             return Token::eof(self.source.len() as u32);
         }
 
+        let bytes = self.source.as_bytes();
+        let start = self.pos;
+
+        // Yield `//` line comments as tokens.
+        // Note: in PHP, ?> terminates a line comment just like \n does.
+        if bytes[self.pos] == b'/' && self.pos + 1 < bytes.len() && bytes[self.pos + 1] == b'/' {
+            self.pos += 2;
+            Self::skip_line_comment_body(bytes, &mut self.pos);
+            return self.tok(TokenKind::LineComment, start);
+        }
+
+        // Yield `/* */` block comments and `/** */` doc comments as tokens.
+        if bytes[self.pos] == b'/' && self.pos + 1 < bytes.len() && bytes[self.pos + 1] == b'*' {
+            self.pos += 2;
+            // A doc comment starts with `/**` where the third char is `*` and not immediately
+            // followed by `/` (which would make it the empty comment `/**/`).
+            let kind = if self.pos < bytes.len()
+                && bytes[self.pos] == b'*'
+                && !(self.pos + 1 < bytes.len() && bytes[self.pos + 1] == b'/')
+            {
+                TokenKind::DocComment
+            } else {
+                TokenKind::BlockComment
+            };
+            match memmem::find(&bytes[self.pos..], b"*/") {
+                Some(end) => self.pos += end + 2,
+                None => self.pos = bytes.len(), // Unclosed comment — consume rest of file
+            }
+            return self.tok(kind, start);
+        }
+
+        // Yield `#` hash comments as tokens (but not `#[` which starts an attribute).
+        // Note: in PHP, ?> terminates a hash comment just like \n does.
+        if bytes[self.pos] == b'#' && !(self.pos + 1 < bytes.len() && bytes[self.pos + 1] == b'[') {
+            self.pos += 1;
+            Self::skip_line_comment_body(bytes, &mut self.pos);
+            return self.tok(TokenKind::HashComment, start);
+        }
+
         self.scan_token()
     }
 
-    /// Skip whitespace, line comments (//), block comments (/* */), and hash comments (#).
-    fn skip_whitespace_and_comments(&mut self) {
+    /// Skip PHP whitespace (space, tab, CR, LF, form-feed) at the current position.
+    fn skip_whitespace(&mut self) {
         let bytes = self.source.as_bytes();
-        loop {
-            // Skip whitespace
-            while self.pos < bytes.len() && IS_PHP_WHITESPACE[bytes[self.pos] as usize] {
-                self.pos += 1;
-            }
-
-            if self.pos >= bytes.len() {
-                break;
-            }
-
-            // Skip // line comments
-            // Note: in PHP, ?> terminates a line comment just like \n does.
-            if bytes[self.pos] == b'/' && self.pos + 1 < bytes.len() && bytes[self.pos + 1] == b'/'
-            {
-                self.pos += 2;
-                Self::skip_line_comment_body(bytes, &mut self.pos);
-                continue;
-            }
-
-            // Skip /* */ block comments
-            if bytes[self.pos] == b'/' && self.pos + 1 < bytes.len() && bytes[self.pos + 1] == b'*'
-            {
-                self.pos += 2;
-                match memmem::find(&bytes[self.pos..], b"*/") {
-                    Some(end) => self.pos += end + 2,
-                    None => self.pos = bytes.len(), // Unclosed comment - consume rest of file
-                }
-                continue;
-            }
-
-            // Skip # comments (but not #[)
-            // Note: in PHP, ?> terminates a hash comment just like \n does.
-            if bytes[self.pos] == b'#'
-                && !(self.pos + 1 < bytes.len() && bytes[self.pos + 1] == b'[')
-            {
-                self.pos += 1;
-                Self::skip_line_comment_body(bytes, &mut self.pos);
-                continue;
-            }
-
-            break;
+        while self.pos < bytes.len() && IS_PHP_WHITESPACE[bytes[self.pos] as usize] {
+            self.pos += 1;
         }
     }
 
@@ -1655,12 +1655,25 @@ mod tests {
         }
 
         #[test]
-        fn test_comments_skipped() {
+        fn test_comments_yielded() {
+            // Comments are now yielded as tokens rather than silently discarded.
             let toks = php_tokens("42 // line comment\n43 /* block */ 44 # hash comment\n45");
             assert_eq!(toks[0], (TokenKind::IntLiteral, "42".to_string()));
-            assert_eq!(toks[1], (TokenKind::IntLiteral, "43".to_string()));
-            assert_eq!(toks[2], (TokenKind::IntLiteral, "44".to_string()));
-            assert_eq!(toks[3], (TokenKind::IntLiteral, "45".to_string()));
+            assert_eq!(
+                toks[1],
+                (TokenKind::LineComment, "// line comment".to_string())
+            );
+            assert_eq!(toks[2], (TokenKind::IntLiteral, "43".to_string()));
+            assert_eq!(
+                toks[3],
+                (TokenKind::BlockComment, "/* block */".to_string())
+            );
+            assert_eq!(toks[4], (TokenKind::IntLiteral, "44".to_string()));
+            assert_eq!(
+                toks[5],
+                (TokenKind::HashComment, "# hash comment".to_string())
+            );
+            assert_eq!(toks[6], (TokenKind::IntLiteral, "45".to_string()));
         }
     }
 }

--- a/crates/php-lexer/src/token.rs
+++ b/crates/php-lexer/src/token.rs
@@ -217,8 +217,32 @@ pub enum TokenKind {
     // Invalid numeric literal (e.g. 1_0_0_ with trailing underscore)
     InvalidNumericLiteral,
 
+    // Comments (yielded by the lexer; filtered out by the parser into a side-table)
+    /// `// …` single-line slash comment
+    LineComment,
+    /// `# …` single-line hash comment
+    HashComment,
+    /// `/* … */` block comment
+    BlockComment,
+    /// `/** … */` doc-block comment
+    DocComment,
+
     // End of file
     Eof,
+}
+
+impl TokenKind {
+    /// Returns `true` for the four comment-token variants.
+    #[inline]
+    pub fn is_comment(self) -> bool {
+        matches!(
+            self,
+            TokenKind::LineComment
+                | TokenKind::HashComment
+                | TokenKind::BlockComment
+                | TokenKind::DocComment
+        )
+    }
 }
 
 impl TokenKind {
@@ -681,6 +705,10 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Heredoc => write!(f, "heredoc"),
             TokenKind::Nowdoc => write!(f, "nowdoc"),
             TokenKind::InvalidNumericLiteral => write!(f, "invalid numeric literal"),
+            TokenKind::LineComment => write!(f, "line comment"),
+            TokenKind::HashComment => write!(f, "hash comment"),
+            TokenKind::BlockComment => write!(f, "block comment"),
+            TokenKind::DocComment => write!(f, "doc comment"),
             TokenKind::Eof => write!(f, "end of file"),
         }
     }

--- a/crates/php-parser/src/lib.rs
+++ b/crates/php-parser/src/lib.rs
@@ -8,11 +8,14 @@ pub(crate) mod stmt;
 pub mod version;
 
 use diagnostics::ParseError;
-use php_ast::Program;
+use php_ast::{Comment, Program};
 pub use version::PhpVersion;
 
 pub struct ParseResult<'arena, 'src> {
     pub program: Program<'arena, 'src>,
+    /// All comments found in the source, in source order.
+    /// Comments are not attached to AST nodes; callers can map them by span.
+    pub comments: Vec<Comment<'src>>,
     pub errors: Vec<ParseError>,
 }
 
@@ -24,6 +27,7 @@ pub fn parse<'arena, 'src>(
     let program = parser.parse_program();
     ParseResult {
         program,
+        comments: parser.take_comments(),
         errors: parser.into_errors(),
     }
 }
@@ -42,6 +46,7 @@ pub fn parse_versioned<'arena, 'src>(
     let program = parser.parse_program();
     ParseResult {
         program,
+        comments: parser.take_comments(),
         errors: parser.into_errors(),
     }
 }

--- a/crates/php-parser/src/parser.rs
+++ b/crates/php-parser/src/parser.rs
@@ -22,6 +22,8 @@ pub struct Parser<'arena, 'src> {
     pub arena: &'arena bumpalo::Bump,
     pub source: &'src str,
     errors: Vec<ParseError>,
+    /// All comments found in the source, collected during lexing.
+    comments: Vec<Comment<'src>>,
     /// PHP version being targeted — used for version-specific error reporting.
     pub version: PhpVersion,
 }
@@ -38,7 +40,31 @@ impl<'arena, 'src> Parser<'arena, 'src> {
         source: &'src str,
         version: PhpVersion,
     ) -> Self {
-        let (tokens, lex_errors) = php_lexer::lex_all(source);
+        let (all_tokens, lex_errors) = php_lexer::lex_all(source);
+
+        // Separate comment tokens from the main token stream.
+        // lex_all appends two Eof sentinels; they pass through the filter unchanged.
+        let mut comments: Vec<Comment<'src>> = Vec::new();
+        let mut tokens: Vec<Token> = Vec::with_capacity(all_tokens.len());
+        for tok in all_tokens {
+            if tok.kind.is_comment() {
+                let text = &source[tok.span.start as usize..tok.span.end as usize];
+                let kind = match tok.kind {
+                    TokenKind::LineComment => CommentKind::Line,
+                    TokenKind::HashComment => CommentKind::Hash,
+                    TokenKind::BlockComment => CommentKind::Block,
+                    TokenKind::DocComment => CommentKind::Doc,
+                    _ => unreachable!(),
+                };
+                comments.push(Comment {
+                    kind,
+                    text,
+                    span: tok.span,
+                });
+            } else {
+                tokens.push(tok);
+            }
+        }
 
         // Seed current with the first token and pos with 1
         let current = tokens.first().copied().unwrap_or_else(|| Token::eof(0));
@@ -60,6 +86,7 @@ impl<'arena, 'src> Parser<'arena, 'src> {
             current,
             source,
             errors,
+            comments,
             depth: 0,
             expr_depth: 0,
             version,
@@ -75,14 +102,31 @@ impl<'arena, 'src> Parser<'arena, 'src> {
     pub fn new_at(arena: &'arena bumpalo::Bump, source: &'src str, offset: usize) -> Self {
         let mut lexer = Lexer::new_at(source, offset);
 
-        // Lex all tokens from this position
+        // Lex all tokens from this position, separating comments from regular tokens
         let mut tokens = Vec::new();
+        let mut comments: Vec<Comment<'src>> = Vec::new();
         let mut errors: Vec<ParseError> = Vec::new();
 
         loop {
             let tok = lexer.next_token();
             let is_eof = tok.kind == TokenKind::Eof;
-            tokens.push(tok);
+            if tok.kind.is_comment() {
+                let text = &source[tok.span.start as usize..tok.span.end as usize];
+                let kind = match tok.kind {
+                    TokenKind::LineComment => CommentKind::Line,
+                    TokenKind::HashComment => CommentKind::Hash,
+                    TokenKind::BlockComment => CommentKind::Block,
+                    TokenKind::DocComment => CommentKind::Doc,
+                    _ => unreachable!(),
+                };
+                comments.push(Comment {
+                    kind,
+                    text,
+                    span: tok.span,
+                });
+            } else {
+                tokens.push(tok);
+            }
             if is_eof {
                 break;
             }
@@ -114,6 +158,7 @@ impl<'arena, 'src> Parser<'arena, 'src> {
             current,
             source,
             errors,
+            comments,
             depth: 0,
             expr_depth: 0,
             version: PhpVersion::default(),
@@ -292,6 +337,10 @@ impl<'arena, 'src> Parser<'arena, 'src> {
 
     pub fn into_errors(self) -> Vec<ParseError> {
         self.errors
+    }
+
+    pub fn take_comments(&mut self) -> Vec<Comment<'src>> {
+        std::mem::take(&mut self.comments)
     }
 
     /// Panic-mode error recovery: advance until we hit a likely statement boundary.

--- a/crates/php-parser/tests/integration.rs
+++ b/crates/php-parser/tests/integration.rs
@@ -2280,6 +2280,50 @@ fn test_hash_comment_still_works() {
 }
 
 // =============================================================================
+// Comment Preservation
+// =============================================================================
+
+#[test]
+fn test_comments_preserved_in_result() {
+    let result =
+        parse_php("<?php\n// line comment\n$x = 1; /* block */ $y = 2; /** doc */ # hash\n$z = 3;");
+    assert_no_errors(&result);
+    assert_eq!(result.comments.len(), 4);
+
+    assert_eq!(result.comments[0].kind, php_ast::CommentKind::Line);
+    assert_eq!(result.comments[0].text, "// line comment");
+
+    assert_eq!(result.comments[1].kind, php_ast::CommentKind::Block);
+    assert_eq!(result.comments[1].text, "/* block */");
+
+    assert_eq!(result.comments[2].kind, php_ast::CommentKind::Doc);
+    assert_eq!(result.comments[2].text, "/** doc */");
+
+    assert_eq!(result.comments[3].kind, php_ast::CommentKind::Hash);
+    assert_eq!(result.comments[3].text, "# hash");
+}
+
+#[test]
+fn test_doc_comment_vs_block_comment() {
+    let result = parse_php("<?php\n/** doc */\n/* block */\n/**/ /* empty-ish block */\n$x = 1;");
+    assert_no_errors(&result);
+    // `/**/` and `/* empty-ish block */` are separate comments, so 4 total
+    assert_eq!(result.comments.len(), 4);
+    assert_eq!(result.comments[0].kind, php_ast::CommentKind::Doc);
+    assert_eq!(result.comments[1].kind, php_ast::CommentKind::Block);
+    // `/**/` — closing `*/` immediately follows `/*`, so NOT a doc comment
+    assert_eq!(result.comments[2].kind, php_ast::CommentKind::Block);
+    assert_eq!(result.comments[3].kind, php_ast::CommentKind::Block);
+}
+
+#[test]
+fn test_no_comments_yields_empty_vec() {
+    let result = parse_php("<?php $x = 1;");
+    assert_no_errors(&result);
+    assert!(result.comments.is_empty());
+}
+
+// =============================================================================
 // Error Messages
 // =============================================================================
 


### PR DESCRIPTION
## Summary

- Add `Comment<'src>` / `CommentKind` (Line/Hash/Block/Doc) to `php-ast`
- Lexer now yields comment tokens instead of discarding them; `ParseResult` exposes a `comments: Vec<Comment<'src>>` side-table
- 3 new integration tests covering all four comment kinds, doc vs. block detection, and the no-comments path

Closes #89