### PR TITLE
feat: improve Visitor API with ControlFlow, type hints, and integration tests

### DIFF
--- a/crates/php-ast/src/visitor.rs
+++ b/crates/php-ast/src/visitor.rs
@@ -1,201 +1,259 @@
+use std::ops::ControlFlow;
+
 use crate::ast::*;
 
-/// Visitor trait for AST traversal. All methods have default implementations
-/// that recursively walk child nodes, so implementors only need to override
-/// the node types they care about.
+/// Visitor trait for immutable AST traversal.
+///
+/// All methods return `ControlFlow<()>`:
+/// - `ControlFlow::Continue(())` — keep walking.
+/// - `ControlFlow::Break(())` — stop the entire traversal immediately.
+///
+/// Default implementations recursively walk child nodes, so implementors
+/// only need to override the node types they care about.
+///
+/// To **skip** a subtree, override the method and return `Continue(())`
+/// without calling the corresponding `walk_*` function.
+///
+/// # Example
+///
+/// ```
+/// use php_ast::visitor::{Visitor, walk_expr};
+/// use php_ast::ast::*;
+/// use std::ops::ControlFlow;
+///
+/// struct VarCounter { count: usize }
+///
+/// impl<'arena, 'src> Visitor<'arena, 'src> for VarCounter {
+///     fn visit_expr(&mut self, expr: &Expr<'arena, 'src>) -> ControlFlow<()> {
+///         if matches!(&expr.kind, ExprKind::Variable(_)) {
+///             self.count += 1;
+///         }
+///         walk_expr(self, expr)
+///     }
+/// }
+/// ```
 pub trait Visitor<'arena, 'src> {
-    fn visit_program(&mut self, program: &Program<'arena, 'src>) {
-        walk_program(self, program);
+    fn visit_program(&mut self, program: &Program<'arena, 'src>) -> ControlFlow<()> {
+        walk_program(self, program)
     }
 
-    fn visit_stmt(&mut self, stmt: &Stmt<'arena, 'src>) {
-        walk_stmt(self, stmt);
+    fn visit_stmt(&mut self, stmt: &Stmt<'arena, 'src>) -> ControlFlow<()> {
+        walk_stmt(self, stmt)
     }
 
-    fn visit_expr(&mut self, expr: &Expr<'arena, 'src>) {
-        walk_expr(self, expr);
+    fn visit_expr(&mut self, expr: &Expr<'arena, 'src>) -> ControlFlow<()> {
+        walk_expr(self, expr)
     }
 
-    fn visit_param(&mut self, param: &Param<'arena, 'src>) {
-        walk_param(self, param);
+    fn visit_param(&mut self, param: &Param<'arena, 'src>) -> ControlFlow<()> {
+        walk_param(self, param)
     }
 
-    fn visit_arg(&mut self, arg: &Arg<'arena, 'src>) {
-        walk_arg(self, arg);
+    fn visit_arg(&mut self, arg: &Arg<'arena, 'src>) -> ControlFlow<()> {
+        walk_arg(self, arg)
     }
 
-    fn visit_class_member(&mut self, member: &ClassMember<'arena, 'src>) {
-        walk_class_member(self, member);
+    fn visit_class_member(&mut self, member: &ClassMember<'arena, 'src>) -> ControlFlow<()> {
+        walk_class_member(self, member)
     }
 
-    fn visit_enum_member(&mut self, member: &EnumMember<'arena, 'src>) {
-        walk_enum_member(self, member);
+    fn visit_enum_member(&mut self, member: &EnumMember<'arena, 'src>) -> ControlFlow<()> {
+        walk_enum_member(self, member)
     }
 
-    fn visit_property_hook(&mut self, hook: &PropertyHook<'arena, 'src>) {
-        walk_property_hook(self, hook);
+    fn visit_property_hook(&mut self, hook: &PropertyHook<'arena, 'src>) -> ControlFlow<()> {
+        walk_property_hook(self, hook)
+    }
+
+    fn visit_type_hint(&mut self, type_hint: &TypeHint<'arena, 'src>) -> ControlFlow<()> {
+        walk_type_hint(self, type_hint)
+    }
+
+    fn visit_attribute(&mut self, attribute: &Attribute<'arena, 'src>) -> ControlFlow<()> {
+        walk_attribute(self, attribute)
+    }
+
+    fn visit_catch_clause(&mut self, catch: &CatchClause<'arena, 'src>) -> ControlFlow<()> {
+        walk_catch_clause(self, catch)
+    }
+
+    fn visit_match_arm(&mut self, arm: &MatchArm<'arena, 'src>) -> ControlFlow<()> {
+        walk_match_arm(self, arm)
+    }
+
+    fn visit_closure_use_var(&mut self, _var: &ClosureUseVar<'src>) -> ControlFlow<()> {
+        ControlFlow::Continue(())
     }
 }
+
+// =============================================================================
+// Walk functions
+// =============================================================================
 
 pub fn walk_program<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     program: &Program<'arena, 'src>,
-) {
+) -> ControlFlow<()> {
     for stmt in program.stmts.iter() {
-        visitor.visit_stmt(stmt);
+        visitor.visit_stmt(stmt)?;
     }
+    ControlFlow::Continue(())
 }
 
 pub fn walk_stmt<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     stmt: &Stmt<'arena, 'src>,
-) {
+) -> ControlFlow<()> {
     match &stmt.kind {
         StmtKind::Expression(expr) => {
-            visitor.visit_expr(expr);
+            visitor.visit_expr(expr)?;
         }
         StmtKind::Echo(exprs) => {
             for expr in exprs.iter() {
-                visitor.visit_expr(expr);
+                visitor.visit_expr(expr)?;
             }
         }
         StmtKind::Return(expr) => {
             if let Some(expr) = expr {
-                visitor.visit_expr(expr);
+                visitor.visit_expr(expr)?;
             }
         }
         StmtKind::Block(stmts) => {
             for stmt in stmts.iter() {
-                visitor.visit_stmt(stmt);
+                visitor.visit_stmt(stmt)?;
             }
         }
         StmtKind::If(if_stmt) => {
-            visitor.visit_expr(&if_stmt.condition);
-            visitor.visit_stmt(if_stmt.then_branch);
+            visitor.visit_expr(&if_stmt.condition)?;
+            visitor.visit_stmt(if_stmt.then_branch)?;
             for elseif in if_stmt.elseif_branches.iter() {
-                visitor.visit_expr(&elseif.condition);
-                visitor.visit_stmt(&elseif.body);
+                visitor.visit_expr(&elseif.condition)?;
+                visitor.visit_stmt(&elseif.body)?;
             }
             if let Some(else_branch) = &if_stmt.else_branch {
-                visitor.visit_stmt(else_branch);
+                visitor.visit_stmt(else_branch)?;
             }
         }
         StmtKind::While(while_stmt) => {
-            visitor.visit_expr(&while_stmt.condition);
-            visitor.visit_stmt(while_stmt.body);
+            visitor.visit_expr(&while_stmt.condition)?;
+            visitor.visit_stmt(while_stmt.body)?;
         }
         StmtKind::For(for_stmt) => {
             for expr in for_stmt.init.iter() {
-                visitor.visit_expr(expr);
+                visitor.visit_expr(expr)?;
             }
             for expr in for_stmt.condition.iter() {
-                visitor.visit_expr(expr);
+                visitor.visit_expr(expr)?;
             }
             for expr in for_stmt.update.iter() {
-                visitor.visit_expr(expr);
+                visitor.visit_expr(expr)?;
             }
-            visitor.visit_stmt(for_stmt.body);
+            visitor.visit_stmt(for_stmt.body)?;
         }
         StmtKind::Foreach(foreach_stmt) => {
-            visitor.visit_expr(&foreach_stmt.expr);
+            visitor.visit_expr(&foreach_stmt.expr)?;
             if let Some(key) = &foreach_stmt.key {
-                visitor.visit_expr(key);
+                visitor.visit_expr(key)?;
             }
-            visitor.visit_expr(&foreach_stmt.value);
-            visitor.visit_stmt(foreach_stmt.body);
+            visitor.visit_expr(&foreach_stmt.value)?;
+            visitor.visit_stmt(foreach_stmt.body)?;
         }
         StmtKind::DoWhile(do_while) => {
-            visitor.visit_stmt(do_while.body);
-            visitor.visit_expr(&do_while.condition);
+            visitor.visit_stmt(do_while.body)?;
+            visitor.visit_expr(&do_while.condition)?;
         }
         StmtKind::Function(func) => {
-            for param in func.params.iter() {
-                visitor.visit_param(param);
-            }
+            walk_function_like(visitor, &func.attributes, &func.params, &func.return_type)?;
             for stmt in func.body.iter() {
-                visitor.visit_stmt(stmt);
+                visitor.visit_stmt(stmt)?;
             }
         }
         StmtKind::Break(expr) | StmtKind::Continue(expr) => {
             if let Some(expr) = expr {
-                visitor.visit_expr(expr);
+                visitor.visit_expr(expr)?;
             }
         }
         StmtKind::Switch(switch_stmt) => {
-            visitor.visit_expr(&switch_stmt.expr);
+            visitor.visit_expr(&switch_stmt.expr)?;
             for case in switch_stmt.cases.iter() {
                 if let Some(value) = &case.value {
-                    visitor.visit_expr(value);
+                    visitor.visit_expr(value)?;
                 }
                 for stmt in case.body.iter() {
-                    visitor.visit_stmt(stmt);
+                    visitor.visit_stmt(stmt)?;
                 }
             }
         }
         StmtKind::Throw(expr) => {
-            visitor.visit_expr(expr);
+            visitor.visit_expr(expr)?;
         }
         StmtKind::TryCatch(tc) => {
             for stmt in tc.body.iter() {
-                visitor.visit_stmt(stmt);
+                visitor.visit_stmt(stmt)?;
             }
             for catch in tc.catches.iter() {
-                for stmt in catch.body.iter() {
-                    visitor.visit_stmt(stmt);
-                }
+                visitor.visit_catch_clause(catch)?;
             }
             if let Some(finally) = &tc.finally {
                 for stmt in finally.iter() {
-                    visitor.visit_stmt(stmt);
+                    visitor.visit_stmt(stmt)?;
                 }
             }
         }
         StmtKind::Declare(decl) => {
+            for (_, expr) in decl.directives.iter() {
+                visitor.visit_expr(expr)?;
+            }
             if let Some(body) = decl.body {
-                visitor.visit_stmt(body);
+                visitor.visit_stmt(body)?;
             }
         }
         StmtKind::Unset(exprs) | StmtKind::Global(exprs) => {
             for expr in exprs.iter() {
-                visitor.visit_expr(expr);
+                visitor.visit_expr(expr)?;
             }
         }
         StmtKind::Class(class) => {
+            walk_attributes(visitor, &class.attributes)?;
             for member in class.members.iter() {
-                visitor.visit_class_member(member);
+                visitor.visit_class_member(member)?;
             }
         }
         StmtKind::Interface(iface) => {
+            walk_attributes(visitor, &iface.attributes)?;
             for member in iface.members.iter() {
-                visitor.visit_class_member(member);
+                visitor.visit_class_member(member)?;
             }
         }
         StmtKind::Trait(trait_decl) => {
+            walk_attributes(visitor, &trait_decl.attributes)?;
             for member in trait_decl.members.iter() {
-                visitor.visit_class_member(member);
+                visitor.visit_class_member(member)?;
             }
         }
         StmtKind::Enum(enum_decl) => {
+            walk_attributes(visitor, &enum_decl.attributes)?;
             for member in enum_decl.members.iter() {
-                visitor.visit_enum_member(member);
+                visitor.visit_enum_member(member)?;
             }
         }
         StmtKind::Namespace(ns) => {
             if let NamespaceBody::Braced(stmts) = &ns.body {
                 for stmt in stmts.iter() {
-                    visitor.visit_stmt(stmt);
+                    visitor.visit_stmt(stmt)?;
                 }
             }
         }
         StmtKind::Const(items) => {
             for item in items.iter() {
-                visitor.visit_expr(&item.value);
+                walk_attributes(visitor, &item.attributes)?;
+                visitor.visit_expr(&item.value)?;
             }
         }
         StmtKind::StaticVar(vars) => {
             for var in vars.iter() {
                 if let Some(default) = &var.default {
-                    visitor.visit_expr(default);
+                    visitor.visit_expr(default)?;
                 }
             }
         }
@@ -207,166 +265,172 @@ pub fn walk_stmt<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
         | StmtKind::HaltCompiler(_)
         | StmtKind::Error => {}
     }
+    ControlFlow::Continue(())
 }
 
 pub fn walk_expr<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     expr: &Expr<'arena, 'src>,
-) {
+) -> ControlFlow<()> {
     match &expr.kind {
         ExprKind::Assign(assign) => {
-            visitor.visit_expr(assign.target);
-            visitor.visit_expr(assign.value);
+            visitor.visit_expr(assign.target)?;
+            visitor.visit_expr(assign.value)?;
         }
         ExprKind::Binary(binary) => {
-            visitor.visit_expr(binary.left);
-            visitor.visit_expr(binary.right);
+            visitor.visit_expr(binary.left)?;
+            visitor.visit_expr(binary.right)?;
         }
         ExprKind::UnaryPrefix(unary) => {
-            visitor.visit_expr(unary.operand);
+            visitor.visit_expr(unary.operand)?;
         }
         ExprKind::UnaryPostfix(unary) => {
-            visitor.visit_expr(unary.operand);
+            visitor.visit_expr(unary.operand)?;
         }
         ExprKind::Ternary(ternary) => {
-            visitor.visit_expr(ternary.condition);
+            visitor.visit_expr(ternary.condition)?;
             if let Some(then_expr) = &ternary.then_expr {
-                visitor.visit_expr(then_expr);
+                visitor.visit_expr(then_expr)?;
             }
-            visitor.visit_expr(ternary.else_expr);
+            visitor.visit_expr(ternary.else_expr)?;
         }
         ExprKind::NullCoalesce(nc) => {
-            visitor.visit_expr(nc.left);
-            visitor.visit_expr(nc.right);
+            visitor.visit_expr(nc.left)?;
+            visitor.visit_expr(nc.right)?;
         }
         ExprKind::FunctionCall(call) => {
-            visitor.visit_expr(call.name);
+            visitor.visit_expr(call.name)?;
             for arg in call.args.iter() {
-                visitor.visit_arg(arg);
+                visitor.visit_arg(arg)?;
             }
         }
         ExprKind::Array(elements) => {
             for elem in elements.iter() {
                 if let Some(key) = &elem.key {
-                    visitor.visit_expr(key);
+                    visitor.visit_expr(key)?;
                 }
-                visitor.visit_expr(&elem.value);
+                visitor.visit_expr(&elem.value)?;
             }
         }
         ExprKind::ArrayAccess(access) => {
-            visitor.visit_expr(access.array);
+            visitor.visit_expr(access.array)?;
             if let Some(index) = &access.index {
-                visitor.visit_expr(index);
+                visitor.visit_expr(index)?;
             }
         }
         ExprKind::Print(expr) => {
-            visitor.visit_expr(expr);
+            visitor.visit_expr(expr)?;
         }
         ExprKind::Parenthesized(expr) => {
-            visitor.visit_expr(expr);
+            visitor.visit_expr(expr)?;
         }
         ExprKind::Cast(_, expr) => {
-            visitor.visit_expr(expr);
+            visitor.visit_expr(expr)?;
         }
         ExprKind::ErrorSuppress(expr) => {
-            visitor.visit_expr(expr);
+            visitor.visit_expr(expr)?;
         }
         ExprKind::Isset(exprs) => {
             for expr in exprs.iter() {
-                visitor.visit_expr(expr);
+                visitor.visit_expr(expr)?;
             }
         }
         ExprKind::Empty(expr) => {
-            visitor.visit_expr(expr);
+            visitor.visit_expr(expr)?;
         }
         ExprKind::Include(_, expr) => {
-            visitor.visit_expr(expr);
+            visitor.visit_expr(expr)?;
         }
         ExprKind::Eval(expr) => {
-            visitor.visit_expr(expr);
+            visitor.visit_expr(expr)?;
         }
         ExprKind::Exit(expr) => {
             if let Some(expr) = expr {
-                visitor.visit_expr(expr);
+                visitor.visit_expr(expr)?;
             }
         }
         ExprKind::Clone(expr) => {
-            visitor.visit_expr(expr);
+            visitor.visit_expr(expr)?;
         }
         ExprKind::CloneWith(object, overrides) => {
-            visitor.visit_expr(object);
-            visitor.visit_expr(overrides);
+            visitor.visit_expr(object)?;
+            visitor.visit_expr(overrides)?;
         }
         ExprKind::New(new_expr) => {
-            visitor.visit_expr(new_expr.class);
+            visitor.visit_expr(new_expr.class)?;
             for arg in new_expr.args.iter() {
-                visitor.visit_arg(arg);
+                visitor.visit_arg(arg)?;
             }
         }
         ExprKind::PropertyAccess(access) | ExprKind::NullsafePropertyAccess(access) => {
-            visitor.visit_expr(access.object);
-            visitor.visit_expr(access.property);
+            visitor.visit_expr(access.object)?;
+            visitor.visit_expr(access.property)?;
         }
         ExprKind::MethodCall(call) | ExprKind::NullsafeMethodCall(call) => {
-            visitor.visit_expr(call.object);
-            visitor.visit_expr(call.method);
+            visitor.visit_expr(call.object)?;
+            visitor.visit_expr(call.method)?;
             for arg in call.args.iter() {
-                visitor.visit_arg(arg);
+                visitor.visit_arg(arg)?;
             }
         }
         ExprKind::StaticPropertyAccess(access) | ExprKind::ClassConstAccess(access) => {
-            visitor.visit_expr(access.class);
+            visitor.visit_expr(access.class)?;
         }
         ExprKind::ClassConstAccessDynamic { class, member }
         | ExprKind::StaticPropertyAccessDynamic { class, member } => {
-            visitor.visit_expr(class);
-            visitor.visit_expr(member);
+            visitor.visit_expr(class)?;
+            visitor.visit_expr(member)?;
         }
         ExprKind::StaticMethodCall(call) => {
-            visitor.visit_expr(call.class);
+            visitor.visit_expr(call.class)?;
             for arg in call.args.iter() {
-                visitor.visit_arg(arg);
+                visitor.visit_arg(arg)?;
             }
         }
         ExprKind::Closure(closure) => {
-            for param in closure.params.iter() {
-                visitor.visit_param(param);
+            walk_function_like(
+                visitor,
+                &closure.attributes,
+                &closure.params,
+                &closure.return_type,
+            )?;
+            for use_var in closure.use_vars.iter() {
+                visitor.visit_closure_use_var(use_var)?;
             }
             for stmt in closure.body.iter() {
-                visitor.visit_stmt(stmt);
+                visitor.visit_stmt(stmt)?;
             }
         }
         ExprKind::ArrowFunction(arrow) => {
-            for param in arrow.params.iter() {
-                visitor.visit_param(param);
-            }
-            visitor.visit_expr(arrow.body);
+            walk_function_like(
+                visitor,
+                &arrow.attributes,
+                &arrow.params,
+                &arrow.return_type,
+            )?;
+            visitor.visit_expr(arrow.body)?;
         }
         ExprKind::Match(match_expr) => {
-            visitor.visit_expr(match_expr.subject);
+            visitor.visit_expr(match_expr.subject)?;
             for arm in match_expr.arms.iter() {
-                if let Some(conditions) = &arm.conditions {
-                    for cond in conditions.iter() {
-                        visitor.visit_expr(cond);
-                    }
-                }
-                visitor.visit_expr(&arm.body);
+                visitor.visit_match_arm(arm)?;
             }
         }
         ExprKind::ThrowExpr(expr) => {
-            visitor.visit_expr(expr);
+            visitor.visit_expr(expr)?;
         }
         ExprKind::Yield(yield_expr) => {
             if let Some(key) = &yield_expr.key {
-                visitor.visit_expr(key);
+                visitor.visit_expr(key)?;
             }
             if let Some(value) = &yield_expr.value {
-                visitor.visit_expr(value);
+                visitor.visit_expr(value)?;
             }
         }
         ExprKind::AnonymousClass(class) => {
+            walk_attributes(visitor, &class.attributes)?;
             for member in class.members.iter() {
-                visitor.visit_class_member(member);
+                visitor.visit_class_member(member)?;
             }
         }
         ExprKind::InterpolatedString(parts)
@@ -374,22 +438,22 @@ pub fn walk_expr<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
         | ExprKind::ShellExec(parts) => {
             for part in parts.iter() {
                 if let StringPart::Expr(e) = part {
-                    visitor.visit_expr(e);
+                    visitor.visit_expr(e)?;
                 }
             }
         }
         ExprKind::VariableVariable(inner) => {
-            visitor.visit_expr(inner);
+            visitor.visit_expr(inner)?;
         }
         ExprKind::CallableCreate(cc) => match &cc.kind {
-            CallableCreateKind::Function(name) => visitor.visit_expr(name),
+            CallableCreateKind::Function(name) => visitor.visit_expr(name)?,
             CallableCreateKind::Method { object, method }
             | CallableCreateKind::NullsafeMethod { object, method } => {
-                visitor.visit_expr(object);
-                visitor.visit_expr(method);
+                visitor.visit_expr(object)?;
+                visitor.visit_expr(method)?;
             }
             CallableCreateKind::StaticMethod { class, .. } => {
-                visitor.visit_expr(class);
+                visitor.visit_expr(class)?;
             }
         },
         ExprKind::Int(_)
@@ -404,140 +468,265 @@ pub fn walk_expr<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
         | ExprKind::Nowdoc { .. }
         | ExprKind::Error => {}
     }
+    ControlFlow::Continue(())
 }
 
 pub fn walk_param<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     param: &Param<'arena, 'src>,
-) {
+) -> ControlFlow<()> {
+    walk_attributes(visitor, &param.attributes)?;
+    if let Some(type_hint) = &param.type_hint {
+        visitor.visit_type_hint(type_hint)?;
+    }
     if let Some(default) = &param.default {
-        visitor.visit_expr(default);
+        visitor.visit_expr(default)?;
     }
     for hook in param.hooks.iter() {
-        visitor.visit_property_hook(hook);
+        visitor.visit_property_hook(hook)?;
     }
+    ControlFlow::Continue(())
 }
 
 pub fn walk_arg<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     arg: &Arg<'arena, 'src>,
-) {
-    visitor.visit_expr(&arg.value);
+) -> ControlFlow<()> {
+    visitor.visit_expr(&arg.value)
 }
 
 pub fn walk_class_member<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     member: &ClassMember<'arena, 'src>,
-) {
+) -> ControlFlow<()> {
     match &member.kind {
         ClassMemberKind::Property(prop) => {
-            if let Some(default) = &prop.default {
-                visitor.visit_expr(default);
-            }
-            for hook in prop.hooks.iter() {
-                visitor.visit_property_hook(hook);
-            }
+            walk_property_decl(visitor, prop)?;
         }
         ClassMemberKind::Method(method) => {
-            for param in method.params.iter() {
-                visitor.visit_param(param);
-            }
-            if let Some(body) = &method.body {
-                for stmt in body.iter() {
-                    visitor.visit_stmt(stmt);
-                }
-            }
+            walk_method_decl(visitor, method)?;
         }
         ClassMemberKind::ClassConst(cc) => {
-            visitor.visit_expr(&cc.value);
+            walk_class_const_decl(visitor, cc)?;
         }
         ClassMemberKind::TraitUse(_) => {}
     }
+    ControlFlow::Continue(())
 }
 
 pub fn walk_property_hook<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     hook: &PropertyHook<'arena, 'src>,
-) {
+) -> ControlFlow<()> {
+    walk_attributes(visitor, &hook.attributes)?;
     for param in hook.params.iter() {
-        visitor.visit_param(param);
+        visitor.visit_param(param)?;
     }
     match &hook.body {
         PropertyHookBody::Block(stmts) => {
             for stmt in stmts.iter() {
-                visitor.visit_stmt(stmt);
+                visitor.visit_stmt(stmt)?;
             }
         }
         PropertyHookBody::Expression(expr) => {
-            visitor.visit_expr(expr);
+            visitor.visit_expr(expr)?;
         }
         PropertyHookBody::Abstract => {}
     }
+    ControlFlow::Continue(())
 }
 
 pub fn walk_enum_member<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     member: &EnumMember<'arena, 'src>,
-) {
+) -> ControlFlow<()> {
     match &member.kind {
         EnumMemberKind::Case(case) => {
+            walk_attributes(visitor, &case.attributes)?;
             if let Some(value) = &case.value {
-                visitor.visit_expr(value);
+                visitor.visit_expr(value)?;
             }
         }
         EnumMemberKind::Method(method) => {
-            for param in method.params.iter() {
-                visitor.visit_param(param);
-            }
-            if let Some(body) = &method.body {
-                for stmt in body.iter() {
-                    visitor.visit_stmt(stmt);
-                }
-            }
+            walk_method_decl(visitor, method)?;
         }
         EnumMemberKind::ClassConst(cc) => {
-            visitor.visit_expr(&cc.value);
+            walk_class_const_decl(visitor, cc)?;
         }
         EnumMemberKind::TraitUse(_) => {}
     }
+    ControlFlow::Continue(())
+}
+
+pub fn walk_type_hint<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
+    visitor: &mut V,
+    type_hint: &TypeHint<'arena, 'src>,
+) -> ControlFlow<()> {
+    match &type_hint.kind {
+        TypeHintKind::Nullable(inner) => {
+            visitor.visit_type_hint(inner)?;
+        }
+        TypeHintKind::Union(types) | TypeHintKind::Intersection(types) => {
+            for ty in types.iter() {
+                visitor.visit_type_hint(ty)?;
+            }
+        }
+        TypeHintKind::Named(_) | TypeHintKind::Keyword(_, _) => {}
+    }
+    ControlFlow::Continue(())
+}
+
+pub fn walk_attribute<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
+    visitor: &mut V,
+    attribute: &Attribute<'arena, 'src>,
+) -> ControlFlow<()> {
+    for arg in attribute.args.iter() {
+        visitor.visit_arg(arg)?;
+    }
+    ControlFlow::Continue(())
+}
+
+pub fn walk_catch_clause<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
+    visitor: &mut V,
+    catch: &CatchClause<'arena, 'src>,
+) -> ControlFlow<()> {
+    for stmt in catch.body.iter() {
+        visitor.visit_stmt(stmt)?;
+    }
+    ControlFlow::Continue(())
+}
+
+pub fn walk_match_arm<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
+    visitor: &mut V,
+    arm: &MatchArm<'arena, 'src>,
+) -> ControlFlow<()> {
+    if let Some(conditions) = &arm.conditions {
+        for cond in conditions.iter() {
+            visitor.visit_expr(cond)?;
+        }
+    }
+    visitor.visit_expr(&arm.body)
+}
+
+// =============================================================================
+// Internal helpers — shared walking logic to avoid duplication
+// =============================================================================
+
+/// Walks the common parts of any function-like construct:
+/// attributes → params → optional return type.
+fn walk_function_like<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
+    visitor: &mut V,
+    attributes: &[Attribute<'arena, 'src>],
+    params: &[Param<'arena, 'src>],
+    return_type: &Option<TypeHint<'arena, 'src>>,
+) -> ControlFlow<()> {
+    walk_attributes(visitor, attributes)?;
+    for param in params.iter() {
+        visitor.visit_param(param)?;
+    }
+    if let Some(ret) = return_type {
+        visitor.visit_type_hint(ret)?;
+    }
+    ControlFlow::Continue(())
+}
+
+/// Walks a method declaration (shared by ClassMember and EnumMember).
+fn walk_method_decl<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
+    visitor: &mut V,
+    method: &MethodDecl<'arena, 'src>,
+) -> ControlFlow<()> {
+    walk_function_like(
+        visitor,
+        &method.attributes,
+        &method.params,
+        &method.return_type,
+    )?;
+    if let Some(body) = &method.body {
+        for stmt in body.iter() {
+            visitor.visit_stmt(stmt)?;
+        }
+    }
+    ControlFlow::Continue(())
+}
+
+/// Walks a class constant declaration (shared by ClassMember and EnumMember).
+fn walk_class_const_decl<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
+    visitor: &mut V,
+    cc: &ClassConstDecl<'arena, 'src>,
+) -> ControlFlow<()> {
+    walk_attributes(visitor, &cc.attributes)?;
+    if let Some(type_hint) = &cc.type_hint {
+        visitor.visit_type_hint(type_hint)?;
+    }
+    visitor.visit_expr(&cc.value)
+}
+
+/// Walks a property declaration.
+fn walk_property_decl<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
+    visitor: &mut V,
+    prop: &PropertyDecl<'arena, 'src>,
+) -> ControlFlow<()> {
+    walk_attributes(visitor, &prop.attributes)?;
+    if let Some(type_hint) = &prop.type_hint {
+        visitor.visit_type_hint(type_hint)?;
+    }
+    if let Some(default) = &prop.default {
+        visitor.visit_expr(default)?;
+    }
+    for hook in prop.hooks.iter() {
+        visitor.visit_property_hook(hook)?;
+    }
+    ControlFlow::Continue(())
+}
+
+fn walk_attributes<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
+    visitor: &mut V,
+    attributes: &[Attribute<'arena, 'src>],
+) -> ControlFlow<()> {
+    for attr in attributes.iter() {
+        visitor.visit_attribute(attr)?;
+    }
+    ControlFlow::Continue(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::Span;
+    use std::borrow::Cow;
 
-    /// A simple visitor that counts variables
+    // =========================================================================
+    // Unit tests with hand-built ASTs
+    // =========================================================================
+
     struct VarCounter {
         count: usize,
     }
 
     impl<'arena, 'src> Visitor<'arena, 'src> for VarCounter {
-        fn visit_expr(&mut self, expr: &Expr<'arena, 'src>) {
+        fn visit_expr(&mut self, expr: &Expr<'arena, 'src>) -> ControlFlow<()> {
             if matches!(&expr.kind, ExprKind::Variable(_)) {
                 self.count += 1;
             }
-            walk_expr(self, expr);
+            walk_expr(self, expr)
         }
     }
 
     #[test]
-    fn test_visitor_counts_variables() {
+    fn counts_variables() {
         let arena = bumpalo::Bump::new();
-
         let var_x = arena.alloc(Expr {
-            kind: ExprKind::Variable(std::borrow::Cow::Borrowed("x")),
+            kind: ExprKind::Variable(Cow::Borrowed("x")),
             span: Span::DUMMY,
         });
         let var_y = arena.alloc(Expr {
-            kind: ExprKind::Variable(std::borrow::Cow::Borrowed("y")),
+            kind: ExprKind::Variable(Cow::Borrowed("y")),
             span: Span::DUMMY,
         });
         let var_z = arena.alloc(Expr {
-            kind: ExprKind::Variable(std::borrow::Cow::Borrowed("z")),
+            kind: ExprKind::Variable(Cow::Borrowed("z")),
             span: Span::DUMMY,
         });
-
         let binary = arena.alloc(Expr {
             kind: ExprKind::Binary(BinaryExpr {
                 left: var_y,
@@ -546,8 +735,7 @@ mod tests {
             }),
             span: Span::DUMMY,
         });
-
-        let assign_expr = arena.alloc(Expr {
+        let assign = arena.alloc(Expr {
             kind: ExprKind::Assign(AssignExpr {
                 target: var_x,
                 op: AssignOp::Assign,
@@ -556,20 +744,152 @@ mod tests {
             }),
             span: Span::DUMMY,
         });
-
         let mut stmts = ArenaVec::new_in(&arena);
         stmts.push(Stmt {
-            kind: StmtKind::Expression(assign_expr),
+            kind: StmtKind::Expression(assign),
             span: Span::DUMMY,
         });
-
         let program = Program {
             stmts,
             span: Span::DUMMY,
         };
 
-        let mut counter = VarCounter { count: 0 };
-        counter.visit_program(&program);
-        assert_eq!(counter.count, 3);
+        let mut v = VarCounter { count: 0 };
+        let _ = v.visit_program(&program);
+        assert_eq!(v.count, 3);
+    }
+
+    #[test]
+    fn early_termination() {
+        let arena = bumpalo::Bump::new();
+        let var_a = arena.alloc(Expr {
+            kind: ExprKind::Variable(Cow::Borrowed("a")),
+            span: Span::DUMMY,
+        });
+        let var_b = arena.alloc(Expr {
+            kind: ExprKind::Variable(Cow::Borrowed("b")),
+            span: Span::DUMMY,
+        });
+        let binary = arena.alloc(Expr {
+            kind: ExprKind::Binary(BinaryExpr {
+                left: var_a,
+                op: BinaryOp::Add,
+                right: var_b,
+            }),
+            span: Span::DUMMY,
+        });
+        let mut stmts = ArenaVec::new_in(&arena);
+        stmts.push(Stmt {
+            kind: StmtKind::Expression(binary),
+            span: Span::DUMMY,
+        });
+        let program = Program {
+            stmts,
+            span: Span::DUMMY,
+        };
+
+        struct FindFirst {
+            found: Option<String>,
+        }
+        impl<'arena, 'src> Visitor<'arena, 'src> for FindFirst {
+            fn visit_expr(&mut self, expr: &Expr<'arena, 'src>) -> ControlFlow<()> {
+                if let ExprKind::Variable(name) = &expr.kind {
+                    self.found = Some(name.to_string());
+                    return ControlFlow::Break(());
+                }
+                walk_expr(self, expr)
+            }
+        }
+
+        let mut finder = FindFirst { found: None };
+        let result = finder.visit_program(&program);
+        assert!(result.is_break());
+        assert_eq!(finder.found.as_deref(), Some("a"));
+    }
+
+    #[test]
+    fn skip_subtree() {
+        let arena = bumpalo::Bump::new();
+        // 1 + 2; function foo() { 3 + 4; }
+        let one = arena.alloc(Expr {
+            kind: ExprKind::Int(1),
+            span: Span::DUMMY,
+        });
+        let two = arena.alloc(Expr {
+            kind: ExprKind::Int(2),
+            span: Span::DUMMY,
+        });
+        let top = arena.alloc(Expr {
+            kind: ExprKind::Binary(BinaryExpr {
+                left: one,
+                op: BinaryOp::Add,
+                right: two,
+            }),
+            span: Span::DUMMY,
+        });
+        let three = arena.alloc(Expr {
+            kind: ExprKind::Int(3),
+            span: Span::DUMMY,
+        });
+        let four = arena.alloc(Expr {
+            kind: ExprKind::Int(4),
+            span: Span::DUMMY,
+        });
+        let inner = arena.alloc(Expr {
+            kind: ExprKind::Binary(BinaryExpr {
+                left: three,
+                op: BinaryOp::Add,
+                right: four,
+            }),
+            span: Span::DUMMY,
+        });
+        let mut func_body = ArenaVec::new_in(&arena);
+        func_body.push(Stmt {
+            kind: StmtKind::Expression(inner),
+            span: Span::DUMMY,
+        });
+        let func = arena.alloc(FunctionDecl {
+            name: "foo",
+            params: ArenaVec::new_in(&arena),
+            body: func_body,
+            return_type: None,
+            by_ref: false,
+            attributes: ArenaVec::new_in(&arena),
+            doc_comment: None,
+        });
+        let mut stmts = ArenaVec::new_in(&arena);
+        stmts.push(Stmt {
+            kind: StmtKind::Expression(top),
+            span: Span::DUMMY,
+        });
+        stmts.push(Stmt {
+            kind: StmtKind::Function(func),
+            span: Span::DUMMY,
+        });
+        let program = Program {
+            stmts,
+            span: Span::DUMMY,
+        };
+
+        struct SkipFunctions {
+            expr_count: usize,
+        }
+        impl<'arena, 'src> Visitor<'arena, 'src> for SkipFunctions {
+            fn visit_expr(&mut self, expr: &Expr<'arena, 'src>) -> ControlFlow<()> {
+                self.expr_count += 1;
+                walk_expr(self, expr)
+            }
+            fn visit_stmt(&mut self, stmt: &Stmt<'arena, 'src>) -> ControlFlow<()> {
+                if matches!(&stmt.kind, StmtKind::Function(_)) {
+                    return ControlFlow::Continue(());
+                }
+                walk_stmt(self, stmt)
+            }
+        }
+
+        let mut v = SkipFunctions { expr_count: 0 };
+        let _ = v.visit_program(&program);
+        // Only top-level: binary(1, 2) = 3 exprs
+        assert_eq!(v.expr_count, 3);
     }
 }

--- a/crates/php-parser/tests/visitor.rs
+++ b/crates/php-parser/tests/visitor.rs
@@ -1,0 +1,367 @@
+//! Integration tests for the visitor API using the real parser.
+//! These tests parse actual PHP source and walk the resulting AST to verify
+//! the visitor reaches all expected nodes.
+
+use php_ast::ast::*;
+use php_ast::visitor::{self, Visitor};
+use std::ops::ControlFlow;
+
+/// Parse PHP source and run a callback with the resulting program.
+/// Keeps the arena alive for the duration of the callback.
+fn with_parsed<F: for<'arena, 'src> FnOnce(&Program<'arena, 'src>)>(src: &str, f: F) {
+    let arena = bumpalo::Bump::new();
+    let result = php_rs_parser::parse(&arena, src);
+    assert!(
+        result.errors.is_empty(),
+        "parse errors: {:?}",
+        result.errors
+    );
+    f(&result.program);
+}
+
+/// Counts occurrences of each node type visited.
+#[derive(Default)]
+struct NodeCounter {
+    stmts: usize,
+    exprs: usize,
+    params: usize,
+    type_hints: usize,
+    attributes: usize,
+    class_members: usize,
+    enum_members: usize,
+    catch_clauses: usize,
+    match_arms: usize,
+    closure_use_vars: usize,
+    args: usize,
+}
+
+impl<'arena, 'src> Visitor<'arena, 'src> for NodeCounter {
+    fn visit_stmt(&mut self, stmt: &Stmt<'arena, 'src>) -> ControlFlow<()> {
+        self.stmts += 1;
+        visitor::walk_stmt(self, stmt)
+    }
+    fn visit_expr(&mut self, expr: &Expr<'arena, 'src>) -> ControlFlow<()> {
+        self.exprs += 1;
+        visitor::walk_expr(self, expr)
+    }
+    fn visit_param(&mut self, param: &Param<'arena, 'src>) -> ControlFlow<()> {
+        self.params += 1;
+        visitor::walk_param(self, param)
+    }
+    fn visit_type_hint(&mut self, th: &TypeHint<'arena, 'src>) -> ControlFlow<()> {
+        self.type_hints += 1;
+        visitor::walk_type_hint(self, th)
+    }
+    fn visit_attribute(&mut self, attr: &Attribute<'arena, 'src>) -> ControlFlow<()> {
+        self.attributes += 1;
+        visitor::walk_attribute(self, attr)
+    }
+    fn visit_class_member(&mut self, m: &ClassMember<'arena, 'src>) -> ControlFlow<()> {
+        self.class_members += 1;
+        visitor::walk_class_member(self, m)
+    }
+    fn visit_enum_member(&mut self, m: &EnumMember<'arena, 'src>) -> ControlFlow<()> {
+        self.enum_members += 1;
+        visitor::walk_enum_member(self, m)
+    }
+    fn visit_catch_clause(&mut self, c: &CatchClause<'arena, 'src>) -> ControlFlow<()> {
+        self.catch_clauses += 1;
+        visitor::walk_catch_clause(self, c)
+    }
+    fn visit_match_arm(&mut self, arm: &MatchArm<'arena, 'src>) -> ControlFlow<()> {
+        self.match_arms += 1;
+        visitor::walk_match_arm(self, arm)
+    }
+    fn visit_closure_use_var(&mut self, _var: &ClosureUseVar<'src>) -> ControlFlow<()> {
+        self.closure_use_vars += 1;
+        ControlFlow::Continue(())
+    }
+    fn visit_arg(&mut self, arg: &Arg<'arena, 'src>) -> ControlFlow<()> {
+        self.args += 1;
+        visitor::walk_arg(self, arg)
+    }
+}
+
+#[test]
+fn walks_function_params_and_return_type() {
+    with_parsed(
+        "<?php function add(int $a, int $b): int { return $a + $b; }",
+        |program| {
+            let mut c = NodeCounter::default();
+            let _ = c.visit_program(program);
+            assert_eq!(c.params, 2);
+            assert_eq!(c.type_hints, 3); // int, int, int
+        },
+    );
+}
+
+#[test]
+fn walks_class_members() {
+    with_parsed(
+        "<?php class Foo {
+            public int $x = 1;
+            public function bar(): void {}
+            const Y = 2;
+        }",
+        |program| {
+            let mut c = NodeCounter::default();
+            let _ = c.visit_program(program);
+            assert_eq!(c.class_members, 3); // property, method, const
+            assert_eq!(c.type_hints, 2); // int, void
+        },
+    );
+}
+
+#[test]
+fn walks_enum_members() {
+    with_parsed(
+        "<?php enum Color: string {
+            case Red = 'red';
+            case Blue = 'blue';
+            public function label(): string { return $this->value; }
+        }",
+        |program| {
+            let mut c = NodeCounter::default();
+            let _ = c.visit_program(program);
+            assert_eq!(c.enum_members, 3); // 2 cases + 1 method
+            assert_eq!(c.type_hints, 1); // return type: string
+        },
+    );
+}
+
+#[test]
+fn walks_match_arms() {
+    with_parsed(
+        "<?php match($x) {
+            1 => 'one',
+            2, 3 => 'few',
+            default => 'many',
+        };",
+        |program| {
+            let mut c = NodeCounter::default();
+            let _ = c.visit_program(program);
+            assert_eq!(c.match_arms, 3);
+        },
+    );
+}
+
+#[test]
+fn walks_catch_clauses() {
+    with_parsed(
+        "<?php try {
+            foo();
+        } catch (RuntimeException $e) {
+            bar();
+        } catch (LogicException $e) {
+            baz();
+        } finally {
+            cleanup();
+        }",
+        |program| {
+            let mut c = NodeCounter::default();
+            let _ = c.visit_program(program);
+            assert_eq!(c.catch_clauses, 2);
+        },
+    );
+}
+
+#[test]
+fn walks_closure_use_vars() {
+    with_parsed(
+        "<?php $f = function() use ($x, &$y) { return $x + $y; };",
+        |program| {
+            let mut c = NodeCounter::default();
+            let _ = c.visit_program(program);
+            assert_eq!(c.closure_use_vars, 2);
+        },
+    );
+}
+
+#[test]
+fn walks_attributes() {
+    with_parsed(
+        "<?php
+        #[Route('/api')]
+        #[Auth('admin')]
+        function handler(#[FromQuery] int $page): void {}",
+        |program| {
+            let mut c = NodeCounter::default();
+            let _ = c.visit_program(program);
+            assert_eq!(c.attributes, 3); // Route, Auth, FromQuery
+        },
+    );
+}
+
+#[test]
+fn walks_union_and_nullable_types() {
+    with_parsed(
+        "<?php function foo(?int $a, string|int $b): bool|null {}",
+        |program| {
+            let mut c = NodeCounter::default();
+            let _ = c.visit_program(program);
+            // ?int(2) + string|int(3) + bool|null(3) = 8
+            assert_eq!(c.type_hints, 8);
+        },
+    );
+}
+
+#[test]
+fn walks_arrow_function() {
+    with_parsed("<?php $f = fn(int $x): int => $x * 2;", |program| {
+        let mut c = NodeCounter::default();
+        let _ = c.visit_program(program);
+        assert_eq!(c.params, 1);
+        assert_eq!(c.type_hints, 2); // param + return
+    });
+}
+
+#[test]
+fn walks_named_args() {
+    with_parsed(
+        "<?php array_slice(array: $a, offset: 1, length: 2);",
+        |program| {
+            let mut c = NodeCounter::default();
+            let _ = c.visit_program(program);
+            assert_eq!(c.args, 3);
+        },
+    );
+}
+
+#[test]
+fn early_break_stops_traversal() {
+    with_parsed(
+        "<?php
+        $first = 1;
+        $second = 2;
+        $third = 3;",
+        |program| {
+            struct StopAfterFirst {
+                var_count: usize,
+            }
+            impl<'arena, 'src> Visitor<'arena, 'src> for StopAfterFirst {
+                fn visit_expr(&mut self, expr: &Expr<'arena, 'src>) -> ControlFlow<()> {
+                    if matches!(&expr.kind, ExprKind::Variable(_)) {
+                        self.var_count += 1;
+                        if self.var_count == 1 {
+                            return ControlFlow::Break(());
+                        }
+                    }
+                    visitor::walk_expr(self, expr)
+                }
+            }
+
+            let mut v = StopAfterFirst { var_count: 0 };
+            let result = v.visit_program(program);
+            assert!(result.is_break());
+            assert_eq!(v.var_count, 1);
+        },
+    );
+}
+
+#[test]
+fn walks_nested_closures_and_control_flow() {
+    with_parsed(
+        "<?php
+        $outer = 1;
+        $f = function($x) use ($outer) {
+            if ($x > 0) {
+                for ($i = 0; $i < $x; $i++) {
+                    echo $i;
+                }
+            }
+            return fn($y) => $y + $outer;
+        };",
+        |program| {
+            struct VarCollector {
+                names: Vec<String>,
+            }
+            impl<'arena, 'src> Visitor<'arena, 'src> for VarCollector {
+                fn visit_expr(&mut self, expr: &Expr<'arena, 'src>) -> ControlFlow<()> {
+                    if let ExprKind::Variable(name) = &expr.kind {
+                        self.names.push(name.to_string());
+                    }
+                    visitor::walk_expr(self, expr)
+                }
+            }
+
+            let mut v = VarCollector { names: vec![] };
+            let _ = v.visit_program(program);
+            assert!(v.names.contains(&"outer".to_string()));
+            assert!(v.names.contains(&"x".to_string()));
+            assert!(v.names.contains(&"i".to_string()));
+            assert!(v.names.contains(&"y".to_string()));
+            assert!(v.names.contains(&"f".to_string()));
+            assert!(v.names.len() >= 10);
+        },
+    );
+}
+
+#[test]
+fn walks_try_catch_switch_and_foreach() {
+    with_parsed(
+        "<?php
+        foreach ($items as $key => $value) {
+            switch ($value) {
+                case 1: break;
+                default: break;
+            }
+            try {
+                process($key);
+            } catch (Exception $e) {
+                log($e);
+            }
+        }",
+        |program| {
+            let mut c = NodeCounter::default();
+            let _ = c.visit_program(program);
+            assert_eq!(c.catch_clauses, 1);
+            assert!(c.stmts >= 5);
+            assert!(c.exprs >= 5);
+        },
+    );
+}
+
+#[test]
+fn walks_class_property_and_method_types() {
+    with_parsed(
+        "<?php class Repo {
+            private string $name;
+            protected ?int $count;
+            public function find(int $id): ?self {}
+        }",
+        |program| {
+            struct TypeCollector {
+                types: Vec<String>,
+            }
+            impl<'arena, 'src> Visitor<'arena, 'src> for TypeCollector {
+                fn visit_type_hint(&mut self, th: &TypeHint<'arena, 'src>) -> ControlFlow<()> {
+                    match &th.kind {
+                        TypeHintKind::Keyword(builtin, _) => {
+                            self.types.push(builtin.as_str().to_string());
+                        }
+                        TypeHintKind::Named(name) => {
+                            self.types.push(name.to_string_repr().to_string());
+                        }
+                        _ => {}
+                    }
+                    visitor::walk_type_hint(self, th)
+                }
+            }
+
+            let mut c = TypeCollector { types: vec![] };
+            let _ = c.visit_program(program);
+            assert!(c.types.contains(&"string".to_string()));
+            assert!(c.types.contains(&"int".to_string()));
+            assert!(c.types.contains(&"self".to_string()));
+        },
+    );
+}
+
+#[test]
+fn walks_declare_directive_expressions() {
+    with_parsed("<?php declare(strict_types=1);", |program| {
+        let mut c = NodeCounter::default();
+        let _ = c.visit_program(program);
+        assert!(c.exprs >= 1); // the `1` in strict_types=1
+    });
+}

--- a/docs/architecture/ROADMAP.md
+++ b/docs/architecture/ROADMAP.md
@@ -18,24 +18,15 @@ Attach comments to AST nodes instead of discarding them during lexing.
 
 **Blockers:** None.
 
-### 1.2 Visitor / Walker API
+### 1.2 Visitor / Walker API ✅
 
 Trait-based AST traversal for analysis and transformation passes.
 
-**Enables:** semantic analysis, linters, codemods, pretty printer, symbol extraction for LSP.
+**Status:** Complete. `Visitor` trait with `ControlFlow<()>` return for early termination and subtree skipping. Visit methods for all node types: statements, expressions, params, args, class/enum members, property hooks, type hints, attributes, catch clauses, match arms, closure use vars. Corresponding `walk_*` free functions for each. Walks type hints (including union/intersection/nullable), attributes, and declare directives that were previously skipped.
 
-**Scope:**
-- `Visitor` trait with `visit_stmt`, `visit_expr`, `visit_type_hint`, etc., with default implementations that recurse
-- `walk_*` free functions that drive the recursion
-- Mutable variant (`VisitorMut` or `Fold`) for AST transformations
-- Derive or hand-write traversal for every AST node
+**Remaining:** `VisitorMut`/`Fold` for AST transformations is deferred — arena allocation (`&'arena`) makes in-place mutation of pointer-behind fields unsound. A `Fold` that rebuilds nodes into a new arena is the correct approach but requires a separate design.
 
-**Difficulties:**
-- **AST size** — 30+ statement kinds, 50+ expression kinds, plus OOP members, params, type hints, match arms, etc. Every variant needs a walk arm. Large, mechanical, error-prone.
-- **Ownership** — a read-only `Visitor<'ast>` taking `&'ast Node` is straightforward. A mutable `Fold` that returns owned nodes requires moving values. Consider providing both.
-- **Traversal control** — callers need to skip subtrees or stop early. A `ControlFlow`-style return type is needed.
-
-**Blockers:** None — can start in parallel with 1.1.
+**Blockers:** None.
 
 ### 1.3 PHP Version Selection ✅
 
@@ -71,7 +62,7 @@ Scope tracking, name resolution, and type checking as a separate pass over the A
 - **Standard library** — type information for 5000+ built-in functions requires a stubs database (phpstorm-stubs or php-src).
 - **Trait resolution** — `insteadof` and `as` create complex method resolution orders.
 
-**Blockers:** Visitor API (1.2). Comment preservation (1.1) is complete, including PHPDoc parsing for doc-block types.
+**Blockers:** None. Visitor API (1.2) and Comment preservation (1.1) are both complete.
 
 ### 2.2 Pretty Printer
 
@@ -91,7 +82,7 @@ AST-to-source output for code generation and refactoring tools.
 - **Comment placement** — printing comments in the right location (before/after/inline) is one of the hardest problems in pretty printers.
 - **Large surface area** — every AST node needs a print implementation.
 
-**Blockers:** Visitor API (1.2). Comment preservation (1.1) is complete.
+**Blockers:** None. Visitor API (1.2) and Comment preservation (1.1) are both complete.
 
 ---
 
@@ -121,7 +112,7 @@ Use the parser as a backend for a PHP Language Server.
 - **Multi-file analysis** — go-to-definition for imported classes requires a project indexer watching the filesystem.
 - **Concurrency** — LSP requests arrive concurrently; the server must handle cancellation and concurrent AST access.
 
-**Blockers:** Semantic analysis (2.1) for anything beyond basic diagnostics. Pretty printer (2.2) for formatting. Comment preservation (1.1) is complete.
+**Blockers:** Semantic analysis (2.1) for anything beyond basic diagnostics. Pretty printer (2.2) for formatting.
 
 ### 3.2 Incremental Parsing
 
@@ -169,16 +160,16 @@ Compile to WebAssembly for browser-based PHP tooling.
 ### Dependency Graph
 
 ```
-1.1 Comment Preservation ✅ ───────────┐
-                                       ├──→ 2.2 Pretty Printer ──→ 3.1 LSP ──→ 3.2 Incremental
-1.2 Visitor / Walker API ──┬───────────┘                             ↑
-                           └──→ 2.1 Semantic Analysis ───────────────┘
+1.1 Comment Preservation ✅ ────────────┐
+                                        ├──→ 2.2 Pretty Printer ──→ 3.1 LSP ──→ 3.2 Incremental
+1.2 Visitor / Walker API ✅ ──┬─────────┘                             ↑
+                              └──→ 2.1 Semantic Analysis ─────────────┘
 1.3 PHP Version Selection ✅
 
 3.3 WASM Target (independent, improves with 2.2)
 ```
 
-**Next up:** Visitor / Walker API (1.2) is the critical-path item — it unblocks both semantic analysis and the pretty printer.
+**Phase 1 complete.** Phase 2 features (semantic analysis, pretty printer) are now unblocked.
 
 **Note:** Performance optimization is tracked separately in `PERFORMANCE_ANALYSIS.md` and is ongoing independent of feature phases.
 
@@ -193,7 +184,7 @@ Compile to WebAssembly for browser-based PHP tooling.
 | Feature | Complexity | Estimate |
 |---------|------------|----------|
 | 1.1 Comment Preservation | ✅ Complete | Includes PHPDoc parser + Psalm/PHPStan annotations |
-| 1.2 Visitor / Walker API | Medium | ~800–1200 lines (mechanical but large) |
+| 1.2 Visitor / Walker API | ✅ Complete | ControlFlow support, type hints, attributes, 13 visit methods |
 | 1.3 PHP Version Selection | ✅ Complete | Full version gating for all version-specific syntax |
 | 2.1 Semantic Analysis | Very High | ~3000–5000+ lines (open-ended) |
 | 2.2 Pretty Printer | High | ~2000–3000 lines |


### PR DESCRIPTION
## Summary

- Add `ControlFlow<()>` return type to all visitor methods, enabling early termination (`Break`) and subtree skipping
- Add 5 new visit hooks: `visit_type_hint`, `visit_attribute`, `visit_catch_clause`, `visit_match_arm`, `visit_closure_use_var` (8 → 13 methods)
- Walk type hints, attributes, declare directives, and closure use vars that were previously skipped
- Extract `walk_function_like`, `walk_method_decl`, `walk_class_const_decl`, `walk_property_decl` helpers to eliminate duplicated walking logic across class members, enum members, and function-like constructs
- Add 15 integration tests that parse real PHP source and walk the AST with visitors
- Fix doc example to compile (was `ignore`)
- Update ROADMAP.md: mark Phase 1 complete (1.1 ✅, 1.2 ✅, 1.3 ✅), update blockers and dependency graph

## Test plan

- [x] All 3 unit tests in `php-ast` pass (variable counting, early termination, subtree skipping)
- [x] All 15 integration tests in `visitor.rs` pass (params, class members, enums, match arms, catch clauses, closure use vars, attributes, union/nullable types, arrow functions, named args, early break, nested closures, control flow, property/method types, declare directives)
- [x] All 414 existing tests pass with zero regressions
- [x] Doc example compiles successfully
- [x] Pre-commit hooks pass (fmt + clippy)