### PR TITLE
docs: add rustdoc to public API

### DIFF
--- a/crates/php-parser/src/diagnostics.rs
+++ b/crates/php-parser/src/diagnostics.rs
@@ -3,8 +3,14 @@ use php_lexer::TokenKind;
 use std::borrow::Cow;
 use thiserror::Error;
 
+/// A parse error or diagnostic emitted during parsing.
+///
+/// The parser recovers from all errors and always produces a complete AST,
+/// so errors are informational rather than fatal. Each variant carries a
+/// [`Span`] identifying the source location.
 #[derive(Debug, Clone, Error)]
 pub enum ParseError {
+    /// A specific token was expected but a different one was found.
     #[error("expected {expected}, found {found}")]
     Expected {
         expected: Cow<'static, str>,
@@ -12,21 +18,27 @@ pub enum ParseError {
         span: Span,
     },
 
+    /// A token appeared where it is not valid.
     #[error("unexpected token {found}")]
     Unexpected { found: TokenKind, span: Span },
 
+    /// An expression was expected but not found (e.g. empty parentheses).
     #[error("expected expression")]
     ExpectedExpression { span: Span },
 
+    /// A statement was expected but not found.
     #[error("expected statement")]
     ExpectedStatement { span: Span },
 
+    /// PHP source must start with `<?php` or `<?`.
     #[error("expected opening PHP tag")]
     ExpectedOpenTag { span: Span },
 
+    /// A string literal was opened but never closed.
     #[error("unterminated string literal")]
     UnterminatedString { span: Span },
 
+    /// A required token was missing after another construct.
     #[error("expected {expected} after {after}")]
     ExpectedAfter {
         expected: Cow<'static, str>,
@@ -34,6 +46,7 @@ pub enum ParseError {
         span: Span,
     },
 
+    /// A delimiter (parenthesis, bracket, brace) was opened but never closed.
     #[error("unclosed {delimiter} opened at {opened_at:?}")]
     UnclosedDelimiter {
         delimiter: Cow<'static, str>,
@@ -41,12 +54,17 @@ pub enum ParseError {
         span: Span,
     },
 
+    /// A construct that is syntactically valid but semantically forbidden
+    /// (e.g. `(unset)` cast, deprecated syntax).
     #[error("{message}")]
     Forbidden {
         message: Cow<'static, str>,
         span: Span,
     },
 
+    /// Syntax that requires a newer PHP version than the targeted one.
+    /// Emitted by [`crate::parse_versioned`] when the source uses features
+    /// unavailable in the specified [`crate::PhpVersion`].
     #[error("'{feature}' requires PHP {required} or higher (targeting PHP {used})")]
     VersionTooLow {
         feature: Cow<'static, str>,

--- a/crates/php-parser/src/lib.rs
+++ b/crates/php-parser/src/lib.rs
@@ -1,3 +1,33 @@
+//! Fast, fault-tolerant PHP parser that produces a fully typed AST.
+//!
+//! This crate parses PHP source code (PHP 8.0–8.5) into a [`php_ast::Program`]
+//! tree, recovering from syntax errors so that downstream tools always receive
+//! a complete AST.
+//!
+//! # Quick start
+//!
+//! ```
+//! let arena = bumpalo::Bump::new();
+//! let result = php_rs_parser::parse(&arena, "<?php echo 'hello';");
+//! assert!(result.errors.is_empty());
+//! ```
+//!
+//! # Version-aware parsing
+//!
+//! Use [`parse_versioned`] to target a specific PHP version. Syntax that
+//! requires a higher version is still parsed into the AST, but a
+//! [`diagnostics::ParseError::VersionTooLow`] diagnostic is emitted.
+//!
+//! ```
+//! let arena = bumpalo::Bump::new();
+//! let result = php_rs_parser::parse_versioned(
+//!     &arena,
+//!     "<?php enum Status { case Active; }",
+//!     php_rs_parser::PhpVersion::Php80,
+//! );
+//! assert!(!result.errors.is_empty()); // enums require PHP 8.1
+//! ```
+
 pub mod diagnostics;
 pub(crate) mod expr;
 pub mod instrument;
@@ -11,14 +41,22 @@ use diagnostics::ParseError;
 use php_ast::{Comment, Program};
 pub use version::PhpVersion;
 
+/// The result of parsing a PHP source string.
 pub struct ParseResult<'arena, 'src> {
+    /// The parsed AST. Always produced, even when errors are present.
     pub program: Program<'arena, 'src>,
     /// All comments found in the source, in source order.
     /// Comments are not attached to AST nodes; callers can map them by span.
     pub comments: Vec<Comment<'src>>,
+    /// Parse errors and diagnostics. Empty on a successful parse.
     pub errors: Vec<ParseError>,
 }
 
+/// Parse PHP `source` using the latest supported PHP version (currently 8.5).
+///
+/// The `arena` is used for all AST allocations, giving callers control over
+/// memory lifetime. The returned [`ParseResult`] borrows from both the arena
+/// and the source string.
 pub fn parse<'arena, 'src>(
     arena: &'arena bumpalo::Bump,
     source: &'src str,


### PR DESCRIPTION
## Summary

- Add crate-level documentation with quick-start and version-aware parsing examples
- Document `ParseResult` struct and all its fields
- Document `parse()` entry point (was undocumented)
- Add doc comments to all `ParseError` variants explaining when each is emitted

## Test plan

- [x] `cargo doc --no-deps` builds cleanly
- [x] `cargo test --lib` passes
- [x] Pre-commit hooks pass