### PR TITLE
Release v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -24,10 +24,10 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.3.3" }
-php-lexer = { path = "crates/php-lexer", version = "0.3.3" }
-php-rs-parser = { path = "crates/php-parser", version = "0.3.3" }
-php-printer = { path = "crates/php-printer", version = "0.3.3" }
+php-ast = { path = "crates/php-ast", version = "0.4.0" }
+php-lexer = { path = "crates/php-lexer", version = "0.4.0" }
+php-rs-parser = { path = "crates/php-parser", version = "0.4.0" }
+php-printer = { path = "crates/php-printer", version = "0.4.0" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

Bump version to 0.4.0. Changes since v0.3.3:

### New features
- **Pretty printer** — new `php-printer` crate for AST-to-PHP source output with round-trip verification
- **LSP foundation utilities** — source map, comment map, and symbol table in `php-ast`
- **PHPDoc parser** — structured doc-comment extraction with Psalm/PHPStan annotation support
- **Doc comment attachment** — doc comments attached to declaration nodes
- **Visitor API improvements** — `ControlFlow`, type hints, attributes, 13 visit methods
- **Complete PHP version gating** — all version-specific syntax properly gated

### Fixes
- Handle unbraced namespaces in symbol table
- Readonly anonymous class requires PHP 8.3
- Various `min_php` annotation fixes for fixtures

### Refactoring
- All tests migrated to `.phpt` fixture files
- Eliminated all `.snap` files, removed `insta` dependency
- Replaced `lazy_static` with `std::sync::OnceLock`
- Public API rustdoc documentation

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean