### PR TITLE
fix(tests): expect_errors in runners, fill error fixture sections

### DIFF
--- a/crates/php-parser/tests/fixtures/errors/abstract_method_in_enum.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_method_in_enum.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php enum Status { abstract public function label(): string; }
 ===errors===
+enum methods cannot be abstract

--- a/crates/php-parser/tests/fixtures/errors/abstract_property_in_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_property_in_class.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php class Foo { abstract public string $bar; }
 ===errors===
+properties cannot be abstract

--- a/crates/php-parser/tests/fixtures/errors/abstract_property_no_visibility.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_property_no_visibility.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php class Foo { abstract string $bar; }
 ===errors===
+properties cannot be abstract

--- a/crates/php-parser/tests/fixtures/errors/array_destructure_error_then_valid_echo.phpt
+++ b/crates/php-parser/tests/fixtures/errors/array_destructure_error_then_valid_echo.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php [$a, , ,] = ; echo $a;
 ===errors===
+expected expression

--- a/crates/php-parser/tests/fixtures/errors/array_invalid_key.phpt
+++ b/crates/php-parser/tests/fixtures/errors/array_invalid_key.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php $a = [=> 'value'];
 ===errors===
+expected expression

--- a/crates/php-parser/tests/fixtures/errors/array_unclosed_bracket.phpt
+++ b/crates/php-parser/tests/fixtures/errors/array_unclosed_bracket.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php $a = [1, 2, 3;
 ===errors===
+expected ']', found ';'

--- a/crates/php-parser/tests/fixtures/errors/catch_missing_exception.phpt
+++ b/crates/php-parser/tests/fixtures/errors/catch_missing_exception.phpt
@@ -1,3 +1,6 @@
 ===source===
 <?php try { } catch { }
 ===errors===
+expected '(', found '{'
+expected identifier, found '{'
+expected ')', found '{'

--- a/crates/php-parser/tests/fixtures/errors/catch_unclosed_paren.phpt
+++ b/crates/php-parser/tests/fixtures/errors/catch_unclosed_paren.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php try { } catch (Exception { }
 ===errors===
+expected ')', found '{'

--- a/crates/php-parser/tests/fixtures/errors/class_error_then_valid_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_error_then_valid_class.phpt
@@ -1,3 +1,8 @@
 ===source===
 <?php class Foo { public function } class Bar { public int $x = 1; }
 ===errors===
+expected method name, found '}'
+expected '(', found '}'
+expected variable, found '}'
+expected ')', found '}'
+expected ';', found '}'

--- a/crates/php-parser/tests/fixtures/errors/class_invalid_extends.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_invalid_extends.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php class Test extends { }
 ===errors===
+expected identifier, found '{'

--- a/crates/php-parser/tests/fixtures/errors/class_invalid_implements.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_invalid_implements.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php class Test implements { }
 ===errors===
+expected identifier, found '{'

--- a/crates/php-parser/tests/fixtures/errors/class_method_error_then_valid_method.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_method_error_then_valid_method.phpt
@@ -4,3 +4,4 @@
     public function good(): string { return 'ok'; }
 }
 ===errors===
+expected variable, found ')'

--- a/crates/php-parser/tests/fixtures/errors/class_missing_name.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_missing_name.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php class { }
 ===errors===
+expected class name, found '{'

--- a/crates/php-parser/tests/fixtures/errors/class_missing_name_then_valid_function.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_missing_name_then_valid_function.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php class {} function foo(): int { return 1; }
 ===errors===
+expected class name, found '{'

--- a/crates/php-parser/tests/fixtures/errors/class_unclosed.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_unclosed.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php class Test {
 ===errors===
+expected '}', found end of file

--- a/crates/php-parser/tests/fixtures/errors/const_without_value.phpt
+++ b/crates/php-parser/tests/fixtures/errors/const_without_value.phpt
@@ -1,3 +1,5 @@
 ===source===
 <?php const X;
 ===errors===
+expected '=', found ';'
+expected expression

--- a/crates/php-parser/tests/fixtures/errors/declare_incomplete_paren.phpt
+++ b/crates/php-parser/tests/fixtures/errors/declare_incomplete_paren.phpt
@@ -1,3 +1,5 @@
 ===source===
 <?php declare(
 ===errors===
+expected ')', found end of file
+expected statement

--- a/crates/php-parser/tests/fixtures/errors/declare_missing_equals.phpt
+++ b/crates/php-parser/tests/fixtures/errors/declare_missing_equals.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php declare(strict_types 1);
 ===errors===
+expected '=', found integer

--- a/crates/php-parser/tests/fixtures/errors/declare_unclosed.phpt
+++ b/crates/php-parser/tests/fixtures/errors/declare_unclosed.phpt
@@ -1,3 +1,5 @@
 ===source===
 <?php declare(strict_types=1
 ===errors===
+expected ')', found end of file
+expected statement

--- a/crates/php-parser/tests/fixtures/errors/enum_error_then_valid_function.phpt
+++ b/crates/php-parser/tests/fixtures/errors/enum_error_then_valid_function.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php enum Status { case Active = ; } function use_status() { return Status::Active; }
 ===errors===
+expected expression

--- a/crates/php-parser/tests/fixtures/errors/error_recovery_invalid_expression.phpt
+++ b/crates/php-parser/tests/fixtures/errors/error_recovery_invalid_expression.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php + ; $x = 1;
 ===errors===
+expected expression

--- a/crates/php-parser/tests/fixtures/errors/error_recovery_missing_closing_paren.phpt
+++ b/crates/php-parser/tests/fixtures/errors/error_recovery_missing_closing_paren.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php foo(1, 2; $x = 3;
 ===errors===
+expected ')', found ';'

--- a/crates/php-parser/tests/fixtures/errors/error_recovery_missing_semicolon.phpt
+++ b/crates/php-parser/tests/fixtures/errors/error_recovery_missing_semicolon.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php $x = 1 $y = 2;
 ===errors===
+expected ';' after expression

--- a/crates/php-parser/tests/fixtures/errors/for_loop_error_then_valid_while.phpt
+++ b/crates/php-parser/tests/fixtures/errors/for_loop_error_then_valid_while.phpt
@@ -1,3 +1,7 @@
 ===source===
 <?php for (;;; ) {} while (true) { break; }
 ===errors===
+expected expression
+unclosed '')'' opened at Span { start: 10, end: 11 }
+expected expression
+expected expression

--- a/crates/php-parser/tests/fixtures/errors/function_invalid_return_type.phpt
+++ b/crates/php-parser/tests/fixtures/errors/function_invalid_return_type.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php function test(): { }
 ===errors===
+expected identifier, found '{'

--- a/crates/php-parser/tests/fixtures/errors/function_missing_name_then_valid_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/function_missing_name_then_valid_class.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php function () {} class Foo {}
 ===errors===
+expected ';' after expression

--- a/crates/php-parser/tests/fixtures/errors/function_unclosed_body.phpt
+++ b/crates/php-parser/tests/fixtures/errors/function_unclosed_body.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php function test() {
 ===errors===
+unclosed ''}'' opened at Span { start: 22, end: 23 }

--- a/crates/php-parser/tests/fixtures/errors/function_unclosed_params.phpt
+++ b/crates/php-parser/tests/fixtures/errors/function_unclosed_params.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php function test(int $x { }
 ===errors===
+unclosed '')'' opened at Span { start: 19, end: 20 }

--- a/crates/php-parser/tests/fixtures/errors/if_missing_condition.phpt
+++ b/crates/php-parser/tests/fixtures/errors/if_missing_condition.phpt
@@ -1,3 +1,7 @@
 ===source===
 <?php if { }
 ===errors===
+expected '(', found '{'
+expected expression
+unclosed '')'' opened at Span { start: 9, end: 10 }
+expected statement

--- a/crates/php-parser/tests/fixtures/errors/if_unclosed_condition.phpt
+++ b/crates/php-parser/tests/fixtures/errors/if_unclosed_condition.phpt
@@ -1,3 +1,6 @@
 ===source===
 <?php if ( { }
 ===errors===
+expected expression
+unclosed '')'' opened at Span { start: 9, end: 10 }
+expected statement

--- a/crates/php-parser/tests/fixtures/errors/incomplete_match.phpt
+++ b/crates/php-parser/tests/fixtures/errors/incomplete_match.phpt
@@ -1,3 +1,5 @@
 ===source===
 <?php match ($x) {
 ===errors===
+expected '}', found end of file
+expected ';' after expression

--- a/crates/php-parser/tests/fixtures/errors/incomplete_ternary.phpt
+++ b/crates/php-parser/tests/fixtures/errors/incomplete_ternary.phpt
@@ -1,3 +1,7 @@
 ===source===
 <?php $x ?
 ===errors===
+expected expression
+expected ':', found end of file
+expected expression
+expected ';' after expression

--- a/crates/php-parser/tests/fixtures/errors/interface_error_then_valid_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/interface_error_then_valid_class.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php interface Foo { const X = ; } class Baz {}
 ===errors===
+expected expression

--- a/crates/php-parser/tests/fixtures/errors/interface_method_with_body.phpt
+++ b/crates/php-parser/tests/fixtures/errors/interface_method_with_body.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php interface Foo { public function bar() { echo 'body'; } }
 ===errors===
+interface method cannot contain a body

--- a/crates/php-parser/tests/fixtures/errors/interface_method_with_body_multiple.phpt
+++ b/crates/php-parser/tests/fixtures/errors/interface_method_with_body_multiple.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php interface Foo { public function bar() { return 1; } public function baz(); }
 ===errors===
+interface method cannot contain a body

--- a/crates/php-parser/tests/fixtures/errors/invalid_abstract_final_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_abstract_final_class.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php abstract final class Foo {}
 ===errors===
+expected 'class', found 'final'

--- a/crates/php-parser/tests/fixtures/errors/invalid_double_operator.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_double_operator.phpt
@@ -3,3 +3,4 @@
 $a = 1 + * 2;
 $b = 3;
 ===errors===
+expected expression

--- a/crates/php-parser/tests/fixtures/errors/invalid_double_readonly_anonymous_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_double_readonly_anonymous_class.phpt
@@ -1,3 +1,5 @@
 ===source===
 <?php new readonly readonly class {};
 ===errors===
+expected ';' after expression
+expected class name, found '{'

--- a/crates/php-parser/tests/fixtures/errors/invalid_eof_unclosed_array_call.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_eof_unclosed_array_call.phpt
@@ -2,3 +2,6 @@
 <?php
 $x = array(1, 2,
 ===errors===
+expected expression
+expected ')', found end of file
+expected ';' after expression

--- a/crates/php-parser/tests/fixtures/errors/invalid_eof_unclosed_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_eof_unclosed_class.phpt
@@ -3,3 +3,5 @@
 class Foo {
     public function bar() {
 ===errors===
+expected '}', found end of file
+expected '}', found end of file

--- a/crates/php-parser/tests/fixtures/errors/invalid_eof_unclosed_if.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_eof_unclosed_if.phpt
@@ -3,3 +3,4 @@
 if ($x > 1) {
     echo "hello";
 ===errors===
+unclosed ''}'' opened at Span { start: 18, end: 19 }

--- a/crates/php-parser/tests/fixtures/errors/invalid_expression_then_valid_function.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_expression_then_valid_function.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php $x = ; function foo() { return 42; }
 ===errors===
+expected expression

--- a/crates/php-parser/tests/fixtures/errors/invalid_foreach_missing_as.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_foreach_missing_as.phpt
@@ -4,3 +4,4 @@ foreach ($items $item) {
     echo $item;
 }
 ===errors===
+expected 'as', found variable

--- a/crates/php-parser/tests/fixtures/errors/invalid_missing_closing_brace_method.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_missing_closing_brace_method.phpt
@@ -11,3 +11,5 @@ class Foo {
     }
 }
 ===errors===
+expected expression
+expected '}', found end of file

--- a/crates/php-parser/tests/fixtures/errors/invalid_missing_closing_paren_function.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_missing_closing_paren_function.phpt
@@ -4,3 +4,4 @@ function foo(int $a, $b {
     return $a + $b;
 }
 ===errors===
+unclosed '')'' opened at Span { start: 18, end: 19 }

--- a/crates/php-parser/tests/fixtures/errors/invalid_missing_closing_paren_if.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_missing_closing_paren_if.phpt
@@ -4,3 +4,7 @@ if ($x > 1 {
     echo "hello";
 }
 ===errors===
+expected expression
+expected '}', found 'echo'
+unclosed '')'' opened at Span { start: 9, end: 10 }
+expected expression

--- a/crates/php-parser/tests/fixtures/errors/invalid_missing_semicolons.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_missing_semicolons.phpt
@@ -4,3 +4,5 @@ echo "hello"
 echo "world";
 $x = 1 + 2
 ===errors===
+expected ';' after echo statement
+expected ';' after expression

--- a/crates/php-parser/tests/fixtures/errors/invalid_switch_missing_colon.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_switch_missing_colon.phpt
@@ -8,3 +8,4 @@ switch ($x) {
         echo "two";
 }
 ===errors===
+expected ';', found 'echo'

--- a/crates/php-parser/tests/fixtures/errors/invalid_unclosed_array.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_unclosed_array.phpt
@@ -3,3 +3,4 @@
 $x = [1, 2, 3;
 $y = 4;
 ===errors===
+expected ']', found ';'

--- a/crates/php-parser/tests/fixtures/errors/invalid_unclosed_try.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_unclosed_try.phpt
@@ -7,3 +7,5 @@ catch (Exception $e) {
     bar();
 }
 ===errors===
+expected expression
+expected catch or finally clause, found end of file

--- a/crates/php-parser/tests/fixtures/errors/malformed_if_condition_then_valid_return.phpt
+++ b/crates/php-parser/tests/fixtures/errors/malformed_if_condition_then_valid_return.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php function f() { if () { return 1; } return 2; }
 ===errors===
+expected expression

--- a/crates/php-parser/tests/fixtures/errors/match_duplicate_default.phpt
+++ b/crates/php-parser/tests/fixtures/errors/match_duplicate_default.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php $x = match ($v) { 1 => 'one', default => 'first', default => 'second' };
 ===errors===
+match expression may only contain one default arm

--- a/crates/php-parser/tests/fixtures/errors/match_error_then_valid_assignment.phpt
+++ b/crates/php-parser/tests/fixtures/errors/match_error_then_valid_assignment.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php $x = match ($y) { 1 => }; $z = 42;
 ===errors===
+expected expression

--- a/crates/php-parser/tests/fixtures/errors/match_missing_comma.phpt
+++ b/crates/php-parser/tests/fixtures/errors/match_missing_comma.phpt
@@ -1,3 +1,8 @@
 ===source===
 <?php match($x) { 1 => 'a' 2 => 'b' }
 ===errors===
+expected '}', found integer
+expected ';' after expression
+expected ';' after expression
+expected expression
+expected expression

--- a/crates/php-parser/tests/fixtures/errors/match_missing_expression_after_arrow.phpt
+++ b/crates/php-parser/tests/fixtures/errors/match_missing_expression_after_arrow.phpt
@@ -1,3 +1,5 @@
 ===source===
 <?php match($x) { 1 => }
 ===errors===
+expected expression
+expected ';' after expression

--- a/crates/php-parser/tests/fixtures/errors/missing_semicolon_then_valid_assignment.phpt
+++ b/crates/php-parser/tests/fixtures/errors/missing_semicolon_then_valid_assignment.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php $x = 1 $y = 2;
 ===errors===
+expected ';' after expression

--- a/crates/php-parser/tests/fixtures/errors/multiple_errors_recover_to_valid_function.phpt
+++ b/crates/php-parser/tests/fixtures/errors/multiple_errors_recover_to_valid_function.phpt
@@ -4,3 +4,5 @@ $a = ;
 $b = ;
 function healthy(): string { return 'ok'; }
 ===errors===
+expected expression
+expected expression

--- a/crates/php-parser/tests/fixtures/errors/namespace_error_then_valid_namespace.phpt
+++ b/crates/php-parser/tests/fixtures/errors/namespace_error_then_valid_namespace.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php namespace ; namespace Foo\Bar;
 ===errors===
+expected identifier, found ';'

--- a/crates/php-parser/tests/fixtures/errors/namespace_missing_name.phpt
+++ b/crates/php-parser/tests/fixtures/errors/namespace_missing_name.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php namespace;
 ===errors===
+expected identifier, found ';'

--- a/crates/php-parser/tests/fixtures/errors/namespace_unclosed_braces.phpt
+++ b/crates/php-parser/tests/fixtures/errors/namespace_unclosed_braces.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php namespace App {
 ===errors===
+expected '}', found end of file

--- a/crates/php-parser/tests/fixtures/errors/repeated_union_types.phpt
+++ b/crates/php-parser/tests/fixtures/errors/repeated_union_types.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php function f(int|string|int): int {}
 ===errors===
+expected variable, found ')'

--- a/crates/php-parser/tests/fixtures/errors/switch_missing_expr.phpt
+++ b/crates/php-parser/tests/fixtures/errors/switch_missing_expr.phpt
@@ -1,3 +1,8 @@
 ===source===
 <?php switch { }
 ===errors===
+expected '(', found '{'
+expected expression
+unclosed '')'' opened at Span { start: 13, end: 14 }
+expected '{', found end of file
+expected '}', found end of file

--- a/crates/php-parser/tests/fixtures/errors/switch_missing_expr_then_valid_if.phpt
+++ b/crates/php-parser/tests/fixtures/errors/switch_missing_expr_then_valid_if.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php switch () { case 1: break; } if (true) { echo 'ok'; }
 ===errors===
+expected expression

--- a/crates/php-parser/tests/fixtures/errors/trait_error_then_valid_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/trait_error_then_valid_class.phpt
@@ -1,3 +1,8 @@
 ===source===
 <?php trait T { public function } class C { use T; }
 ===errors===
+expected method name, found '}'
+expected '(', found '}'
+expected variable, found '}'
+expected ')', found '}'
+expected ';', found '}'

--- a/crates/php-parser/tests/fixtures/errors/trait_invalid_adaptation_syntax.phpt
+++ b/crates/php-parser/tests/fixtures/errors/trait_invalid_adaptation_syntax.phpt
@@ -1,3 +1,6 @@
 ===source===
 <?php trait A { public function m() {} } class C { use A { m invalid; } }
 ===errors===
+expected '::' or 'as', found identifier
+expected identifier, found ';'
+expected '::' or 'as', found ';'

--- a/crates/php-parser/tests/fixtures/errors/trait_missing_method_name.phpt
+++ b/crates/php-parser/tests/fixtures/errors/trait_missing_method_name.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php trait A {} class C { use A { insteadof; } }
 ===errors===
+expected '::' or 'as', found ';'

--- a/crates/php-parser/tests/fixtures/errors/trait_unclosed_brace.phpt
+++ b/crates/php-parser/tests/fixtures/errors/trait_unclosed_brace.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php trait A {} class C { use A { m as x; }
 ===errors===
+expected '}', found end of file

--- a/crates/php-parser/tests/fixtures/errors/try_missing_catch_then_valid_echo.phpt
+++ b/crates/php-parser/tests/fixtures/errors/try_missing_catch_then_valid_echo.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php try { $x = 1; } echo 'after';
 ===errors===
+expected catch or finally clause, found 'echo'

--- a/crates/php-parser/tests/fixtures/errors/try_without_catch_or_finally.phpt
+++ b/crates/php-parser/tests/fixtures/errors/try_without_catch_or_finally.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php try { }
 ===errors===
+expected catch or finally clause, found end of file

--- a/crates/php-parser/tests/fixtures/errors/unclosed_double_quote.phpt
+++ b/crates/php-parser/tests/fixtures/errors/unclosed_double_quote.phpt
@@ -1,3 +1,5 @@
 ===source===
 <?php "unclosed string
 ===errors===
+expected ';' after expression
+expected ';' after expression

--- a/crates/php-parser/tests/fixtures/errors/unclosed_heredoc.phpt
+++ b/crates/php-parser/tests/fixtures/errors/unclosed_heredoc.phpt
@@ -2,3 +2,7 @@
 <?php <<<EOT
 Content
 ===errors===
+expected expression
+expected expression
+expected ';' after expression
+expected ';' after expression

--- a/crates/php-parser/tests/fixtures/errors/unclosed_single_quote.phpt
+++ b/crates/php-parser/tests/fixtures/errors/unclosed_single_quote.phpt
@@ -1,3 +1,5 @@
 ===source===
 <?php 'unclosed string
 ===errors===
+expected ';' after expression
+expected ';' after expression

--- a/crates/php-parser/tests/fixtures/errors/unclosed_string_then_valid_echo.phpt
+++ b/crates/php-parser/tests/fixtures/errors/unclosed_string_then_valid_echo.phpt
@@ -2,3 +2,4 @@
 <?php $x = 'unterminated
  echo 'hello';
 ===errors===
+expected ';' after expression

--- a/crates/php-parser/tests/fixtures/errors/use_error_then_valid_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/use_error_then_valid_class.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php use ; class Foo {}
 ===errors===
+expected identifier, found ';'

--- a/crates/php-parser/tests/fixtures/errors/use_missing_name.phpt
+++ b/crates/php-parser/tests/fixtures/errors/use_missing_name.phpt
@@ -1,3 +1,4 @@
 ===source===
 <?php use;
 ===errors===
+expected identifier, found ';'


### PR DESCRIPTION
## Summary

- Use `config.expect_errors` in `error_fixtures()`, `corpus.rs`, and `php_syntax.rs` to gate error assertions — error fixtures are only required to produce errors when the `===errors===` marker is present
- Fix missing newlines before `===errors===` in 17 fixture files; regenerate 17 snapshots
- Gate PHP-version-specific fixtures (`property_hooks`, `constructor_promotion_with_hooks`, `constructor_promoted_param_with_hooks`, `pipe_operator_precedence`) on the correct minimum PHP version
- Fill the `===errors===` section in all 75 error fixture files with the actual parser error messages, making each fixture self-documenting

## Test plan

- [ ] `cargo test error_fixtures` passes
- [ ] `cargo test` (full suite) passes
- [ ] Each `.phpt` file in `tests/fixtures/errors/` now has error messages in its `===errors===` section matching the corresponding insta snapshot