### PR TITLE
fix(ci): add min_php to fixtures using version-specific syntax

### DIFF
--- a/crates/php-parser/tests/fixtures/dynamic_class_constant_access.phpt
+++ b/crates/php-parser/tests/fixtures/dynamic_class_constant_access.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php
 $a = Foo::{$name};

--- a/crates/php-parser/tests/fixtures/magic_property_in_hook_body.phpt
+++ b/crates/php-parser/tests/fixtures/magic_property_in_hook_body.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php
 class Foo {

--- a/crates/php-parser/tests/fixtures/new_readonly_anonymous_class.phpt
+++ b/crates/php-parser/tests/fixtures/new_readonly_anonymous_class.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php new readonly class {};
 ===ast===

--- a/crates/php-parser/tests/fixtures/property_hook_body_full.phpt
+++ b/crates/php-parser/tests/fixtures/property_hook_body_full.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php class A { public string $x { get { return $this->x; } set { $this->x = $value; } } }
 ===ast===


### PR DESCRIPTION
## Summary

- Add `min_php=8.3` to `dynamic_class_constant_access.phpt` (uses `Foo::{$name}`, added in PHP 8.3)
- Add `min_php=8.4` to `magic_property_in_hook_body.phpt` (uses property hooks, added in PHP 8.4)

These missing configs caused `fixture_files_are_valid_php` to fail on PHP 8.2 and 8.3 in CI, and the Coverage job (which also runs php_syntax tests).

## Test plan

- [x] CI should now pass on all PHP version matrix entries (8.2, 8.3, 8.4, 8.5)