### PR TITLE
fix(correctness): thread PHP version through interpolation sub-parser

### DIFF
--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -921,6 +921,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                     src,
                     inner,
                     inner_offset,
+                    parser.version,
                 );
                 Expr {
                     kind: ExprKind::InterpolatedString(parts),
@@ -943,6 +944,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                     src,
                     inner,
                     inner_offset,
+                    parser.version,
                 );
                 // Collapse single literal part into String, or use InterpolatedString
                 if parts.len() == 1 {
@@ -983,6 +985,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                     src,
                     inner,
                     inner_offset,
+                    parser.version,
                 );
                 Expr {
                     kind: ExprKind::ShellExec(parts),
@@ -1007,6 +1010,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                     src,
                     inner,
                     inner_offset,
+                    parser.version,
                 );
                 Expr {
                     kind: ExprKind::ShellExec(parts),
@@ -1035,6 +1039,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                         raw_body,
                         body_offset,
                         &indent,
+                        parser.version,
                     );
                     Expr {
                         kind: ExprKind::Heredoc { label, parts },
@@ -1047,6 +1052,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                         src,
                         raw_body,
                         body_offset,
+                        parser.version,
                     );
                     Expr {
                         kind: ExprKind::Heredoc { label, parts },

--- a/crates/php-parser/src/interpolation.rs
+++ b/crates/php-parser/src/interpolation.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 
 use php_ast::*;
 
+use crate::version::PhpVersion;
+
 /// Parse the inner content of a double-quoted or backtick string into parts.
 /// `source` is the full original source string.
 /// `inner` is the string content without surrounding quotes — must be a verbatim
@@ -12,6 +14,7 @@ pub fn parse_interpolated_parts<'arena, 'src>(
     source: &'src str,
     inner: &'src str,
     base_offset: u32,
+    version: PhpVersion,
 ) -> ArenaVec<'arena, StringPart<'arena, 'src>> {
     let mut parts = ArenaVec::with_capacity_in(8, arena);
     let bytes = inner.as_bytes();
@@ -168,6 +171,7 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                             source,
                             base_offset + expr_start as u32,
                             base_offset + i as u32,
+                            version,
                         );
                         if i < len {
                             i += 1; // skip }
@@ -376,7 +380,8 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                 // Parse the expression using a sub-parser starting at the absolute offset
                 let expr_offset = base_offset + expr_start as u32;
                 let end_offset = base_offset + expr_end as u32;
-                let expr = parse_complex_interpolation(arena, source, expr_offset, end_offset);
+                let expr =
+                    parse_complex_interpolation(arena, source, expr_offset, end_offset, version);
                 parts.push(StringPart::Expr(expr));
                 literal_start = i;
             }
@@ -419,6 +424,7 @@ pub fn parse_interpolated_parts_indented<'arena, 'src>(
     raw_body: &'src str,
     body_offset: u32,
     indent: &str,
+    version: PhpVersion,
 ) -> ArenaVec<'arena, StringPart<'arena, 'src>> {
     let indent_len = indent.len();
     let mut parts: ArenaVec<'arena, StringPart<'arena, 'src>> =
@@ -662,7 +668,8 @@ pub fn parse_interpolated_parts_indented<'arena, 'src>(
                 // correct absolute position — use the fast sub-parser path directly.
                 let expr_offset = body_offset + expr_start as u32;
                 let end_offset = body_offset + expr_end as u32;
-                let expr = parse_complex_interpolation(arena, source, expr_offset, end_offset);
+                let expr =
+                    parse_complex_interpolation(arena, source, expr_offset, end_offset, version);
                 parts.push(StringPart::Expr(expr));
             }
             _ => {
@@ -761,13 +768,9 @@ fn parse_complex_interpolation<'arena, 'src>(
     source: &'src str,
     offset: u32,
     end: u32,
+    version: PhpVersion,
 ) -> Expr<'arena, 'src> {
-    let mut sub = crate::parser::Parser::new_at(
-        arena,
-        source,
-        offset as usize,
-        crate::version::PhpVersion::default(),
-    );
+    let mut sub = crate::parser::Parser::new_at(arena, source, offset as usize, version);
     let expr = crate::expr::parse_expr(&mut sub);
     if matches!(expr.kind, ExprKind::Error) {
         Expr {

--- a/crates/php-parser/tests/fixtures/versioned/interpolation_respects_version_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/interpolation_respects_version_v80.phpt
@@ -1,0 +1,82 @@
+===config===
+parse_version=8.0
+===source===
+<?php
+$x = "{$obj?->prop}";
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Expr": {
+                        "kind": {
+                          "NullsafePropertyAccess": {
+                            "object": {
+                              "kind": {
+                                "Variable": "obj"
+                              },
+                              "span": {
+                                "start": 13,
+                                "end": 17
+                              }
+                            },
+                            "property": {
+                              "kind": {
+                                "Identifier": "prop"
+                              },
+                              "span": {
+                                "start": 20,
+                                "end": 24
+                              }
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 13,
+                          "end": 24
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 26
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 26
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 27
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 27
+  }
+}


### PR DESCRIPTION
## Summary

- Thread the configured `PhpVersion` through `parse_interpolated_parts`, `parse_interpolated_parts_indented`, and `parse_complex_interpolation`
- The interpolation sub-parser (`Parser::new_at`) was hardcoding `PhpVersion::default()` (8.5), silently bypassing all version checks inside interpolated strings, heredocs, and shell exec
- Add regression test fixture for version-aware interpolation parsing

Fixes #72

## Test plan
- [x] All existing tests pass
- [x] New `versioned/interpolation_respects_version_v80.phpt` fixture verifies version threading
- [x] Pre-commit hooks (fmt + clippy) pass