### PR TITLE
test: include corpus fixtures in php -l validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ The parser prioritizes performance on contemporary PHP patterns:
 
 ```sh
 cargo test --test integration   # all .phpt fixture tests (including corpus)
+cargo test --test php_syntax    # validate fixtures via php -l
 cargo test --test malformed_php # error recovery and diagnostics
 ```
 
-Fixture files live in `crates/php-parser/tests/fixtures/`.
+Fixture files live in `crates/php-parser/tests/fixtures/`. All fixtures are validated against `php -l` in CI across PHP 8.2–8.5. Fixtures using version-gated syntax should include a `===config===` section with `min_php=X.Y`.
 
 ## Documentation
 

--- a/crates/php-parser/src/parser.rs
+++ b/crates/php-parser/src/parser.rs
@@ -534,21 +534,22 @@ impl<'arena, 'src> Parser<'arena, 'src> {
         }
 
         // First part
-        let first: &'src str = if let Some((text, _)) = self.eat_identifier_or_keyword() {
-            text
-        } else {
-            self.error(ParseError::Expected {
-                expected: "identifier".into(),
-                found: self.current_kind(),
-                span: self.current_span(),
-            });
-            "<error>"
-        };
+        let (first, first_span): (&'src str, Span) =
+            if let Some((text, span)) = self.eat_identifier_or_keyword() {
+                (text, span)
+            } else {
+                self.error(ParseError::Expected {
+                    expected: "identifier".into(),
+                    found: self.current_kind(),
+                    span: self.current_span(),
+                });
+                ("<error>", self.current_span())
+            };
 
         // Fast path: single unqualified identifier (the common case, ~95% of names).
         // Avoids allocating an ArenaVec entirely.
         if !fully_qualified && !relative && !self.check(TokenKind::Backslash) {
-            let span = Span::new(start, self.current_span().start);
+            let span = Span::new(start, first_span.end);
             return Name::Simple { value: first, span };
         }
 
@@ -557,13 +558,15 @@ impl<'arena, 'src> Parser<'arena, 'src> {
         parts.push(first);
 
         // Subsequent parts: \Ident
+        let mut last_end = first_span.end;
         while self.eat(TokenKind::Backslash).is_some() {
-            if let Some((text, _)) = self.eat_identifier_or_keyword() {
+            if let Some((text, span)) = self.eat_identifier_or_keyword() {
                 parts.push(text);
+                last_end = span.end;
             }
         }
 
-        let span = Span::new(start, self.current_span().start);
+        let span = Span::new(start, last_end);
 
         let kind = if fully_qualified {
             NameKind::FullyQualified

--- a/crates/php-parser/tests/fixtures/anonymous_classes.phpt
+++ b/crates/php-parser/tests/fixtures/anonymous_classes.phpt
@@ -223,7 +223,7 @@ $obj = new class($x) extends Base implements Iface {
                             "kind": "Unqualified",
                             "span": {
                               "start": 148,
-                              "end": 152
+                              "end": 151
                             }
                           },
                           "implements": [],
@@ -303,7 +303,7 @@ $obj = new class($x) extends Base implements Iface {
                               "kind": "Unqualified",
                               "span": {
                                 "start": 209,
-                                "end": 213
+                                "end": 212
                               }
                             }
                           ],
@@ -495,7 +495,7 @@ $obj = new class($x) extends Base implements Iface {
                             "kind": "Unqualified",
                             "span": {
                               "start": 422,
-                              "end": 427
+                              "end": 426
                             }
                           },
                           "implements": [
@@ -506,7 +506,7 @@ $obj = new class($x) extends Base implements Iface {
                               "kind": "Unqualified",
                               "span": {
                                 "start": 438,
-                                "end": 444
+                                "end": 443
                               }
                             }
                           ],

--- a/crates/php-parser/tests/fixtures/catch_four_type_union.phpt
+++ b/crates/php-parser/tests/fixtures/catch_four_type_union.phpt
@@ -81,7 +81,7 @@ try {
                   "kind": "Unqualified",
                   "span": {
                     "start": 72,
-                    "end": 87
+                    "end": 86
                   }
                 }
               ],

--- a/crates/php-parser/tests/fixtures/catch_three_type_union.phpt
+++ b/crates/php-parser/tests/fixtures/catch_three_type_union.phpt
@@ -71,7 +71,7 @@ try {
                   "kind": "Unqualified",
                   "span": {
                     "start": 38,
-                    "end": 40
+                    "end": 39
                   }
                 }
               ],

--- a/crates/php-parser/tests/fixtures/categories/class/abstract_with_interface.phpt
+++ b/crates/php-parser/tests/fixtures/categories/class/abstract_with_interface.phpt
@@ -31,7 +31,7 @@
               "kind": "Unqualified",
               "span": {
                 "start": 41,
-                "end": 45
+                "end": 44
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/categories/class/anon_class_full.phpt
+++ b/crates/php-parser/tests/fixtures/categories/class/anon_class_full.phpt
@@ -37,7 +37,7 @@
                             "kind": "Unqualified",
                             "span": {
                               "start": 34,
-                              "end": 39
+                              "end": 38
                             }
                           },
                           "implements": [
@@ -58,7 +58,7 @@
                               "kind": "Unqualified",
                               "span": {
                                 "start": 58,
-                                "end": 65
+                                "end": 64
                               }
                             }
                           ],

--- a/crates/php-parser/tests/fixtures/categories/class/class_extends_base.phpt
+++ b/crates/php-parser/tests/fixtures/categories/class/class_extends_base.phpt
@@ -1,0 +1,41 @@
+===source===
+<?php class Incomplete extends Base {
+}
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Incomplete",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": {
+            "parts": [
+              "Base"
+            ],
+            "kind": "Unqualified",
+            "span": {
+              "start": 31,
+              "end": 36
+            }
+          },
+          "implements": [],
+          "members": [],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 39
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 39
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/class/class_extends_base.phpt
+++ b/crates/php-parser/tests/fixtures/categories/class/class_extends_base.phpt
@@ -20,7 +20,7 @@
             "kind": "Unqualified",
             "span": {
               "start": 31,
-              "end": 36
+              "end": 35
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/categories/class/interface_extends_multi.phpt
+++ b/crates/php-parser/tests/fixtures/categories/class/interface_extends_multi.phpt
@@ -25,7 +25,7 @@
               "kind": "Unqualified",
               "span": {
                 "start": 33,
-                "end": 37
+                "end": 36
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/categories/control_flow/empty_braced_ns.phpt
+++ b/crates/php-parser/tests/fixtures/categories/control_flow/empty_braced_ns.phpt
@@ -13,7 +13,7 @@
             "kind": "Unqualified",
             "span": {
               "start": 16,
-              "end": 18
+              "end": 17
             }
           },
           "body": {

--- a/crates/php-parser/tests/fixtures/categories/control_flow/multiple_braced_ns.phpt
+++ b/crates/php-parser/tests/fixtures/categories/control_flow/multiple_braced_ns.phpt
@@ -13,7 +13,7 @@
             "kind": "Unqualified",
             "span": {
               "start": 16,
-              "end": 18
+              "end": 17
             }
           },
           "body": {
@@ -53,7 +53,7 @@
             "kind": "Unqualified",
             "span": {
               "start": 50,
-              "end": 52
+              "end": 51
             }
           },
           "body": {

--- a/crates/php-parser/tests/fixtures/categories/degenerate/empty_input.phpt
+++ b/crates/php-parser/tests/fixtures/categories/degenerate/empty_input.phpt
@@ -1,0 +1,10 @@
+===source===
+
+===ast===
+{
+  "stmts": [],
+  "span": {
+    "start": 0,
+    "end": 0
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/degenerate/only_open_tag.phpt
+++ b/crates/php-parser/tests/fixtures/categories/degenerate/only_open_tag.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+===ast===
+{
+  "stmts": [],
+  "span": {
+    "start": 0,
+    "end": 5
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/degenerate/only_semicolons.phpt
+++ b/crates/php-parser/tests/fixtures/categories/degenerate/only_semicolons.phpt
@@ -1,0 +1,67 @@
+===source===
+<?php ;;;;;;;;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": "Nop",
+      "span": {
+        "start": 6,
+        "end": 7
+      }
+    },
+    {
+      "kind": "Nop",
+      "span": {
+        "start": 7,
+        "end": 8
+      }
+    },
+    {
+      "kind": "Nop",
+      "span": {
+        "start": 8,
+        "end": 9
+      }
+    },
+    {
+      "kind": "Nop",
+      "span": {
+        "start": 9,
+        "end": 10
+      }
+    },
+    {
+      "kind": "Nop",
+      "span": {
+        "start": 10,
+        "end": 11
+      }
+    },
+    {
+      "kind": "Nop",
+      "span": {
+        "start": 11,
+        "end": 12
+      }
+    },
+    {
+      "kind": "Nop",
+      "span": {
+        "start": 12,
+        "end": 13
+      }
+    },
+    {
+      "kind": "Nop",
+      "span": {
+        "start": 13,
+        "end": 14
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 14
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/degenerate/only_whitespace_after_open_tag.phpt
+++ b/crates/php-parser/tests/fixtures/categories/degenerate/only_whitespace_after_open_tag.phpt
@@ -1,0 +1,13 @@
+===source===
+<?php   
+
+
+  
+===ast===
+{
+  "stmts": [],
+  "span": {
+    "start": 0,
+    "end": 13
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/enum/backed_enum_int.phpt
+++ b/crates/php-parser/tests/fixtures/categories/enum/backed_enum_int.phpt
@@ -16,7 +16,7 @@ min_php=8.1
             "kind": "Unqualified",
             "span": {
               "start": 19,
-              "end": 23
+              "end": 22
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/categories/enum/enum_const.phpt
+++ b/crates/php-parser/tests/fixtures/categories/enum/enum_const.phpt
@@ -16,7 +16,7 @@ min_php=8.1
             "kind": "Unqualified",
             "span": {
               "start": 17,
-              "end": 24
+              "end": 23
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/categories/enum/enum_implements.phpt
+++ b/crates/php-parser/tests/fixtures/categories/enum/enum_implements.phpt
@@ -18,7 +18,7 @@ min_php=8.1
               "kind": "Unqualified",
               "span": {
                 "start": 28,
-                "end": 37
+                "end": 36
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/categories/enum/enum_interface_method.phpt
+++ b/crates/php-parser/tests/fixtures/categories/enum/enum_interface_method.phpt
@@ -16,7 +16,7 @@ min_php=8.1
             "kind": "Unqualified",
             "span": {
               "start": 17,
-              "end": 24
+              "end": 23
             }
           },
           "implements": [
@@ -27,7 +27,7 @@ min_php=8.1
               "kind": "FullyQualified",
               "span": {
                 "start": 35,
-                "end": 47
+                "end": 46
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/categories/enum_in_match/backed_enum_in_match.phpt
+++ b/crates/php-parser/tests/fixtures/categories/enum_in_match/backed_enum_in_match.phpt
@@ -16,7 +16,7 @@ min_php=8.1
             "kind": "Unqualified",
             "span": {
               "start": 18,
-              "end": 25
+              "end": 24
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/categories/function/intersection_param.phpt
+++ b/crates/php-parser/tests/fixtures/categories/function/intersection_param.phpt
@@ -40,20 +40,20 @@
                           "kind": "Unqualified",
                           "span": {
                             "start": 29,
-                            "end": 41
+                            "end": 40
                           }
                         }
                       },
                       "span": {
                         "start": 29,
-                        "end": 41
+                        "end": 40
                       }
                     }
                   ]
                 },
                 "span": {
                   "start": 19,
-                  "end": 41
+                  "end": 40
                 }
               },
               "default": null,

--- a/crates/php-parser/tests/fixtures/categories/phpdoc/param_return_throws.phpt
+++ b/crates/php-parser/tests/fixtures/categories/phpdoc/param_return_throws.phpt
@@ -94,13 +94,13 @@ function createUser(string $name, int $age): User {}
                 "kind": "Unqualified",
                 "span": {
                   "start": 195,
-                  "end": 200
+                  "end": 199
                 }
               }
             },
             "span": {
               "start": 195,
-              "end": 200
+              "end": 199
             }
           },
           "by_ref": false,

--- a/crates/php-parser/tests/fixtures/categories/phpdoc/phpdoc_function_tags.phpt
+++ b/crates/php-parser/tests/fixtures/categories/phpdoc/phpdoc_function_tags.phpt
@@ -94,13 +94,13 @@ function createUser(string $name, int $age): User {}
                 "kind": "Unqualified",
                 "span": {
                   "start": 195,
-                  "end": 200
+                  "end": 199
                 }
               }
             },
             "span": {
               "start": 195,
-              "end": 200
+              "end": 199
             }
           },
           "by_ref": false,

--- a/crates/php-parser/tests/fixtures/categories/scope_resolution/parent_const.phpt
+++ b/crates/php-parser/tests/fixtures/categories/scope_resolution/parent_const.phpt
@@ -19,7 +19,7 @@
             "kind": "Unqualified",
             "span": {
               "start": 24,
-              "end": 28
+              "end": 27
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/categories/scope_resolution/parent_method.phpt
+++ b/crates/php-parser/tests/fixtures/categories/scope_resolution/parent_method.phpt
@@ -19,7 +19,7 @@
             "kind": "Unqualified",
             "span": {
               "start": 24,
-              "end": 28
+              "end": 27
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/categories/trait_use/alias_qualified_method.phpt
+++ b/crates/php-parser/tests/fixtures/categories/trait_use/alias_qualified_method.phpt
@@ -26,7 +26,7 @@
                       "kind": "Unqualified",
                       "span": {
                         "start": 20,
-                        "end": 22
+                        "end": 21
                       }
                     }
                   ],

--- a/crates/php-parser/tests/fixtures/categories/trait_use/alias_qualified_with_visibility.phpt
+++ b/crates/php-parser/tests/fixtures/categories/trait_use/alias_qualified_with_visibility.phpt
@@ -26,7 +26,7 @@
                       "kind": "Unqualified",
                       "span": {
                         "start": 20,
-                        "end": 22
+                        "end": 21
                       }
                     }
                   ],

--- a/crates/php-parser/tests/fixtures/categories/trait_use/alias_visibility_only.phpt
+++ b/crates/php-parser/tests/fixtures/categories/trait_use/alias_visibility_only.phpt
@@ -26,7 +26,7 @@
                       "kind": "Unqualified",
                       "span": {
                         "start": 20,
-                        "end": 22
+                        "end": 21
                       }
                     }
                   ],

--- a/crates/php-parser/tests/fixtures/categories/trait_use/insteadof_multi.phpt
+++ b/crates/php-parser/tests/fixtures/categories/trait_use/insteadof_multi.phpt
@@ -36,7 +36,7 @@
                       "kind": "Unqualified",
                       "span": {
                         "start": 23,
-                        "end": 25
+                        "end": 24
                       }
                     }
                   ],

--- a/crates/php-parser/tests/fixtures/categories/trait_use/multiple_adaptations.phpt
+++ b/crates/php-parser/tests/fixtures/categories/trait_use/multiple_adaptations.phpt
@@ -36,7 +36,7 @@
                       "kind": "Unqualified",
                       "span": {
                         "start": 23,
-                        "end": 25
+                        "end": 24
                       }
                     }
                   ],

--- a/crates/php-parser/tests/fixtures/categories/try_catch/catch_rethrow.phpt
+++ b/crates/php-parser/tests/fixtures/categories/try_catch/catch_rethrow.phpt
@@ -46,7 +46,7 @@
                   "kind": "Unqualified",
                   "span": {
                     "start": 28,
-                    "end": 38
+                    "end": 37
                   }
                 }
               ],

--- a/crates/php-parser/tests/fixtures/categories/try_catch/multi_catch_blocks.phpt
+++ b/crates/php-parser/tests/fixtures/categories/try_catch/multi_catch_blocks.phpt
@@ -46,7 +46,7 @@
                   "kind": "Unqualified",
                   "span": {
                     "start": 28,
-                    "end": 30
+                    "end": 29
                   }
                 }
               ],
@@ -66,7 +66,7 @@
                   "kind": "Unqualified",
                   "span": {
                     "start": 45,
-                    "end": 47
+                    "end": 46
                   }
                 }
               ],
@@ -86,7 +86,7 @@
                   "kind": "Unqualified",
                   "span": {
                     "start": 62,
-                    "end": 64
+                    "end": 63
                   }
                 }
               ],

--- a/crates/php-parser/tests/fixtures/categories/try_catch/multi_catch_no_var.phpt
+++ b/crates/php-parser/tests/fixtures/categories/try_catch/multi_catch_no_var.phpt
@@ -46,7 +46,7 @@
                   "kind": "Unqualified",
                   "span": {
                     "start": 28,
-                    "end": 38
+                    "end": 37
                   }
                 },
                 {

--- a/crates/php-parser/tests/fixtures/categories/try_catch/multi_catch_types.phpt
+++ b/crates/php-parser/tests/fixtures/categories/try_catch/multi_catch_types.phpt
@@ -46,7 +46,7 @@
                   "kind": "Unqualified",
                   "span": {
                     "start": 28,
-                    "end": 38
+                    "end": 37
                   }
                 },
                 {
@@ -56,7 +56,7 @@
                   "kind": "Unqualified",
                   "span": {
                     "start": 40,
-                    "end": 51
+                    "end": 50
                   }
                 }
               ],

--- a/crates/php-parser/tests/fixtures/categories/type_hints/dnf_complex.phpt
+++ b/crates/php-parser/tests/fixtures/categories/type_hints/dnf_complex.phpt
@@ -68,20 +68,20 @@
                           "kind": "Unqualified",
                           "span": {
                             "start": 23,
-                            "end": 25
+                            "end": 24
                           }
                         }
                       },
                       "span": {
                         "start": 23,
-                        "end": 25
+                        "end": 24
                       }
                     }
                   ]
                 },
                 "span": {
                   "start": 17,
-                  "end": 25
+                  "end": 24
                 }
               },
               "default": null,

--- a/crates/php-parser/tests/fixtures/categories/type_hints/parent_type.phpt
+++ b/crates/php-parser/tests/fixtures/categories/type_hints/parent_type.phpt
@@ -19,7 +19,7 @@
             "kind": "Unqualified",
             "span": {
               "start": 24,
-              "end": 28
+              "end": 27
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/categories/type_hints/three_intersection.phpt
+++ b/crates/php-parser/tests/fixtures/categories/type_hints/three_intersection.phpt
@@ -58,20 +58,20 @@
                           "kind": "Unqualified",
                           "span": {
                             "start": 39,
-                            "end": 51
+                            "end": 50
                           }
                         }
                       },
                       "span": {
                         "start": 39,
-                        "end": 51
+                        "end": 50
                       }
                     }
                   ]
                 },
                 "span": {
                   "start": 17,
-                  "end": 51
+                  "end": 50
                 }
               },
               "default": null,

--- a/crates/php-parser/tests/fixtures/chained_arrow_functions_with_type_hints.phpt
+++ b/crates/php-parser/tests/fixtures/chained_arrow_functions_with_type_hints.phpt
@@ -50,13 +50,13 @@
                           "kind": "Unqualified",
                           "span": {
                             "start": 20,
-                            "end": 28
+                            "end": 27
                           }
                         }
                       },
                       "span": {
                         "start": 20,
-                        "end": 28
+                        "end": 27
                       }
                     },
                     "body": {

--- a/crates/php-parser/tests/fixtures/class_extends_implements.phpt
+++ b/crates/php-parser/tests/fixtures/class_extends_implements.phpt
@@ -135,7 +135,7 @@ class User extends Model implements Loggable, Serializable {
             "kind": "Unqualified",
             "span": {
               "start": 149,
-              "end": 155
+              "end": 154
             }
           },
           "implements": [
@@ -156,7 +156,7 @@ class User extends Model implements Loggable, Serializable {
               "kind": "Unqualified",
               "span": {
                 "start": 176,
-                "end": 189
+                "end": 188
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/complex_union_and_intersection_types.phpt
+++ b/crates/php-parser/tests/fixtures/complex_union_and_intersection_types.phpt
@@ -49,20 +49,20 @@ class Container {
                           "kind": "Unqualified",
                           "span": {
                             "start": 37,
-                            "end": 49
+                            "end": 48
                           }
                         }
                       },
                       "span": {
                         "start": 37,
-                        "end": 49
+                        "end": 48
                       }
                     }
                   ]
                 },
                 "span": {
                   "start": 27,
-                  "end": 49
+                  "end": 48
                 }
               },
               "default": null,
@@ -205,20 +205,20 @@ class Container {
                                   "kind": "Unqualified",
                                   "span": {
                                     "start": 174,
-                                    "end": 183
+                                    "end": 182
                                   }
                                 }
                               },
                               "span": {
                                 "start": 174,
-                                "end": 183
+                                "end": 182
                               }
                             }
                           ]
                         },
                         "span": {
                           "start": 164,
-                          "end": 183
+                          "end": 182
                         }
                       },
                       "default": null,

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/eofError_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/eofError_1.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php foo
 ===errors===
+expected ';' after expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/eofError_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/eofError_2.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php foo /* bar */
 ===errors===
+expected ';' after expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/lexerErrors_5.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/lexerErrors_5.phpt
@@ -6,6 +6,8 @@ if ($b) {
     /* unterminated
 }
 ===errors===
+unterminated block comment
+unclosed ''}'' opened at Span { start: 15, end: 16 }
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_1.phpt
@@ -5,6 +5,9 @@ foo()
 bar()
 baz()
 ===errors===
+expected ';' after expression
+expected ';' after expression
+expected ';' after expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_10.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_10.phpt
@@ -4,6 +4,8 @@ function foo() {
     $bar->
 }
 ===errors===
+expected member name, found '}'
+expected ';' after expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_11.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_11.phpt
@@ -2,6 +2,7 @@
 <?php
 new T
 ===errors===
+expected ';' after expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_12.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_12.phpt
@@ -2,6 +2,8 @@
 <?php
 new
 ===errors===
+expected identifier, found end of file
+expected ';' after expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_13.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_13.phpt
@@ -2,6 +2,8 @@
 <?php
 $foo instanceof
 ===errors===
+expected expression
+expected ';' after expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_14.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_14.phpt
@@ -2,6 +2,8 @@
 <?php
 $
 ===errors===
+expected expression
+expected ';' after expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_15.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_15.phpt
@@ -2,6 +2,8 @@
 <?php
 Foo::$
 ===errors===
+expected expression
+expected ';' after expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_16.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_16.phpt
@@ -2,6 +2,8 @@
 <?php
 Foo::
 ===errors===
+expected identifier, found end of file
+expected ';' after expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_17.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_17.phpt
@@ -16,6 +16,24 @@ unset($a)
 throw $x
 goto label
 ===errors===
+expected ';', found 'use'
+expected ';', found 'use'
+expected ';', found 'use'
+expected ';', found 'const'
+expected ';', found 'break'
+expected expression
+expected ';' after break statement
+expected ';' after break statement
+expected expression
+expected ';' after continue statement
+expected ';' after continue statement
+expected expression
+expected ';' after return statement
+expected ';' after return statement
+expected ';' after echo statement
+expected ';', found 'throw'
+expected ';' after throw statement
+expected ';', found end of file
 ===ast===
 {
   "stmts": [
@@ -29,7 +47,7 @@ goto label
             "kind": "Unqualified",
             "span": {
               "start": 16,
-              "end": 20
+              "end": 19
             }
           },
           "body": "Simple"
@@ -53,7 +71,7 @@ goto label
                 "kind": "Unqualified",
                 "span": {
                   "start": 24,
-                  "end": 26
+                  "end": 25
                 }
               },
               "alias": null,
@@ -83,7 +101,7 @@ goto label
                 "kind": "Unqualified",
                 "span": {
                   "start": 39,
-                  "end": 41
+                  "end": 40
                 }
               },
               "alias": null,

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_19.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_19.phpt
@@ -3,6 +3,7 @@
 
 foo(Bar::);
 ===errors===
+expected identifier, found ')'
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_2.phpt
@@ -5,6 +5,7 @@ foo()
 bar();
 baz();
 ===errors===
+expected ';' after expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_20.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_20.phpt
@@ -7,6 +7,7 @@ class Foo {
     public $bar;
 }
 ===errors===
+expected modifier, found identifier
 ===ast===
 {
   "stmts": [
@@ -57,13 +58,13 @@ class Foo {
                         "kind": "Unqualified",
                         "span": {
                           "start": 41,
-                          "end": 47
+                          "end": 46
                         }
                       }
                     },
                     "span": {
                       "start": 41,
-                      "end": 47
+                      "end": 46
                     }
                   },
                   "default": null,

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_21.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_21.phpt
@@ -4,6 +4,9 @@
 foreach ($foo) { $bar; }
 foreach ($foo as ) { $bar; }
 ===errors===
+expected 'as', found ')'
+expected expression
+expected expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_22.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_22.phpt
@@ -25,6 +25,19 @@ class Bar {
 
 function(Foo);
 ===errors===
+expected variable, found ')'
+expected variable, found ')'
+expected variable, found ')'
+expected variable, found ')'
+expected variable, found ')'
+expected '{', found 'class'
+expected variable, found ')'
+expected ';', found '}'
+expected variable, found ')'
+expected '{', found ';'
+expected '}', found end of file
+expected ';' after expression
+unclosed ''}'' opened at Span { start: 171, end: 176 }
 ===ast===
 {
   "stmts": [
@@ -112,13 +125,13 @@ function(Foo);
                     "kind": "Unqualified",
                     "span": {
                       "start": 54,
-                      "end": 60
+                      "end": 59
                     }
                   }
                 },
                 "span": {
                   "start": 54,
-                  "end": 60
+                  "end": 59
                 }
               },
               "default": null,

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_23.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_23.phpt
@@ -10,6 +10,18 @@ $array = [
     'key' => $value $oopsAnotherValue
 ];
 ===errors===
+expected ']', found variable
+expected ';' after expression
+expected ';' after expression
+expected expression
+expected ']', found variable
+expected ';' after expression
+expected ';' after expression
+expected expression
+expected ']', found variable
+expected ';' after expression
+expected ';' after expression
+expected expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_24.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_24.phpt
@@ -5,6 +5,7 @@ function foo() :
     return $a;
 }
 ===errors===
+expected identifier, found '{'
 ===ast===
 {
   "stmts": [
@@ -41,13 +42,13 @@ function foo() :
                 "kind": "Unqualified",
                 "span": {
                   "start": 23,
-                  "end": 23
+                  "end": 24
                 }
               }
             },
             "span": {
               "start": 23,
-              "end": 23
+              "end": 24
             }
           },
           "by_ref": false,

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_25.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_25.phpt
@@ -2,6 +2,10 @@
 <?php
 $a = ["a "thing"];
 ===errors===
+expected ']', found identifier
+expected ';' after expression
+expected ';' after expression
+expected expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_26.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_26.phpt
@@ -12,6 +12,8 @@ class B {
     const X = 1
 }
 ===errors===
+expected ';', found 'public'
+expected ';', found '}'
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_3.phpt
@@ -5,6 +5,7 @@ foo();
 bar()
 baz();
 ===errors===
+expected ';' after expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_4.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_4.phpt
@@ -3,6 +3,7 @@
 abc;
 1 + ;
 ===errors===
+expected expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_5.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_5.phpt
@@ -4,6 +4,8 @@ function test() {
     1 +
 }
 ===errors===
+expected expression
+expected ';' after expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_6.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_6.phpt
@@ -7,6 +7,8 @@ while
 $j = 1;
 $k = 2;
 ===errors===
+expected '(', found variable
+unclosed '')'' opened at Span { start: 22, end: 24 }
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_7.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_7.phpt
@@ -8,6 +8,7 @@ while () {
 $k = 2;
 // The output here drops the loop - would require Error node to handle this
 ===errors===
+expected expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_8.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_8.phpt
@@ -8,6 +8,7 @@ while (true) {
     $i = 1;
     $i = 2;
 ===errors===
+unclosed ''}'' opened at Span { start: 118, end: 119 }
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_9.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_9.phpt
@@ -3,6 +3,7 @@
 $foo->
 ;
 ===errors===
+expected member name, found ';'
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/expr/arrayEmptyElemens.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/arrayEmptyElemens.phpt
@@ -4,6 +4,7 @@
 [1, , 2];
 array(1, , 2);
 ===errors===
+expected expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/expr/cast.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/cast.phpt
@@ -12,6 +12,7 @@
 (string)  $a;
 (unset)   $a;
 ===errors===
+the (unset) cast is no longer supported
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/expr/closure.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/closure.phpt
@@ -317,13 +317,13 @@ function() use($a) : \Foo\Bar {};
                     "kind": "FullyQualified",
                     "span": {
                       "start": 168,
-                      "end": 177
+                      "end": 176
                     }
                   }
                 },
                 "span": {
                   "start": 168,
-                  "end": 177
+                  "end": 176
                 }
               },
               "body": [],

--- a/crates/php-parser/tests/fixtures/corpus/expr/dynamicClassConst.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/dynamicClassConst.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php
 Foo::{bar()};

--- a/crates/php-parser/tests/fixtures/corpus/expr/exit.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/exit.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php
 exit;

--- a/crates/php-parser/tests/fixtures/corpus/expr/newDeref.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/newDeref.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/expr/newWithoutClass.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/newWithoutClass.phpt
@@ -2,6 +2,7 @@
 <?php
 new;
 ===errors===
+expected identifier, found ';'
 ===ast===
 {
   "stmts": [
@@ -16,7 +17,7 @@ new;
                 },
                 "span": {
                   "start": 9,
-                  "end": 9
+                  "end": 10
                 }
               },
               "args": []

--- a/crates/php-parser/tests/fixtures/corpus/expr/pipe.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/pipe.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.5
 ===source===
 <?php
 $a |> $b |> $c;

--- a/crates/php-parser/tests/fixtures/corpus/expr/uvs/globalNonSimpleVarError.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/uvs/globalNonSimpleVarError.phpt
@@ -2,6 +2,7 @@
 <?php
 global $$foo->bar;
 ===errors===
+expected variable, found ';'
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/scalar/numberSeparators.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/scalar/numberSeparators.phpt
@@ -20,6 +20,14 @@ _100;
 1_e2;
 1e_2;
 ===errors===
+Invalid numeric literal
+Invalid numeric literal
+Invalid numeric literal
+Invalid numeric literal
+Invalid numeric literal
+Invalid numeric literal
+Invalid numeric literal
+Invalid numeric literal
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/semiReserved.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/semiReserved.phpt
@@ -751,7 +751,7 @@ class Foo {
                       "kind": "Unqualified",
                       "span": {
                         "start": 551,
-                        "end": 558
+                        "end": 557
                       }
                     }
                   ],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/anonymous.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/anonymous.phpt
@@ -103,7 +103,7 @@ class A {
                       "kind": "Unqualified",
                       "span": {
                         "start": 70,
-                        "end": 72
+                        "end": 71
                       }
                     },
                     "implements": [
@@ -124,7 +124,7 @@ class A {
                         "kind": "Unqualified",
                         "span": {
                           "start": 86,
-                          "end": 88
+                          "end": 87
                         }
                       }
                     ],
@@ -230,7 +230,7 @@ class A {
                       "kind": "Unqualified",
                       "span": {
                         "start": 152,
-                        "end": 154
+                        "end": 153
                       }
                     },
                     "implements": [],
@@ -363,7 +363,7 @@ class A {
                                       "kind": "Unqualified",
                                       "span": {
                                         "start": 250,
-                                        "end": 252
+                                        "end": 251
                                       }
                                     },
                                     "implements": [],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_1.phpt
@@ -4,6 +4,7 @@ class A {
     static const X = 1;
 }
 ===errors===
+cannot use 'static' as constant modifier
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_2.phpt
@@ -4,6 +4,7 @@ class A {
     abstract const X = 1;
 }
 ===errors===
+cannot use 'abstract' as constant modifier
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_3.phpt
@@ -4,6 +4,7 @@ class A {
     readonly const X = 1;
 }
 ===errors===
+cannot use 'readonly' as constant modifier
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_4.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_4.phpt
@@ -4,6 +4,7 @@ class A {
     public public const X = 1;
 }
 ===errors===
+cannot use multiple visibility modifiers
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/enum.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/enum.phpt
@@ -10,6 +10,7 @@ enum C: int implements Bar {
     case Foo = 1;
 }
 ===errors===
+'class' cannot be used as an enum case name
 ===ast===
 {
   "stmts": [
@@ -65,7 +66,7 @@ enum C: int implements Bar {
               "kind": "Unqualified",
               "span": {
                 "start": 57,
-                "end": 61
+                "end": 60
               }
             }
           ],
@@ -89,7 +90,7 @@ enum C: int implements Bar {
             "kind": "Unqualified",
             "span": {
               "start": 73,
-              "end": 77
+              "end": 76
             }
           },
           "implements": [
@@ -100,7 +101,7 @@ enum C: int implements Bar {
               "kind": "Unqualified",
               "span": {
                 "start": 88,
-                "end": 92
+                "end": 91
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/enum_with_string.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/enum_with_string.phpt
@@ -22,7 +22,7 @@ enum Suit: string
             "kind": "Unqualified",
             "span": {
               "start": 18,
-              "end": 25
+              "end": 24
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/interface.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/interface.phpt
@@ -29,7 +29,7 @@ interface A extends C, D {
               "kind": "Unqualified",
               "span": {
                 "start": 30,
-                "end": 32
+                "end": 31
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_1.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class A { public public $a; }
 ===errors===
+cannot use multiple visibility modifiers
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_2.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class A { public protected $a; }
 ===errors===
+cannot use multiple visibility modifiers
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_3.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class C { readonly readonly $a; }
 ===errors===
+duplicate modifier 'readonly'
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_4.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_4.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class A { abstract abstract function a(); }
 ===errors===
+duplicate modifier 'abstract'
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_5.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_5.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class A { static static $a; }
 ===errors===
+duplicate modifier 'static'
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_6.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_6.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class A { final final function a() {} }
 ===errors===
+duplicate modifier 'final'
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_7.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_7.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class A { abstract final function a(); }
 ===errors===
+cannot use 'abstract' and 'final' together
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_8.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_8.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php abstract final class A { }
 ===errors===
+expected 'class', found 'final'
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_1.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class self {}
 ===errors===
+cannot use 'self' as class name
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_10.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_10.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php interface self {}
 ===errors===
+cannot use 'self' as interface name
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_11.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_11.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php interface PARENT {}
 ===errors===
+cannot use 'PARENT' as interface name
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_12.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_12.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php interface static {}
 ===errors===
+cannot use 'static' as interface name
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_13.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_13.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php interface A extends self {}
 ===errors===
+cannot use 'self' as class name
 ===ast===
 {
   "stmts": [
@@ -16,7 +17,7 @@
               "kind": "Unqualified",
               "span": {
                 "start": 26,
-                "end": 31
+                "end": 30
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_14.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_14.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php interface A extends PARENT {}
 ===errors===
+cannot use 'PARENT' as class name
 ===ast===
 {
   "stmts": [
@@ -16,7 +17,7 @@
               "kind": "Unqualified",
               "span": {
                 "start": 26,
-                "end": 33
+                "end": 32
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_15.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_15.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php interface A extends static {}
 ===errors===
+cannot use 'static' as class name
 ===ast===
 {
   "stmts": [
@@ -16,7 +17,7 @@
               "kind": "Unqualified",
               "span": {
                 "start": 26,
-                "end": 33
+                "end": 32
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_2.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class PARENT {}
 ===errors===
+cannot use 'PARENT' as class name
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_3.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class static {}
 ===errors===
+cannot use 'static' as class name
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_4.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_4.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class A extends self {}
 ===errors===
+cannot use 'self' as class name
 ===ast===
 {
   "stmts": [
@@ -20,7 +21,7 @@
             "kind": "Unqualified",
             "span": {
               "start": 22,
-              "end": 27
+              "end": 26
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_5.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_5.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class A extends PARENT {}
 ===errors===
+cannot use 'PARENT' as class name
 ===ast===
 {
   "stmts": [
@@ -20,7 +21,7 @@
             "kind": "Unqualified",
             "span": {
               "start": 22,
-              "end": 29
+              "end": 28
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_6.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_6.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class A extends static {}
 ===errors===
+cannot use 'static' as class name
 ===ast===
 {
   "stmts": [
@@ -20,7 +21,7 @@
             "kind": "Unqualified",
             "span": {
               "start": 22,
-              "end": 29
+              "end": 28
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_7.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_7.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class A implements self {}
 ===errors===
+cannot use 'self' as class name
 ===ast===
 {
   "stmts": [
@@ -22,7 +23,7 @@
               "kind": "Unqualified",
               "span": {
                 "start": 25,
-                "end": 30
+                "end": 29
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_8.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_8.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class A implements PARENT {}
 ===errors===
+cannot use 'PARENT' as class name
 ===ast===
 {
   "stmts": [
@@ -22,7 +23,7 @@
               "kind": "Unqualified",
               "span": {
                 "start": 25,
-                "end": 32
+                "end": 31
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_9.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_9.phpt
@@ -1,6 +1,7 @@
 ===source===
 <?php class A implements static {}
 ===errors===
+cannot use 'static' as class name
 ===ast===
 {
   "stmts": [
@@ -22,7 +23,7 @@
               "kind": "Unqualified",
               "span": {
                 "start": 25,
-                "end": 32
+                "end": 31
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/php4Style.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/php4Style.phpt
@@ -7,6 +7,7 @@ class A {
     static abstract function baz() {}
 }
 ===errors===
+abstract method cannot contain a body
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/propertyTypes.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/propertyTypes.phpt
@@ -74,13 +74,13 @@ class A {
                         "kind": "Unqualified",
                         "span": {
                           "start": 60,
-                          "end": 62
+                          "end": 61
                         }
                       }
                     },
                     "span": {
                       "start": 60,
-                      "end": 62
+                      "end": 61
                     }
                   },
                   "default": null,

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_4.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_4.phpt
@@ -4,6 +4,7 @@ class Test {
     public $prop { FOO => bar; }
 }
 ===errors===
+expected 'get' or 'set', found identifier
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_5.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_5.phpt
@@ -10,6 +10,13 @@ class Test {
     }
 }
 ===errors===
+expected 'get' or 'set', found 'public'
+expected 'get' or 'set', found 'public'
+expected 'get' or 'set', found 'protected'
+expected 'get' or 'set', found 'private'
+expected 'get' or 'set', found 'abstract'
+expected 'get' or 'set', found 'static'
+expected 'get' or 'set', found 'readonly'
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_6.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_6.phpt
@@ -7,6 +7,7 @@ class Test
 
 }
 ===errors===
+cannot have hooks on comma-separated property
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_7.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_7.phpt
@@ -7,6 +7,7 @@ class Test
 
 }
 ===errors===
+cannot have hooks on comma-separated property
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_promotion.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_promotion.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.5
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/readonlyAnonyous.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/readonlyAnonyous.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/readonlyAsClassName_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/readonlyAsClassName_1.phpt
@@ -2,6 +2,7 @@
 <?php
 class ReadOnly {}
 ===errors===
+cannot use 'ReadOnly' as class name
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/readonlyAsClassName_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/readonlyAsClassName_2.phpt
@@ -2,6 +2,7 @@
 <?php
 class ReadOnly {}
 ===errors===
+cannot use 'ReadOnly' as class name
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/shortEchoAsIdentifier.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/shortEchoAsIdentifier.phpt
@@ -6,6 +6,14 @@ class C {
     }
 }
 ===errors===
+expected ';', found '?>'
+expected identifier, found '?>'
+expected '::' or 'as', found '?>'
+expected identifier, found '<?php'
+expected '::' or 'as', found '<?php'
+expected '::' or 'as', found identifier
+expected identifier, found ';'
+expected '::' or 'as', found ';'
 ===ast===
 {
   "stmts": [
@@ -32,7 +40,7 @@ class C {
                       "kind": "Unqualified",
                       "span": {
                         "start": 24,
-                        "end": 26
+                        "end": 25
                       }
                     }
                   ],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/simple.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/simple.phpt
@@ -33,7 +33,7 @@ class A extends B implements C, D {
             "kind": "Unqualified",
             "span": {
               "start": 23,
-              "end": 25
+              "end": 24
             }
           },
           "implements": [
@@ -54,7 +54,7 @@ class A extends B implements C, D {
               "kind": "Unqualified",
               "span": {
                 "start": 39,
-                "end": 41
+                "end": 40
               }
             }
           ],
@@ -267,13 +267,13 @@ class A extends B implements C, D {
                         "kind": "Unqualified",
                         "span": {
                           "start": 233,
-                          "end": 235
+                          "end": 234
                         }
                       }
                     },
                     "span": {
                       "start": 233,
-                      "end": 235
+                      "end": 234
                     }
                   },
                   "body": [],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/trait.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/trait.phpt
@@ -102,7 +102,7 @@ class B {
                       "kind": "Unqualified",
                       "span": {
                         "start": 76,
-                        "end": 78
+                        "end": 77
                       }
                     }
                   ],
@@ -188,7 +188,7 @@ class B {
                       "kind": "Unqualified",
                       "span": {
                         "start": 164,
-                        "end": 166
+                        "end": 165
                       }
                     }
                   ],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/typedConstants.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/typedConstants.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php
 class Test {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/const.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/const.phpt
@@ -17,6 +17,7 @@ const WithGroupAttributes = 3;
 const ThisIsInvalid = 4,
     AttributesOnMultipleConstants = 5;
 ===errors===
+cannot use attributes on multi-constant declaration
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/disjointNormalFormTypes.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/disjointNormalFormTypes.phpt
@@ -207,20 +207,20 @@ function test((A&B)|(X&Y) $a): (A&B)|(X&Y) {}
                               "kind": "Unqualified",
                               "span": {
                                 "start": 76,
-                                "end": 78
+                                "end": 77
                               }
                             }
                           },
                           "span": {
                             "start": 76,
-                            "end": 78
+                            "end": 77
                           }
                         }
                       ]
                     },
                     "span": {
                       "start": 70,
-                      "end": 78
+                      "end": 77
                     }
                   },
                   "default": null,

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/intersectionTypes.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/intersectionTypes.phpt
@@ -59,20 +59,20 @@ function test(A&B $a): A&B {}
                               "kind": "Unqualified",
                               "span": {
                                 "start": 33,
-                                "end": 35
+                                "end": 34
                               }
                             }
                           },
                           "span": {
                             "start": 33,
-                            "end": 35
+                            "end": 34
                           }
                         }
                       ]
                     },
                     "span": {
                       "start": 31,
-                      "end": 35
+                      "end": 34
                     }
                   },
                   "default": null,
@@ -130,20 +130,20 @@ function test(A&B $a): A&B {}
                           "kind": "Unqualified",
                           "span": {
                             "start": 61,
-                            "end": 63
+                            "end": 62
                           }
                         }
                       },
                       "span": {
                         "start": 61,
-                        "end": 63
+                        "end": 62
                       }
                     }
                   ]
                 },
                 "span": {
                   "start": 59,
-                  "end": 63
+                  "end": 62
                 }
               },
               "default": null,
@@ -191,20 +191,20 @@ function test(A&B $a): A&B {}
                       "kind": "Unqualified",
                       "span": {
                         "start": 70,
-                        "end": 72
+                        "end": 71
                       }
                     }
                   },
                   "span": {
                     "start": 70,
-                    "end": 72
+                    "end": 71
                   }
                 }
               ]
             },
             "span": {
               "start": 68,
-              "end": 72
+              "end": 71
             }
           },
           "by_ref": false,

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/nullableTypes.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/nullableTypes.phpt
@@ -24,19 +24,19 @@ function test(?Foo $bar, ?string $foo) : ?Baz {
                         "kind": "Unqualified",
                         "span": {
                           "start": 22,
-                          "end": 26
+                          "end": 25
                         }
                       }
                     },
                     "span": {
                       "start": 22,
-                      "end": 26
+                      "end": 25
                     }
                   }
                 },
                 "span": {
                   "start": 21,
-                  "end": 26
+                  "end": 25
                 }
               },
               "default": null,
@@ -106,19 +106,19 @@ function test(?Foo $bar, ?string $foo) : ?Baz {
                     "kind": "Unqualified",
                     "span": {
                       "start": 49,
-                      "end": 53
+                      "end": 52
                     }
                   }
                 },
                 "span": {
                   "start": 49,
-                  "end": 53
+                  "end": 52
                 }
               }
             },
             "span": {
               "start": 48,
-              "end": 53
+              "end": 52
             }
           },
           "by_ref": false,

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/returnTypes.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/returnTypes.phpt
@@ -106,13 +106,13 @@ function test4() : Foo\Bar {}
                 "kind": "Qualified",
                 "span": {
                   "start": 105,
-                  "end": 113
+                  "end": 112
                 }
               }
             },
             "span": {
               "start": 105,
-              "end": 113
+              "end": 112
             }
           },
           "by_ref": false,

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/typeDeclarations.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/typeDeclarations.phpt
@@ -103,13 +103,13 @@ function a($b, array $c, callable $d, E $f) {}
                     "kind": "Unqualified",
                     "span": {
                       "start": 45,
-                      "end": 47
+                      "end": 46
                     }
                   }
                 },
                 "span": {
                   "start": 45,
-                  "end": 47
+                  "end": 46
                 }
               },
               "default": null,

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/unionTypes.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/unionTypes.phpt
@@ -148,20 +148,20 @@ function test(A|B $a): int|false {}
                           "kind": "Unqualified",
                           "span": {
                             "start": 73,
-                            "end": 75
+                            "end": 74
                           }
                         }
                       },
                       "span": {
                         "start": 73,
-                        "end": 75
+                        "end": 74
                       }
                     }
                   ]
                 },
                 "span": {
                   "start": 71,
-                  "end": 75
+                  "end": 74
                 }
               },
               "default": null,

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/variadic.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/variadic.phpt
@@ -137,13 +137,13 @@ function test4($a, Type &... $b) {}
                     "kind": "Unqualified",
                     "span": {
                       "start": 86,
-                      "end": 91
+                      "end": 90
                     }
                   }
                 },
                 "span": {
                   "start": 86,
-                  "end": 91
+                  "end": 90
                 }
               },
               "default": null,
@@ -203,13 +203,13 @@ function test4($a, Type &... $b) {}
                     "kind": "Unqualified",
                     "span": {
                       "start": 121,
-                      "end": 126
+                      "end": 125
                     }
                   }
                 },
                 "span": {
                   "start": 121,
-                  "end": 126
+                  "end": 125
                 }
               },
               "default": null,

--- a/crates/php-parser/tests/fixtures/corpus/stmt/haltCompilerInvalidSyntax.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/haltCompilerInvalidSyntax.phpt
@@ -2,6 +2,7 @@
 <?php
 __halt_compiler()
 ===errors===
+expected ';' or '?>' after __halt_compiler()
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/haltCompilerOutermostScope.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/haltCompilerOutermostScope.phpt
@@ -4,6 +4,8 @@ if (true) {
     __halt_compiler();
 }
 ===errors===
+__halt_compiler() can only be used at the outermost scope
+unclosed ''}'' opened at Span { start: 16, end: 17 }
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/multiCatch.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/multiCatch.phpt
@@ -52,7 +52,7 @@ try {
                   "kind": "Unqualified",
                   "span": {
                     "start": 31,
-                    "end": 33
+                    "end": 32
                   }
                 }
               ],
@@ -101,7 +101,7 @@ try {
                   "kind": "Qualified",
                   "span": {
                     "start": 60,
-                    "end": 64
+                    "end": 63
                   }
                 }
               ],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/alias.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/alias.phpt
@@ -62,7 +62,7 @@ use const foo\BAR as BAZ;
                 "kind": "Qualified",
                 "span": {
                   "start": 20,
-                  "end": 24
+                  "end": 23
                 }
               },
               "alias": "E",
@@ -93,7 +93,7 @@ use const foo\BAR as BAZ;
                 "kind": "Qualified",
                 "span": {
                   "start": 34,
-                  "end": 38
+                  "end": 37
                 }
               },
               "alias": "H",
@@ -170,7 +170,7 @@ use const foo\BAR as BAZ;
                 "kind": "FullyQualified",
                 "span": {
                   "start": 97,
-                  "end": 100
+                  "end": 99
                 }
               },
               "alias": "B",
@@ -232,7 +232,7 @@ use const foo\BAR as BAZ;
                 "kind": "Qualified",
                 "span": {
                   "start": 175,
-                  "end": 183
+                  "end": 182
                 }
               },
               "alias": "baz",
@@ -294,7 +294,7 @@ use const foo\BAR as BAZ;
                 "kind": "Qualified",
                 "span": {
                   "start": 220,
-                  "end": 228
+                  "end": 227
                 }
               },
               "alias": "BAZ",

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/braced.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/braced.phpt
@@ -21,7 +21,7 @@ namespace {
             "kind": "Qualified",
             "span": {
               "start": 17,
-              "end": 25
+              "end": 24
             }
           },
           "body": {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/commentAfterNamespace.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/commentAfterNamespace.phpt
@@ -15,7 +15,7 @@ namespace Foo {}
             "kind": "Unqualified",
             "span": {
               "start": 16,
-              "end": 20
+              "end": 19
             }
           },
           "body": {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/groupUseErrors_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/groupUseErrors_1.phpt
@@ -4,6 +4,7 @@
 use Foo\{Bar}
 use Bar\{Foo};
 ===errors===
+expected ';', found 'use'
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/groupUseErrors_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/groupUseErrors_2.phpt
@@ -3,6 +3,7 @@
 // Missing NS separator
 use Foo {Bar, Baz};
 ===errors===
+expected namespace separator before '{', found '{'
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/groupUseErrors_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/groupUseErrors_3.phpt
@@ -3,6 +3,7 @@
 // Extra NS separator
 use Foo\{\Bar};
 ===errors===
+expected non-fully-qualified name in group use, found '}'
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/invalidName_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/invalidName_1.phpt
@@ -1,6 +1,8 @@
 ===source===
 <?php use A as self;
 ===errors===
+expected identifier, found 'self'
+expected ';', found 'self'
 ===ast===
 {
   "stmts": [
@@ -17,7 +19,7 @@
                 "kind": "Unqualified",
                 "span": {
                   "start": 10,
-                  "end": 12
+                  "end": 11
                 }
               },
               "alias": null,

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/invalidName_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/invalidName_2.phpt
@@ -1,6 +1,8 @@
 ===source===
 <?php use B as PARENT;
 ===errors===
+expected identifier, found 'parent'
+expected ';', found 'parent'
 ===ast===
 {
   "stmts": [
@@ -17,7 +19,7 @@
                 "kind": "Unqualified",
                 "span": {
                   "start": 10,
-                  "end": 12
+                  "end": 11
                 }
               },
               "alias": null,

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/invalidName_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/invalidName_3.phpt
@@ -1,6 +1,8 @@
 ===source===
 <?php use C as static;
 ===errors===
+expected identifier, found 'static'
+expected ';', found 'static'
 ===ast===
 {
   "stmts": [
@@ -17,7 +19,7 @@
                 "kind": "Unqualified",
                 "span": {
                   "start": 10,
-                  "end": 12
+                  "end": 11
                 }
               },
               "alias": null,

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_1.phpt
@@ -59,7 +59,7 @@ echo 3;
             "kind": "Unqualified",
             "span": {
               "start": 37,
-              "end": 39
+              "end": 38
             }
           },
           "body": {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_2.phpt
@@ -19,7 +19,7 @@ echo 3;
             "kind": "Unqualified",
             "span": {
               "start": 16,
-              "end": 18
+              "end": 17
             }
           },
           "body": {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/nested.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/nested.phpt
@@ -18,7 +18,7 @@ namespace A {
             "kind": "Unqualified",
             "span": {
               "start": 16,
-              "end": 18
+              "end": 17
             }
           },
           "body": {
@@ -33,7 +33,7 @@ namespace A {
                       "kind": "Unqualified",
                       "span": {
                         "start": 34,
-                        "end": 36
+                        "end": 35
                       }
                     },
                     "body": {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_2.phpt
@@ -15,7 +15,7 @@ echo 1;
             "kind": "Unqualified",
             "span": {
               "start": 16,
-              "end": 18
+              "end": 17
             }
           },
           "body": {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_3.phpt
@@ -17,7 +17,7 @@ namespace B {}
             "kind": "Unqualified",
             "span": {
               "start": 16,
-              "end": 18
+              "end": 17
             }
           },
           "body": {
@@ -93,7 +93,7 @@ namespace B {}
             "kind": "Unqualified",
             "span": {
               "start": 56,
-              "end": 58
+              "end": 57
             }
           },
           "body": {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmt_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmt_1.phpt
@@ -45,7 +45,7 @@ Hi!
             "kind": "Unqualified",
             "span": {
               "start": 32,
-              "end": 34
+              "end": 33
             }
           },
           "body": {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/tryCatch.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/tryCatch.phpt
@@ -64,7 +64,7 @@ finally { }
                   "kind": "Unqualified",
                   "span": {
                     "start": 35,
-                    "end": 37
+                    "end": 36
                   }
                 }
               ],
@@ -113,7 +113,7 @@ finally { }
                   "kind": "Unqualified",
                   "span": {
                     "start": 68,
-                    "end": 70
+                    "end": 69
                   }
                 }
               ],
@@ -205,7 +205,7 @@ finally { }
                   "kind": "Unqualified",
                   "span": {
                     "start": 153,
-                    "end": 155
+                    "end": 154
                   }
                 }
               ],

--- a/crates/php-parser/tests/fixtures/corpus/stmt/tryWithoutCatch.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/tryWithoutCatch.phpt
@@ -5,6 +5,7 @@ try {
     foo();
 }
 ===errors===
+expected catch or finally clause, found end of file
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/deep_namespace_nesting.phpt
+++ b/crates/php-parser/tests/fixtures/deep_namespace_nesting.phpt
@@ -19,7 +19,7 @@
             "kind": "Qualified",
             "span": {
               "start": 16,
-              "end": 30
+              "end": 29
             }
           },
           "body": {

--- a/crates/php-parser/tests/fixtures/dnf_types.phpt
+++ b/crates/php-parser/tests/fixtures/dnf_types.phpt
@@ -74,20 +74,20 @@ function bar((A&B)|(C&D) $y): (E&F)|null {
                           "kind": "Unqualified",
                           "span": {
                             "start": 25,
-                            "end": 27
+                            "end": 26
                           }
                         }
                       },
                       "span": {
                         "start": 25,
-                        "end": 27
+                        "end": 26
                       }
                     }
                   ]
                 },
                 "span": {
                   "start": 19,
-                  "end": 27
+                  "end": 26
                 }
               },
               "default": null,
@@ -181,20 +181,20 @@ function bar((A&B)|(C&D) $y): (E&F)|null {
                       "kind": "Unqualified",
                       "span": {
                         "start": 38,
-                        "end": 40
+                        "end": 39
                       }
                     }
                   },
                   "span": {
                     "start": 38,
-                    "end": 40
+                    "end": 39
                   }
                 }
               ]
             },
             "span": {
               "start": 32,
-              "end": 40
+              "end": 39
             }
           },
           "by_ref": false,

--- a/crates/php-parser/tests/fixtures/dnf_types_complex.phpt
+++ b/crates/php-parser/tests/fixtures/dnf_types_complex.phpt
@@ -349,20 +349,20 @@ class Foo {
                               "kind": "Unqualified",
                               "span": {
                                 "start": 100,
-                                "end": 102
+                                "end": 101
                               }
                             }
                           },
                           "span": {
                             "start": 100,
-                            "end": 102
+                            "end": 101
                           }
                         }
                       ]
                     },
                     "span": {
                       "start": 94,
-                      "end": 102
+                      "end": 101
                     }
                   },
                   "default": null,

--- a/crates/php-parser/tests/fixtures/enum_backed.phpt
+++ b/crates/php-parser/tests/fixtures/enum_backed.phpt
@@ -21,7 +21,7 @@ enum Status: string {
             "kind": "Unqualified",
             "span": {
               "start": 19,
-              "end": 26
+              "end": 25
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/enum_multiple_interfaces_const_method.phpt
+++ b/crates/php-parser/tests/fixtures/enum_multiple_interfaces_const_method.phpt
@@ -30,7 +30,7 @@ enum Status: string implements Loggable, Serializable {
             "kind": "Unqualified",
             "span": {
               "start": 19,
-              "end": 26
+              "end": 25
             }
           },
           "implements": [
@@ -51,7 +51,7 @@ enum Status: string implements Loggable, Serializable {
               "kind": "Unqualified",
               "span": {
                 "start": 47,
-                "end": 60
+                "end": 59
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/enum_with_methods.phpt
+++ b/crates/php-parser/tests/fixtures/enum_with_methods.phpt
@@ -31,7 +31,7 @@ enum Suit: string implements HasColor {
             "kind": "Unqualified",
             "span": {
               "start": 17,
-              "end": 24
+              "end": 23
             }
           },
           "implements": [
@@ -42,7 +42,7 @@ enum Suit: string implements HasColor {
               "kind": "Unqualified",
               "span": {
                 "start": 35,
-                "end": 44
+                "end": 43
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/enum_with_trait.phpt
+++ b/crates/php-parser/tests/fixtures/enum_with_trait.phpt
@@ -25,7 +25,7 @@ enum Direction implements HasLabel {
               "kind": "Unqualified",
               "span": {
                 "start": 32,
-                "end": 41
+                "end": 40
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/errors/arrow_function_missing_body.phpt
+++ b/crates/php-parser/tests/fixtures/errors/arrow_function_missing_body.phpt
@@ -1,0 +1,60 @@
+===source===
+<?php fn($x) =>;
+===errors===
+expected expression
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "ArrowFunction": {
+              "is_static": false,
+              "by_ref": false,
+              "params": [
+                {
+                  "name": "x",
+                  "type_hint": null,
+                  "default": null,
+                  "by_ref": false,
+                  "variadic": false,
+                  "is_readonly": false,
+                  "is_final": false,
+                  "visibility": null,
+                  "set_visibility": null,
+                  "attributes": [],
+                  "span": {
+                    "start": 9,
+                    "end": 11
+                  }
+                }
+              ],
+              "return_type": null,
+              "body": {
+                "kind": "Error",
+                "span": {
+                  "start": 15,
+                  "end": 16
+                }
+              },
+              "attributes": []
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 16
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 16
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 16
+  }
+}

--- a/crates/php-parser/tests/fixtures/errors/catch_missing_exception.phpt
+++ b/crates/php-parser/tests/fixtures/errors/catch_missing_exception.phpt
@@ -21,7 +21,7 @@ expected ')', found '{'
                   "kind": "Unqualified",
                   "span": {
                     "start": 20,
-                    "end": 20
+                    "end": 21
                   }
                 }
               ],

--- a/crates/php-parser/tests/fixtures/errors/catch_unclosed_paren.phpt
+++ b/crates/php-parser/tests/fixtures/errors/catch_unclosed_paren.phpt
@@ -19,7 +19,7 @@ expected ')', found '{'
                   "kind": "Unqualified",
                   "span": {
                     "start": 21,
-                    "end": 31
+                    "end": 30
                   }
                 }
               ],

--- a/crates/php-parser/tests/fixtures/errors/class_invalid_extends.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_invalid_extends.phpt
@@ -21,7 +21,7 @@ expected identifier, found '{'
             "kind": "Unqualified",
             "span": {
               "start": 25,
-              "end": 25
+              "end": 26
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/errors/class_invalid_implements.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_invalid_implements.phpt
@@ -23,7 +23,7 @@ expected identifier, found '{'
               "kind": "Unqualified",
               "span": {
                 "start": 28,
-                "end": 28
+                "end": 29
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/errors/consecutive_operators.phpt
+++ b/crates/php-parser/tests/fixtures/errors/consecutive_operators.phpt
@@ -1,0 +1,70 @@
+===source===
+<?php $x = + + ;
+===errors===
+expected expression
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "UnaryPrefix": {
+                    "op": "Plus",
+                    "operand": {
+                      "kind": {
+                        "UnaryPrefix": {
+                          "op": "Plus",
+                          "operand": {
+                            "kind": "Error",
+                            "span": {
+                              "start": 15,
+                              "end": 16
+                            }
+                          }
+                        }
+                      },
+                      "span": {
+                        "start": 13,
+                        "end": 16
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 16
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 16
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 16
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 16
+  }
+}

--- a/crates/php-parser/tests/fixtures/errors/double_comma_in_args.phpt
+++ b/crates/php-parser/tests/fixtures/errors/double_comma_in_args.phpt
@@ -1,8 +1,7 @@
 ===source===
-<?php foo(1, 2
+<?php foo(1,, 2);
 ===errors===
-expected ')', found end of file
-expected ';' after expression
+expected expression
 ===ast===
 {
   "stmts": [
@@ -42,19 +41,35 @@ expected ';' after expression
                 {
                   "name": null,
                   "value": {
-                    "kind": {
-                      "Int": 2
-                    },
+                    "kind": "Error",
                     "span": {
-                      "start": 13,
-                      "end": 14
+                      "start": 12,
+                      "end": 13
                     }
                   },
                   "unpack": false,
                   "by_ref": false,
                   "span": {
-                    "start": 13,
-                    "end": 14
+                    "start": 12,
+                    "end": 13
+                  }
+                },
+                {
+                  "name": null,
+                  "value": {
+                    "kind": {
+                      "Int": 2
+                    },
+                    "span": {
+                      "start": 14,
+                      "end": 15
+                    }
+                  },
+                  "unpack": false,
+                  "by_ref": false,
+                  "span": {
+                    "start": 14,
+                    "end": 15
                   }
                 }
               ]
@@ -62,18 +77,18 @@ expected ';' after expression
           },
           "span": {
             "start": 6,
-            "end": 14
+            "end": 16
           }
         }
       },
       "span": {
         "start": 6,
-        "end": 14
+        "end": 17
       }
     }
   ],
   "span": {
     "start": 0,
-    "end": 14
+    "end": 17
   }
 }

--- a/crates/php-parser/tests/fixtures/errors/function_invalid_return_type.phpt
+++ b/crates/php-parser/tests/fixtures/errors/function_invalid_return_type.phpt
@@ -20,13 +20,13 @@ expected identifier, found '{'
                 "kind": "Unqualified",
                 "span": {
                   "start": 23,
-                  "end": 23
+                  "end": 24
                 }
               }
             },
             "span": {
               "start": 23,
-              "end": 23
+              "end": 24
             }
           },
           "by_ref": false,

--- a/crates/php-parser/tests/fixtures/errors/invalid_double_readonly_anonymous_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_double_readonly_anonymous_class.phpt
@@ -17,7 +17,7 @@ expected class name, found '{'
                 },
                 "span": {
                   "start": 10,
-                  "end": 19
+                  "end": 18
                 }
               },
               "args": []

--- a/crates/php-parser/tests/fixtures/errors/keyword_salad.phpt
+++ b/crates/php-parser/tests/fixtures/errors/keyword_salad.phpt
@@ -1,0 +1,34 @@
+===source===
+<?php class function while;
+===errors===
+expected '{', found 'while'
+expected '}', found end of file
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "function",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 27
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 27
+  }
+}

--- a/crates/php-parser/tests/fixtures/errors/missing_expression_after_echo.phpt
+++ b/crates/php-parser/tests/fixtures/errors/missing_expression_after_echo.phpt
@@ -1,0 +1,30 @@
+===source===
+<?php echo ;
+===errors===
+expected expression
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Echo": [
+          {
+            "kind": "Error",
+            "span": {
+              "start": 11,
+              "end": 12
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 6,
+        "end": 12
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 12
+  }
+}

--- a/crates/php-parser/tests/fixtures/errors/missing_semicolons_between_statements.phpt
+++ b/crates/php-parser/tests/fixtures/errors/missing_semicolons_between_statements.phpt
@@ -1,0 +1,88 @@
+===source===
+<?php $x = 1 $y = 2
+===errors===
+expected ';' after expression
+expected ';' after expression
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Int": 1
+                },
+                "span": {
+                  "start": 11,
+                  "end": 12
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 12
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 13
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "y"
+                },
+                "span": {
+                  "start": 13,
+                  "end": 15
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Int": 2
+                },
+                "span": {
+                  "start": 18,
+                  "end": 19
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 13,
+            "end": 19
+          }
+        }
+      },
+      "span": {
+        "start": 13,
+        "end": 19
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 19
+  }
+}

--- a/crates/php-parser/tests/fixtures/errors/namespace_error_then_valid_namespace.phpt
+++ b/crates/php-parser/tests/fixtures/errors/namespace_error_then_valid_namespace.phpt
@@ -15,7 +15,7 @@ expected identifier, found ';'
             "kind": "Unqualified",
             "span": {
               "start": 16,
-              "end": 16
+              "end": 17
             }
           },
           "body": "Simple"

--- a/crates/php-parser/tests/fixtures/errors/namespace_missing_name.phpt
+++ b/crates/php-parser/tests/fixtures/errors/namespace_missing_name.phpt
@@ -15,7 +15,7 @@ expected identifier, found ';'
             "kind": "Unqualified",
             "span": {
               "start": 15,
-              "end": 15
+              "end": 16
             }
           },
           "body": "Simple"

--- a/crates/php-parser/tests/fixtures/errors/namespace_unclosed_braces.phpt
+++ b/crates/php-parser/tests/fixtures/errors/namespace_unclosed_braces.phpt
@@ -15,7 +15,7 @@ expected '}', found end of file
             "kind": "Unqualified",
             "span": {
               "start": 16,
-              "end": 20
+              "end": 19
             }
           },
           "body": {

--- a/crates/php-parser/tests/fixtures/errors/reserved_extends_parent.phpt
+++ b/crates/php-parser/tests/fixtures/errors/reserved_extends_parent.phpt
@@ -21,7 +21,7 @@ cannot use 'parent' as class name
             "kind": "Unqualified",
             "span": {
               "start": 22,
-              "end": 29
+              "end": 28
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/errors/reserved_extends_self.phpt
+++ b/crates/php-parser/tests/fixtures/errors/reserved_extends_self.phpt
@@ -21,7 +21,7 @@ cannot use 'self' as class name
             "kind": "Unqualified",
             "span": {
               "start": 22,
-              "end": 27
+              "end": 26
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/errors/reserved_extends_static.phpt
+++ b/crates/php-parser/tests/fixtures/errors/reserved_extends_static.phpt
@@ -21,7 +21,7 @@ cannot use 'static' as class name
             "kind": "Unqualified",
             "span": {
               "start": 22,
-              "end": 29
+              "end": 28
             }
           },
           "implements": [],

--- a/crates/php-parser/tests/fixtures/errors/reserved_implements_parent.phpt
+++ b/crates/php-parser/tests/fixtures/errors/reserved_implements_parent.phpt
@@ -23,7 +23,7 @@ cannot use 'parent' as class name
               "kind": "Unqualified",
               "span": {
                 "start": 25,
-                "end": 32
+                "end": 31
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/errors/reserved_implements_self.phpt
+++ b/crates/php-parser/tests/fixtures/errors/reserved_implements_self.phpt
@@ -23,7 +23,7 @@ cannot use 'self' as class name
               "kind": "Unqualified",
               "span": {
                 "start": 25,
-                "end": 30
+                "end": 29
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/errors/reserved_implements_static.phpt
+++ b/crates/php-parser/tests/fixtures/errors/reserved_implements_static.phpt
@@ -23,7 +23,7 @@ cannot use 'static' as class name
               "kind": "Unqualified",
               "span": {
                 "start": 25,
-                "end": 32
+                "end": 31
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/errors/trait_invalid_adaptation_syntax.phpt
+++ b/crates/php-parser/tests/fixtures/errors/trait_invalid_adaptation_syntax.phpt
@@ -64,7 +64,7 @@ expected '::' or 'as', found ';'
                       "kind": "Unqualified",
                       "span": {
                         "start": 55,
-                        "end": 57
+                        "end": 56
                       }
                     }
                   ],

--- a/crates/php-parser/tests/fixtures/errors/trait_missing_method_name.phpt
+++ b/crates/php-parser/tests/fixtures/errors/trait_missing_method_name.phpt
@@ -41,7 +41,7 @@ expected '::' or 'as', found ';'
                       "kind": "Unqualified",
                       "span": {
                         "start": 31,
-                        "end": 33
+                        "end": 32
                       }
                     }
                   ],

--- a/crates/php-parser/tests/fixtures/errors/trait_unclosed_brace.phpt
+++ b/crates/php-parser/tests/fixtures/errors/trait_unclosed_brace.phpt
@@ -41,7 +41,7 @@ expected '}', found end of file
                       "kind": "Unqualified",
                       "span": {
                         "start": 31,
-                        "end": 33
+                        "end": 32
                       }
                     }
                   ],

--- a/crates/php-parser/tests/fixtures/errors/unclosed_brace.phpt
+++ b/crates/php-parser/tests/fixtures/errors/unclosed_brace.phpt
@@ -1,67 +1,81 @@
 ===source===
-<?php function foo() { $x = 1;
+<?php if (true) { $x = 1;
 ===errors===
-unclosed ''}'' opened at Span { start: 21, end: 22 }
+unclosed ''}'' opened at Span { start: 16, end: 17 }
 ===ast===
 {
   "stmts": [
     {
       "kind": {
-        "Function": {
-          "name": "foo",
-          "params": [],
-          "body": [
-            {
-              "kind": {
-                "Expression": {
+        "If": {
+          "condition": {
+            "kind": {
+              "Bool": true
+            },
+            "span": {
+              "start": 10,
+              "end": 14
+            }
+          },
+          "then_branch": {
+            "kind": {
+              "Block": [
+                {
                   "kind": {
-                    "Assign": {
-                      "target": {
-                        "kind": {
-                          "Variable": "x"
-                        },
-                        "span": {
-                          "start": 23,
-                          "end": 25
+                    "Expression": {
+                      "kind": {
+                        "Assign": {
+                          "target": {
+                            "kind": {
+                              "Variable": "x"
+                            },
+                            "span": {
+                              "start": 18,
+                              "end": 20
+                            }
+                          },
+                          "op": "Assign",
+                          "value": {
+                            "kind": {
+                              "Int": 1
+                            },
+                            "span": {
+                              "start": 23,
+                              "end": 24
+                            }
+                          }
                         }
                       },
-                      "op": "Assign",
-                      "value": {
-                        "kind": {
-                          "Int": 1
-                        },
-                        "span": {
-                          "start": 28,
-                          "end": 29
-                        }
+                      "span": {
+                        "start": 18,
+                        "end": 24
                       }
                     }
                   },
                   "span": {
-                    "start": 23,
-                    "end": 29
+                    "start": 18,
+                    "end": 25
                   }
                 }
-              },
-              "span": {
-                "start": 23,
-                "end": 30
-              }
+              ]
+            },
+            "span": {
+              "start": 16,
+              "end": 25
             }
-          ],
-          "return_type": null,
-          "by_ref": false,
-          "attributes": []
+          },
+          "elseif_branches": [],
+          "else_branch": null
         }
       },
       "span": {
         "start": 6,
-        "end": 30
+        "end": 25
       }
     }
   ],
   "span": {
     "start": 0,
-    "end": 30
+    "end": 25
   }
 }

--- a/crates/php-parser/tests/fixtures/errors/unclosed_bracket.phpt
+++ b/crates/php-parser/tests/fixtures/errors/unclosed_bracket.phpt
@@ -1,0 +1,86 @@
+===source===
+<?php $x = [1, 2
+===errors===
+expected ']', found end of file
+expected ';' after expression
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Array": [
+                    {
+                      "key": null,
+                      "value": {
+                        "kind": {
+                          "Int": 1
+                        },
+                        "span": {
+                          "start": 12,
+                          "end": 13
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 12,
+                        "end": 13
+                      }
+                    },
+                    {
+                      "key": null,
+                      "value": {
+                        "kind": {
+                          "Int": 2
+                        },
+                        "span": {
+                          "start": 15,
+                          "end": 16
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 15,
+                        "end": 16
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 16
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 16
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 16
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 16
+  }
+}

--- a/crates/php-parser/tests/fixtures/errors/unclosed_class_body.phpt
+++ b/crates/php-parser/tests/fixtures/errors/unclosed_class_body.phpt
@@ -1,0 +1,54 @@
+===source===
+<?php class Foo { public function bar() {}
+===errors===
+expected '}', found end of file
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Method": {
+                  "name": "bar",
+                  "visibility": "Public",
+                  "is_static": false,
+                  "is_abstract": false,
+                  "is_final": false,
+                  "by_ref": false,
+                  "params": [],
+                  "return_type": null,
+                  "body": [],
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 18,
+                "end": 42
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 42
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 42
+  }
+}

--- a/crates/php-parser/tests/fixtures/errors/unterminated_heredoc.phpt
+++ b/crates/php-parser/tests/fixtures/errors/unterminated_heredoc.phpt
@@ -1,0 +1,107 @@
+===source===
+<?php $x = <<<EOT
+hello
+===errors===
+expected expression
+expected expression
+expected ';' after expression
+expected ';' after expression
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Binary": {
+                    "left": {
+                      "kind": {
+                        "Binary": {
+                          "left": {
+                            "kind": "Error",
+                            "span": {
+                              "start": 11,
+                              "end": 13
+                            }
+                          },
+                          "op": "ShiftLeft",
+                          "right": {
+                            "kind": "Error",
+                            "span": {
+                              "start": 13,
+                              "end": 14
+                            }
+                          }
+                        }
+                      },
+                      "span": {
+                        "start": 11,
+                        "end": 14
+                      }
+                    },
+                    "op": "Less",
+                    "right": {
+                      "kind": {
+                        "Identifier": "EOT"
+                      },
+                      "span": {
+                        "start": 14,
+                        "end": 17
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 17
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 17
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 18
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Identifier": "hello"
+          },
+          "span": {
+            "start": 18,
+            "end": 23
+          }
+        }
+      },
+      "span": {
+        "start": 18,
+        "end": 23
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 23
+  }
+}

--- a/crates/php-parser/tests/fixtures/errors/use_error_then_valid_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/use_error_then_valid_class.phpt
@@ -18,7 +18,7 @@ expected identifier, found ';'
                 "kind": "Unqualified",
                 "span": {
                   "start": 10,
-                  "end": 10
+                  "end": 11
                 }
               },
               "alias": null,

--- a/crates/php-parser/tests/fixtures/errors/use_missing_name.phpt
+++ b/crates/php-parser/tests/fixtures/errors/use_missing_name.phpt
@@ -18,7 +18,7 @@ expected identifier, found ';'
                 "kind": "Unqualified",
                 "span": {
                   "start": 9,
-                  "end": 9
+                  "end": 10
                 }
               },
               "alias": null,

--- a/crates/php-parser/tests/fixtures/function_type_hints.phpt
+++ b/crates/php-parser/tests/fixtures/function_type_hints.phpt
@@ -145,20 +145,20 @@ function process(?int $x, int|string $y, Countable&Traversable $z): ?string {
                           "kind": "Unqualified",
                           "span": {
                             "start": 57,
-                            "end": 69
+                            "end": 68
                           }
                         }
                       },
                       "span": {
                         "start": 57,
-                        "end": 69
+                        "end": 68
                       }
                     }
                   ]
                 },
                 "span": {
                   "start": 47,
-                  "end": 69
+                  "end": 68
                 }
               },
               "default": null,

--- a/crates/php-parser/tests/fixtures/interface.phpt
+++ b/crates/php-parser/tests/fixtures/interface.phpt
@@ -73,7 +73,7 @@ interface HasName extends HasId {
               "kind": "Unqualified",
               "span": {
                 "start": 86,
-                "end": 92
+                "end": 91
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/interface_multiple_extends.phpt
+++ b/crates/php-parser/tests/fixtures/interface_multiple_extends.phpt
@@ -28,7 +28,7 @@ interface ReadWrite extends Readable, Writable {
               "kind": "Unqualified",
               "span": {
                 "start": 44,
-                "end": 53
+                "end": 52
               }
             }
           ],

--- a/crates/php-parser/tests/fixtures/intersection_type_with_object.phpt
+++ b/crates/php-parser/tests/fixtures/intersection_type_with_object.phpt
@@ -40,20 +40,20 @@
                           "kind": "Unqualified",
                           "span": {
                             "start": 28,
-                            "end": 38
+                            "end": 37
                           }
                         }
                       },
                       "span": {
                         "start": 28,
-                        "end": 38
+                        "end": 37
                       }
                     }
                   ]
                 },
                 "span": {
                   "start": 19,
-                  "end": 38
+                  "end": 37
                 }
               },
               "default": null,

--- a/crates/php-parser/tests/fixtures/multiple_catch_types.phpt
+++ b/crates/php-parser/tests/fixtures/multiple_catch_types.phpt
@@ -53,7 +53,7 @@ try {
                   "kind": "Unqualified",
                   "span": {
                     "start": 32,
-                    "end": 42
+                    "end": 41
                   }
                 },
                 {
@@ -63,7 +63,7 @@ try {
                   "kind": "Unqualified",
                   "span": {
                     "start": 44,
-                    "end": 55
+                    "end": 54
                   }
                 },
                 {
@@ -73,7 +73,7 @@ try {
                   "kind": "Unqualified",
                   "span": {
                     "start": 57,
-                    "end": 74
+                    "end": 73
                   }
                 }
               ],
@@ -141,7 +141,7 @@ try {
                   "kind": "Unqualified",
                   "span": {
                     "start": 105,
-                    "end": 120
+                    "end": 119
                   }
                 }
               ],

--- a/crates/php-parser/tests/fixtures/namespace_braced.phpt
+++ b/crates/php-parser/tests/fixtures/namespace_braced.phpt
@@ -20,7 +20,7 @@ namespace App\Models {
             "kind": "Qualified",
             "span": {
               "start": 16,
-              "end": 29
+              "end": 28
             }
           },
           "body": {
@@ -65,7 +65,7 @@ namespace App\Models {
             "kind": "Qualified",
             "span": {
               "start": 68,
-              "end": 79
+              "end": 78
             }
           },
           "body": {

--- a/crates/php-parser/tests/fixtures/nested_try_catch.phpt
+++ b/crates/php-parser/tests/fixtures/nested_try_catch.phpt
@@ -60,7 +60,7 @@ try {
                           "kind": "Unqualified",
                           "span": {
                             "start": 58,
-                            "end": 73
+                            "end": 72
                           }
                         }
                       ],
@@ -156,7 +156,7 @@ try {
                   "kind": "Unqualified",
                   "span": {
                     "start": 129,
-                    "end": 144
+                    "end": 143
                   }
                 }
               ],

--- a/crates/php-parser/tests/fixtures/no_hang/catch_body.phpt
+++ b/crates/php-parser/tests/fixtures/no_hang/catch_body.phpt
@@ -17,7 +17,7 @@
                   "kind": "Unqualified",
                   "span": {
                     "start": 20,
-                    "end": 30
+                    "end": 29
                   }
                 }
               ],

--- a/crates/php-parser/tests/fixtures/no_hang/namespace_braced.phpt
+++ b/crates/php-parser/tests/fixtures/no_hang/namespace_braced.phpt
@@ -13,7 +13,7 @@
             "kind": "Unqualified",
             "span": {
               "start": 16,
-              "end": 20
+              "end": 19
             }
           },
           "body": {

--- a/crates/php-parser/tests/fixtures/no_hang/try_body.phpt
+++ b/crates/php-parser/tests/fixtures/no_hang/try_body.phpt
@@ -34,7 +34,7 @@
                   "kind": "Unqualified",
                   "span": {
                     "start": 30,
-                    "end": 40
+                    "end": 39
                   }
                 }
               ],

--- a/crates/php-parser/tests/fixtures/readonly_intersection_type_property.phpt
+++ b/crates/php-parser/tests/fixtures/readonly_intersection_type_property.phpt
@@ -56,20 +56,20 @@ class Foo {
                               "kind": "Unqualified",
                               "span": {
                                 "start": 48,
-                                "end": 60
+                                "end": 59
                               }
                             }
                           },
                           "span": {
                             "start": 48,
-                            "end": 60
+                            "end": 59
                           }
                         }
                       ]
                     },
                     "span": {
                       "start": 38,
-                      "end": 60
+                      "end": 59
                     }
                   },
                   "default": null,

--- a/crates/php-parser/tests/fixtures/realistic_controller.phpt
+++ b/crates/php-parser/tests/fixtures/realistic_controller.phpt
@@ -118,7 +118,7 @@ class UserController extends BaseController implements JsonResponder
                 "kind": "Qualified",
                 "span": {
                   "start": 59,
-                  "end": 84
+                  "end": 83
                 }
               },
               "alias": "Auth",
@@ -151,7 +151,7 @@ class UserController extends BaseController implements JsonResponder
             "kind": "Unqualified",
             "span": {
               "start": 123,
-              "end": 138
+              "end": 137
             }
           },
           "implements": [
@@ -162,7 +162,7 @@ class UserController extends BaseController implements JsonResponder
               "kind": "Unqualified",
               "span": {
                 "start": 149,
-                "end": 163
+                "end": 162
               }
             }
           ],
@@ -184,13 +184,13 @@ class UserController extends BaseController implements JsonResponder
                         "kind": "Unqualified",
                         "span": {
                           "start": 186,
-                          "end": 198
+                          "end": 197
                         }
                       }
                     },
                     "span": {
                       "start": 186,
-                      "end": 198
+                      "end": 197
                     }
                   },
                   "default": null,
@@ -223,13 +223,13 @@ class UserController extends BaseController implements JsonResponder
                             "kind": "Unqualified",
                             "span": {
                               "start": 238,
-                              "end": 250
+                              "end": 249
                             }
                           }
                         },
                         "span": {
                           "start": 238,
-                          "end": 250
+                          "end": 249
                         }
                       },
                       "default": null,
@@ -820,7 +820,7 @@ class UserController extends BaseController implements JsonResponder
                                   "kind": "Unqualified",
                                   "span": {
                                     "start": 814,
-                                    "end": 832
+                                    "end": 831
                                   }
                                 }
                               ],

--- a/crates/php-parser/tests/fixtures/realistic_enum_service.phpt
+++ b/crates/php-parser/tests/fixtures/realistic_enum_service.phpt
@@ -82,7 +82,7 @@ class TaskService
             "kind": "Unqualified",
             "span": {
               "start": 43,
-              "end": 47
+              "end": 46
             }
           },
           "implements": [],
@@ -628,13 +628,13 @@ class TaskService
                             "kind": "Unqualified",
                             "span": {
                               "start": 661,
-                              "end": 670
+                              "end": 669
                             }
                           }
                         },
                         "span": {
                           "start": 661,
-                          "end": 670
+                          "end": 669
                         }
                       },
                       "default": null,

--- a/crates/php-parser/tests/fixtures/realistic_middleware.phpt
+++ b/crates/php-parser/tests/fixtures/realistic_middleware.phpt
@@ -261,13 +261,13 @@ class RateLimitMiddleware implements MiddlewareInterface
                             "kind": "Unqualified",
                             "span": {
                               "start": 198,
-                              "end": 206
+                              "end": 205
                             }
                           }
                         },
                         "span": {
                           "start": 198,
-                          "end": 206
+                          "end": 205
                         }
                       },
                       "default": null,
@@ -371,7 +371,7 @@ class RateLimitMiddleware implements MiddlewareInterface
               "kind": "Unqualified",
               "span": {
                 "start": 278,
-                "end": 298
+                "end": 297
               }
             }
           ],
@@ -393,13 +393,13 @@ class RateLimitMiddleware implements MiddlewareInterface
                         "kind": "Unqualified",
                         "span": {
                           "start": 321,
-                          "end": 336
+                          "end": 335
                         }
                       }
                     },
                     "span": {
                       "start": 321,
-                      "end": 336
+                      "end": 335
                     }
                   },
                   "default": null,
@@ -475,13 +475,13 @@ class RateLimitMiddleware implements MiddlewareInterface
                             "kind": "Unqualified",
                             "span": {
                               "start": 427,
-                              "end": 442
+                              "end": 441
                             }
                           }
                         },
                         "span": {
                           "start": 427,
-                          "end": 442
+                          "end": 441
                         }
                       },
                       "default": null,
@@ -586,13 +586,13 @@ class RateLimitMiddleware implements MiddlewareInterface
                             "kind": "Unqualified",
                             "span": {
                               "start": 533,
-                              "end": 541
+                              "end": 540
                             }
                           }
                         },
                         "span": {
                           "start": 533,
-                          "end": 541
+                          "end": 540
                         }
                       },
                       "default": null,
@@ -651,13 +651,13 @@ class RateLimitMiddleware implements MiddlewareInterface
                         "kind": "Unqualified",
                         "span": {
                           "start": 568,
-                          "end": 581
+                          "end": 576
                         }
                       }
                     },
                     "span": {
                       "start": 568,
-                      "end": 581
+                      "end": 576
                     }
                   },
                   "body": [
@@ -1520,7 +1520,7 @@ class RateLimitMiddleware implements MiddlewareInterface
                                   "kind": "FullyQualified",
                                   "span": {
                                     "start": 1228,
-                                    "end": 1254
+                                    "end": 1253
                                   }
                                 }
                               ],
@@ -1652,7 +1652,7 @@ class RateLimitMiddleware implements MiddlewareInterface
                                   "kind": "FullyQualified",
                                   "span": {
                                     "start": 1346,
-                                    "end": 1364
+                                    "end": 1363
                                   }
                                 },
                                 {
@@ -1662,7 +1662,7 @@ class RateLimitMiddleware implements MiddlewareInterface
                                   "kind": "FullyQualified",
                                   "span": {
                                     "start": 1366,
-                                    "end": 1382
+                                    "end": 1381
                                   }
                                 }
                               ],
@@ -2118,7 +2118,7 @@ class RateLimitMiddleware implements MiddlewareInterface
               "kind": "Unqualified",
               "span": {
                 "start": 1746,
-                "end": 1766
+                "end": 1765
               }
             }
           ],
@@ -2188,13 +2188,13 @@ class RateLimitMiddleware implements MiddlewareInterface
                             "kind": "Unqualified",
                             "span": {
                               "start": 1873,
-                              "end": 1881
+                              "end": 1880
                             }
                           }
                         },
                         "span": {
                           "start": 1873,
-                          "end": 1881
+                          "end": 1880
                         }
                       },
                       "default": null,
@@ -2253,13 +2253,13 @@ class RateLimitMiddleware implements MiddlewareInterface
                         "kind": "Unqualified",
                         "span": {
                           "start": 1908,
-                          "end": 1921
+                          "end": 1916
                         }
                       }
                     },
                     "span": {
                       "start": 1908,
-                      "end": 1921
+                      "end": 1916
                     }
                   },
                   "body": [

--- a/crates/php-parser/tests/fixtures/realistic_repository.phpt
+++ b/crates/php-parser/tests/fixtures/realistic_repository.phpt
@@ -203,7 +203,7 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                 "kind": "Qualified",
                 "span": {
                   "start": 84,
-                  "end": 108
+                  "end": 107
                 }
               },
               "alias": "DB",
@@ -395,13 +395,13 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                             "kind": "Unqualified",
                             "span": {
                               "start": 288,
-                              "end": 293
+                              "end": 292
                             }
                           }
                         },
                         "span": {
                           "start": 288,
-                          "end": 293
+                          "end": 292
                         }
                       },
                       "default": null,
@@ -554,13 +554,13 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                         "kind": "Unqualified",
                         "span": {
                           "start": 412,
-                          "end": 415
+                          "end": 414
                         }
                       }
                     },
                     "span": {
                       "start": 412,
-                      "end": 415
+                      "end": 414
                     }
                   },
                   "default": null,
@@ -593,13 +593,13 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                             "kind": "Unqualified",
                             "span": {
                               "start": 453,
-                              "end": 456
+                              "end": 455
                             }
                           }
                         },
                         "span": {
                           "start": 453,
-                          "end": 456
+                          "end": 455
                         }
                       },
                       "default": null,
@@ -1036,7 +1036,7 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
             "kind": "Unqualified",
             "span": {
               "start": 811,
-              "end": 830
+              "end": 829
             }
           },
           "implements": [
@@ -1047,7 +1047,7 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
               "kind": "Unqualified",
               "span": {
                 "start": 841,
-                "end": 861
+                "end": 860
               }
             }
           ],
@@ -1258,13 +1258,13 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                         "kind": "Unqualified",
                         "span": {
                           "start": 1090,
-                          "end": 1099
+                          "end": 1094
                         }
                       }
                     },
                     "span": {
                       "start": 1090,
-                      "end": 1099
+                      "end": 1094
                     }
                   },
                   "body": [
@@ -1500,19 +1500,19 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                             "kind": "Unqualified",
                             "span": {
                               "start": 1287,
-                              "end": 1296
+                              "end": 1291
                             }
                           }
                         },
                         "span": {
                           "start": 1287,
-                          "end": 1296
+                          "end": 1291
                         }
                       }
                     },
                     "span": {
                       "start": 1286,
-                      "end": 1296
+                      "end": 1291
                     }
                   },
                   "body": [
@@ -2209,19 +2209,19 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                             "kind": "Unqualified",
                             "span": {
                               "start": 1744,
-                              "end": 1753
+                              "end": 1748
                             }
                           }
                         },
                         "span": {
                           "start": 1744,
-                          "end": 1753
+                          "end": 1748
                         }
                       }
                     },
                     "span": {
                       "start": 1743,
-                      "end": 1753
+                      "end": 1748
                     }
                   },
                   "body": [
@@ -2414,13 +2414,13 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                                                         "kind": "Unqualified",
                                                         "span": {
                                                           "start": 1904,
-                                                          "end": 1909
+                                                          "end": 1908
                                                         }
                                                       }
                                                     },
                                                     "span": {
                                                       "start": 1904,
-                                                      "end": 1909
+                                                      "end": 1908
                                                     }
                                                   },
                                                   "default": null,
@@ -2642,13 +2642,13 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                             "kind": "Unqualified",
                             "span": {
                               "start": 2081,
-                              "end": 2086
+                              "end": 2085
                             }
                           }
                         },
                         "span": {
                           "start": 2081,
-                          "end": 2086
+                          "end": 2085
                         }
                       },
                       "default": null,
@@ -2869,7 +2869,7 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                                   "kind": "FullyQualified",
                                   "span": {
                                     "start": 2252,
-                                    "end": 2266
+                                    "end": 2265
                                   }
                                 }
                               ],

--- a/crates/php-parser/tests/fixtures/trait_conflict_resolution.phpt
+++ b/crates/php-parser/tests/fixtures/trait_conflict_resolution.phpt
@@ -46,7 +46,7 @@ class MyClass {
                       "kind": "Unqualified",
                       "span": {
                         "start": 33,
-                        "end": 35
+                        "end": 34
                       }
                     }
                   ],

--- a/crates/php-parser/tests/fixtures/trait_multiple_alias_and_precedence.phpt
+++ b/crates/php-parser/tests/fixtures/trait_multiple_alias_and_precedence.phpt
@@ -133,7 +133,7 @@ class C {
                       "kind": "Unqualified",
                       "span": {
                         "start": 126,
-                        "end": 128
+                        "end": 127
                       }
                     }
                   ],

--- a/crates/php-parser/tests/fixtures/trait_multiple_insteadof.phpt
+++ b/crates/php-parser/tests/fixtures/trait_multiple_insteadof.phpt
@@ -157,7 +157,7 @@ class C {
                       "kind": "Unqualified",
                       "span": {
                         "start": 140,
-                        "end": 143
+                        "end": 142
                       }
                     }
                   ],

--- a/crates/php-parser/tests/fixtures/try_catch_basic.phpt
+++ b/crates/php-parser/tests/fixtures/try_catch_basic.phpt
@@ -73,7 +73,7 @@ try {
                   "kind": "Unqualified",
                   "span": {
                     "start": 48,
-                    "end": 58
+                    "end": 57
                   }
                 }
               ],

--- a/crates/php-parser/tests/fixtures/try_multi_catch.phpt
+++ b/crates/php-parser/tests/fixtures/try_multi_catch.phpt
@@ -63,7 +63,7 @@ try {
                   "kind": "Unqualified",
                   "span": {
                     "start": 46,
-                    "end": 57
+                    "end": 56
                   }
                 }
               ],

--- a/crates/php-parser/tests/fixtures/use_declarations.phpt
+++ b/crates/php-parser/tests/fixtures/use_declarations.phpt
@@ -54,7 +54,7 @@ use const App\Config\VERSION;
                 "kind": "Qualified",
                 "span": {
                   "start": 31,
-                  "end": 49
+                  "end": 48
                 }
               },
               "alias": "AuthService",

--- a/crates/php-parser/tests/fixtures/versioned/dnf_types_require_82_v81.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/dnf_types_require_82_v81.phpt
@@ -72,20 +72,20 @@ parse_version=8.1
                           "kind": "Unqualified",
                           "span": {
                             "start": 23,
-                            "end": 25
+                            "end": 24
                           }
                         }
                       },
                       "span": {
                         "start": 23,
-                        "end": 25
+                        "end": 24
                       }
                     }
                   ]
                 },
                 "span": {
                   "start": 17,
-                  "end": 25
+                  "end": 24
                 }
               },
               "default": null,

--- a/crates/php-parser/tests/fixtures/versioned/dnf_types_require_82_v82.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/dnf_types_require_82_v82.phpt
@@ -70,20 +70,20 @@ parse_version=8.2
                           "kind": "Unqualified",
                           "span": {
                             "start": 23,
-                            "end": 25
+                            "end": 24
                           }
                         }
                       },
                       "span": {
                         "start": 23,
-                        "end": 25
+                        "end": 24
                       }
                     }
                   ]
                 },
                 "span": {
                   "start": 17,
-                  "end": 25
+                  "end": 24
                 }
               },
               "default": null,

--- a/crates/php-parser/tests/malformed_php.rs
+++ b/crates/php-parser/tests/malformed_php.rs
@@ -17,6 +17,43 @@ fn format_errors(result: &php_rs_parser::ParseResult) -> String {
         .join("\n")
 }
 
+/// Run a test on a large thread stack to avoid stack overflow on deeply nested input.
+fn with_large_stack<F: FnOnce() + Send + 'static>(f: F) {
+    std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(f)
+        .unwrap()
+        .join()
+        .unwrap();
+}
+
+fn assert_has_errors(code: &str) {
+    let result = parse(code);
+    assert!(
+        !result.errors.is_empty(),
+        "expected parse errors but got none for: {}...",
+        &code[..code.len().min(80)]
+    );
+}
+
+fn assert_depth_exceeded(code: &str) {
+    let result = parse(code);
+    let msgs = format_errors(&result);
+    assert!(
+        msgs.contains("maximum expression nesting depth exceeded"),
+        "expected depth-limit error, got:\n{msgs}"
+    );
+}
+
+fn assert_no_errors(code: &str) {
+    let result = parse(code);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {}",
+        format_errors(&result)
+    );
+}
+
 // ============================================================================
 // NESTING DEPTH LIMIT
 // These tests generate input programmatically and must stay inline.
@@ -25,43 +62,193 @@ fn format_errors(result: &php_rs_parser::ParseResult) -> String {
 #[test]
 fn deeply_nested_arrays_hit_depth_limit() {
     let nested = format!("<?php {}{};", "[".repeat(75), "]".repeat(75));
-    std::thread::Builder::new()
-        .stack_size(16 * 1024 * 1024)
-        .spawn(move || {
-            let result = parse(&nested);
-            let msgs = format_errors(&result);
-            assert!(
-                !msgs.is_empty(),
-                "expected parse errors for deeply nested arrays"
-            );
-            assert!(
-                msgs.contains("maximum expression nesting depth exceeded"),
-                "expected depth-limit error, got:\n{msgs}"
-            );
-        })
-        .unwrap()
-        .join()
-        .unwrap();
+    with_large_stack(move || assert_depth_exceeded(&nested));
 }
 
 #[test]
 fn deeply_nested_parens_hit_depth_limit() {
     let nested = format!("<?php {}{};", "(".repeat(75), ")".repeat(75));
-    std::thread::Builder::new()
-        .stack_size(16 * 1024 * 1024)
-        .spawn(move || {
-            let result = parse(&nested);
-            let msgs = format_errors(&result);
-            assert!(
-                !msgs.is_empty(),
-                "expected parse errors for deeply nested parens"
-            );
-            assert!(
-                msgs.contains("maximum expression nesting depth exceeded"),
-                "expected depth-limit error, got:\n{msgs}"
-            );
-        })
-        .unwrap()
-        .join()
-        .unwrap();
+    with_large_stack(move || assert_depth_exceeded(&nested));
+}
+
+#[test]
+fn deeply_nested_ternary_hit_depth_limit() {
+    // $x ? $x ? $x ? ... : 1 : 1 : 1
+    let nested = format!(
+        "<?php {};",
+        "$x ? ".repeat(75).to_string() + "1" + &" : 1".repeat(75)
+    );
+    with_large_stack(move || assert_depth_exceeded(&nested));
+}
+
+#[test]
+fn deeply_nested_binary_ops_hit_depth_limit() {
+    // $x + ($x + ($x + ... ))
+    let nested = format!("<?php {}{};", "($x + ".repeat(75), ")".repeat(75));
+    with_large_stack(move || assert_depth_exceeded(&nested));
+}
+
+#[test]
+fn deeply_nested_function_calls_hit_depth_limit() {
+    // f(f(f(f(...))))
+    let nested = format!("<?php {}{};", "f(".repeat(75), ")".repeat(75));
+    with_large_stack(move || assert_depth_exceeded(&nested));
+}
+
+#[test]
+fn deeply_nested_match_hit_depth_limit() {
+    // match(match(match(...) {}) {}) {}
+    let open = "match(".repeat(75);
+    let close = ") { default => 1 }".repeat(75);
+    let nested = format!("<?php {open}1{close};");
+    with_large_stack(move || assert_depth_exceeded(&nested));
+}
+
+// ============================================================================
+// LARGE INPUT / REPETITIVE PATTERNS
+// Ensures the parser handles high volume without panicking or hanging.
+// ============================================================================
+
+#[test]
+fn many_sequential_statements() {
+    let code = format!("<?php {}", "$x = 1;\n".repeat(10_000));
+    let result = parse(&code);
+    assert!(result.errors.is_empty());
+}
+
+#[test]
+fn very_long_concatenation_chain() {
+    // "a" . "b" . "c" . ... (flat, not nested — should not hit depth limit)
+    let parts: Vec<&str> = (0..5_000).map(|_| "\"a\"").collect();
+    let code = format!("<?php echo {};", parts.join(" . "));
+    assert_no_errors(&code);
+}
+
+#[test]
+fn many_function_parameters() {
+    let params: Vec<String> = (0..500).map(|i| format!("$p{i}")).collect();
+    let code = format!("<?php function f({}) {{}}", params.join(", "));
+    assert_no_errors(&code);
+}
+
+#[test]
+fn many_array_elements() {
+    let elements: Vec<String> = (0..5_000).map(|i| i.to_string()).collect();
+    let code = format!("<?php [{}];", elements.join(", "));
+    assert_no_errors(&code);
+}
+
+#[test]
+fn many_match_arms() {
+    let arms: Vec<String> = (0..500).map(|i| format!("{i} => {i}")).collect();
+    let code = format!("<?php match($x) {{ {} }};", arms.join(", "));
+    assert_no_errors(&code);
+}
+
+#[test]
+fn many_method_chains() {
+    let chain = "->m()".repeat(1_000);
+    let code = format!("<?php $obj{chain};");
+    assert_no_errors(&code);
+}
+
+#[test]
+fn many_class_members() {
+    let members: Vec<String> = (0..500)
+        .map(|i| format!("public int $p{i} = {i};"))
+        .collect();
+    let code = format!("<?php class C {{ {} }}", members.join("\n"));
+    assert_no_errors(&code);
+}
+
+// ============================================================================
+// EMPTY / DEGENERATE INPUT
+// ============================================================================
+
+#[test]
+fn empty_input() {
+    assert_no_errors("");
+}
+
+#[test]
+fn only_open_tag() {
+    assert_no_errors("<?php");
+}
+
+#[test]
+fn only_whitespace_after_open_tag() {
+    assert_no_errors("<?php   \n\n\n  ");
+}
+
+#[test]
+fn null_bytes_in_source() {
+    assert_has_errors("<?php $x = \0;");
+}
+
+#[test]
+fn only_semicolons() {
+    assert_no_errors("<?php ;;;;;;;;");
+}
+
+// ============================================================================
+// UNTERMINATED CONSTRUCTS
+// ============================================================================
+
+#[test]
+fn missing_expression_after_echo() {
+    assert_has_errors("<?php echo ;");
+}
+
+#[test]
+fn unterminated_heredoc() {
+    assert_has_errors("<?php $x = <<<EOT\nhello\n");
+}
+
+#[test]
+fn unclosed_paren() {
+    assert_has_errors("<?php foo(1, 2");
+}
+
+#[test]
+fn unclosed_bracket() {
+    assert_has_errors("<?php $x = [1, 2");
+}
+
+#[test]
+fn unclosed_brace() {
+    assert_has_errors("<?php if (true) { $x = 1;");
+}
+
+#[test]
+fn unclosed_class_body() {
+    assert_has_errors("<?php class Foo { public function bar() {}");
+}
+
+// ============================================================================
+// UNEXPECTED TOKEN SEQUENCES
+// ============================================================================
+
+#[test]
+fn consecutive_operators() {
+    assert_has_errors("<?php $x = + + ;");
+}
+
+#[test]
+fn arrow_function_missing_body() {
+    assert_has_errors("<?php fn($x) =>;");
+}
+
+#[test]
+fn double_comma_in_args() {
+    assert_has_errors("<?php foo(1,, 2);");
+}
+
+#[test]
+fn keyword_salad() {
+    assert_has_errors("<?php class function while;");
+}
+
+#[test]
+fn missing_semicolons_between_statements() {
+    assert_has_errors("<?php $x = 1 $y = 2");
 }

--- a/crates/php-parser/tests/malformed_php.rs
+++ b/crates/php-parser/tests/malformed_php.rs
@@ -162,93 +162,11 @@ fn many_class_members() {
 }
 
 // ============================================================================
-// EMPTY / DEGENERATE INPUT
+// NULL BYTES
+// Cannot be expressed in .phpt fixture files.
 // ============================================================================
-
-#[test]
-fn empty_input() {
-    assert_no_errors("");
-}
-
-#[test]
-fn only_open_tag() {
-    assert_no_errors("<?php");
-}
-
-#[test]
-fn only_whitespace_after_open_tag() {
-    assert_no_errors("<?php   \n\n\n  ");
-}
 
 #[test]
 fn null_bytes_in_source() {
     assert_has_errors("<?php $x = \0;");
-}
-
-#[test]
-fn only_semicolons() {
-    assert_no_errors("<?php ;;;;;;;;");
-}
-
-// ============================================================================
-// UNTERMINATED CONSTRUCTS
-// ============================================================================
-
-#[test]
-fn missing_expression_after_echo() {
-    assert_has_errors("<?php echo ;");
-}
-
-#[test]
-fn unterminated_heredoc() {
-    assert_has_errors("<?php $x = <<<EOT\nhello\n");
-}
-
-#[test]
-fn unclosed_paren() {
-    assert_has_errors("<?php foo(1, 2");
-}
-
-#[test]
-fn unclosed_bracket() {
-    assert_has_errors("<?php $x = [1, 2");
-}
-
-#[test]
-fn unclosed_brace() {
-    assert_has_errors("<?php if (true) { $x = 1;");
-}
-
-#[test]
-fn unclosed_class_body() {
-    assert_has_errors("<?php class Foo { public function bar() {}");
-}
-
-// ============================================================================
-// UNEXPECTED TOKEN SEQUENCES
-// ============================================================================
-
-#[test]
-fn consecutive_operators() {
-    assert_has_errors("<?php $x = + + ;");
-}
-
-#[test]
-fn arrow_function_missing_body() {
-    assert_has_errors("<?php fn($x) =>;");
-}
-
-#[test]
-fn double_comma_in_args() {
-    assert_has_errors("<?php foo(1,, 2);");
-}
-
-#[test]
-fn keyword_salad() {
-    assert_has_errors("<?php class function while;");
-}
-
-#[test]
-fn missing_semicolons_between_statements() {
-    assert_has_errors("<?php $x = 1 $y = 2");
 }

--- a/crates/php-parser/tests/php_syntax.rs
+++ b/crates/php-parser/tests/php_syntax.rs
@@ -158,6 +158,8 @@ fn fixture_files_are_valid_php() {
     let mut paths = collect_phpt_files(&dir);
     paths.sort();
 
+    let mut failures: Vec<String> = Vec::new();
+
     for path in paths {
         let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
         if name == "error_recovery.phpt" || php_rejects.contains(&name) {
@@ -185,6 +187,21 @@ fn fixture_files_are_valid_php() {
         if config.expect_errors {
             continue;
         }
-        assert_php_syntax_labeled(&label, source);
+
+        let out = php_lint(source);
+        if !out.status.success() {
+            failures.push(format!(
+                "{label}:\n  {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            ));
+        }
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "php -l failed for {} fixture(s):\n\n{}",
+            failures.len(),
+            failures.join("\n\n")
+        );
     }
 }

--- a/crates/php-parser/tests/php_syntax.rs
+++ b/crates/php-parser/tests/php_syntax.rs
@@ -41,16 +41,13 @@ fn assert_php_syntax_labeled(label: &str, code: &str) {
     }
 }
 
-/// Recursively collect all `.phpt` files under `dir`, excluding `corpus/`.
+/// Recursively collect all `.phpt` files under `dir`.
 fn collect_phpt_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
     let mut paths = Vec::new();
     for entry in std::fs::read_dir(dir).unwrap().filter_map(|e| e.ok()) {
         let path = entry.path();
         if path.is_dir() {
-            let name = path.file_name().unwrap().to_str().unwrap();
-            if name != "corpus" {
-                paths.extend(collect_phpt_files(&path));
-            }
+            paths.extend(collect_phpt_files(&path));
         } else if path.extension().map_or(false, |ext| ext == "phpt") {
             paths.push(path);
         }
@@ -58,51 +55,104 @@ fn collect_phpt_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
     paths
 }
 
-/// Validates every `.phpt` fixture file through `php -l` (recursive, excluding corpus/).
+/// Validates every `.phpt` fixture file through `php -l` (recursive, including corpus/).
 /// Skips error-expected fixtures, version-specific fixtures, and known divergences.
 #[cfg_attr(not(php_available), ignore)]
 #[test]
 fn fixture_files_are_valid_php() {
     let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     // Fixtures where the Rust parser is intentionally more lenient than PHP.
-    // Each entry is documented with the reason for the divergence.
-    let php_rejects = &[
-        // Calling with & at call-site was deprecated in PHP 5.3 and removed in 5.4;
-        // our parser still accepts it for AST completeness.
+    // PHP rejects these at parse time or compile time, but our parser accepts
+    // the syntax and defers enforcement to semantic analysis.
+    //
+    // Categories:
+    //   [parse-leniency] — syntax PHP rejects at parse time; we accept for AST completeness
+    //   [semantic]        — syntactically valid but PHP rejects at compile time (Fatal error)
+    //   [deprecated]      — removed syntax our parser still accepts for compatibility
+    let php_rejects: &[&str] = &[
+        // [deprecated] Calling with & at call-site was removed in PHP 5.4.
         "arg_by_ref.phpt",
         "arg_by_ref_preserved.phpt",
-        // PHP forbids using reserved keywords as function names; our parser
-        // accepts them gracefully without panicking.
+        "args.phpt", // corpus: &$arg at call-site
+        // [parse-leniency] Reserved keywords as function names.
         "keyword_as_function_clone.phpt",
         "keyword_as_function_die.phpt",
         "keyword_as_function_exit.phpt",
         "keyword_as_function_fn.phpt",
         "keyword_as_function_match.phpt",
         "keyword_as_function_readonly.phpt",
-        // PHP rejects `null` in destructuring position; our parser accepts it
-        // and lets semantic analysis report the error.
+        "clone_function.phpt",    // corpus: function clone()
+        "exit_die_function.phpt", // corpus: function exit() / die()
+        // [semantic] Destructuring edge cases.
         "null_in_destructuring.phpt",
         "destructuring_null_vs_omit.phpt",
-        // PHP 8 made legacy octal digits (e.g. 0778) a parse error; our parser
-        // still accepts them for compatibility and emits a warning-level diagnostic.
+        "exprInList.phpt", // corpus: non-writable targets in list()
+        // [deprecated] Legacy octal digits (e.g. 0778) — parse error in PHP 8.
         "legacy_octal_invalid_digits.phpt",
-        // PHP forbids spread after named args at the engine level; our parser
-        // parses the syntax to enable better error reporting downstream.
+        "invalidOctal_1.phpt", // corpus
+        "invalidOctal_2.phpt", // corpus
+        "float.phpt",          // corpus: contains invalid numeric literal
+        // [parse-leniency] Spread after named args.
         "named_args_mixed_with_spread.phpt",
-        // PHP forbids mixing [] and list() destructuring; our parser accepts both forms.
+        // [parse-leniency] Mixing [] and list() destructuring.
         "nested_list_destructuring.phpt",
-        // PHP 8.1 only allows `new` in specific default-value positions; our parser
-        // accepts it in any initializer context.
+        // [semantic] `new` in initializer positions PHP restricts.
         "new_in_complex_initializers.phpt",
         "new_in_initializers.phpt",
-        // PHP does not support `self` in intersection return types; our parser
-        // accepts it and lets semantic analysis report the error.
+        "newInInitializer.phpt", // corpus
+        // [semantic] `self` in intersection return types.
         "return_type_self_intersection.phpt",
-        // `static;` is parsed by our parser (static as a statement); PHP rejects it.
+        // [parse-leniency] `static;` as statement.
         "static_semicolon_as_stmt.phpt",
-        // Duplicate `default` in switch is a semantic error, not a parse error;
-        // our parser accepts it and leaves this constraint to semantic analysis.
+        // [semantic] Duplicate default in switch.
         "switch_multiple_defaults.phpt",
+        // [parse-leniency] Trailing commas in positions PHP forbids.
+        "recovery_18.phpt",
+        // [deprecated] Curly brace array/string access — removed in PHP 8.0.
+        "alternative_array_syntax_1.phpt",
+        "alternative_array_syntax_2.phpt",
+        // [deprecated] Assign new by reference ($a =& new Foo) — removed in PHP 7.0.
+        "assignNewByRef_1.phpt",
+        "assignNewByRef_2.phpt",
+        // [semantic] isset() on expression result.
+        "exprInIsset.phpt",
+        // [semantic] First-class callable with `new`.
+        "firstClassCallables.phpt",
+        // [semantic] Write context for temporary expressions.
+        "misc.phpt", // corpus/expr/uvs/misc.phpt
+        // [parse-leniency] (void) cast — not valid in PHP.
+        "voidCast.phpt",
+        // [semantic] break/continue outside loop.
+        "controlFlow.phpt",
+        // [semantic] Unicode escape with codepoint too large.
+        "unicodeEscape_3.phpt",
+        // [semantic] Namespace declaration constraints (nesting, mixing, ordering).
+        "alias.phpt",
+        "groupUse.phpt",
+        "mix_1.phpt",
+        "mix_2.phpt",
+        "nested.phpt",
+        "outsideStmtInvalid_1.phpt",
+        "outsideStmtInvalid_2.phpt",
+        "outsideStmtInvalid_3.phpt",
+        // [semantic] Variadic parameter with default value.
+        "variadicDefaultValue.phpt",
+        // [semantic] Class member constraints enforced by PHP at compile time.
+        "asymmetric_visibility_1.phpt", // must have type
+        "asymmetric_visibility_2.phpt", // multiple access modifiers
+        "enum_with_string.phpt",        // backed enum case without value
+        "propertyTypes.phpt",           // static readonly
+        "property_hooks_1.phpt",        // hook parameter type mismatch
+        "property_hooks_2.phpt",        // empty hook list
+        "property_hooks_3.phpt",        // get hook with parameter list
+        "property_modifiers.phpt",      // property redeclaration
+        "readonlyMethod.phpt",          // readonly on method
+        "staticMethod_1.phpt",          // static __construct
+        "staticMethod_2.phpt",          // static __destruct
+        "staticMethod_3.phpt",          // static __clone
+        "staticMethod_4.phpt",          // static __CONSTRUCT
+        "staticMethod_5.phpt",          // static __Destruct
+        "staticMethod_6.phpt",          // static __cLoNe
     ];
 
     let mut paths = collect_phpt_files(&dir);
@@ -127,8 +177,8 @@ fn fixture_files_are_valid_php() {
                 continue;
             }
         }
-        // Skip version-specific fixtures — the installed PHP may not support the
-        // syntax being tested at the specified version.
+        // Skip version-specific fixtures — they test parser behavior at a particular
+        // PHP version and may contain syntax that PHP itself rejects semantically.
         if config.parse_version.is_some() {
             continue;
         }


### PR DESCRIPTION
## Summary
- Removed the blanket `corpus/` exclusion from `php_syntax.rs` — ~188 valid-PHP corpus fixtures are now validated via `php -l`
- Expanded the `php_rejects` skip list from 18 to 55 entries, covering newly-discovered corpus divergences
- Categorized all skip entries as `[parse-leniency]`, `[semantic]`, or `[deprecated]` for clarity

## Test plan
- [x] `cargo test -p php-rs-parser fixture_files_are_valid_php` passes
- [x] Full `cargo test -p php-rs-parser` passes
- [ ] CI passes across PHP 8.2–8.5