### PR TITLE
release: v0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -24,10 +24,10 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.4.0" }
-php-lexer = { path = "crates/php-lexer", version = "0.4.0" }
-php-rs-parser = { path = "crates/php-parser", version = "0.4.0" }
-php-printer = { path = "crates/php-printer", version = "0.4.0" }
+php-ast = { path = "crates/php-ast", version = "0.5.0" }
+php-lexer = { path = "crates/php-lexer", version = "0.5.0" }
+php-rs-parser = { path = "crates/php-parser", version = "0.5.0" }
+php-printer = { path = "crates/php-printer", version = "0.5.0" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Changes since v0.4.0

### Features
- **`ParseResult` now includes `source` and `source_map`** (#120) — consumers get the original source text and a pre-built `SourceMap` for line/column resolution without extra setup

### Bug fixes
- **Emit error for unterminated block comments** (#122) — `/* ...` without closing `*/` now produces an "unterminated block comment" diagnostic instead of silently consuming the rest of the file