### PR TITLE
fix(correctness): reject chained non-associative operators and ternaries in PHP 8

### DIFF
--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -10,6 +10,41 @@ use crate::precedence::{self, ASSIGNMENT_BP, TERNARY_BP};
 use crate::stmt;
 use crate::version::PhpVersion;
 
+/// Returns true if the token is a non-associative operator in PHP 8.
+/// Chaining these (e.g. `1 < 2 < 3`) is a fatal error in PHP 8.0+.
+fn is_nonassoc_token(kind: TokenKind) -> bool {
+    matches!(
+        kind,
+        TokenKind::EqualsEquals
+            | TokenKind::BangEquals
+            | TokenKind::EqualsEqualsEquals
+            | TokenKind::BangEqualsEquals
+            | TokenKind::Spaceship
+            | TokenKind::LessThan
+            | TokenKind::GreaterThan
+            | TokenKind::LessThanEquals
+            | TokenKind::GreaterThanEquals
+            | TokenKind::Instanceof
+    )
+}
+
+/// Returns true if the binary op is a non-associative operator.
+fn is_nonassoc_binary_op(op: BinaryOp) -> bool {
+    matches!(
+        op,
+        BinaryOp::Equal
+            | BinaryOp::NotEqual
+            | BinaryOp::Identical
+            | BinaryOp::NotIdentical
+            | BinaryOp::Spaceship
+            | BinaryOp::Less
+            | BinaryOp::Greater
+            | BinaryOp::LessOrEqual
+            | BinaryOp::GreaterOrEqual
+            | BinaryOp::Instanceof
+    )
+}
+
 /// Cast keyword strings and their CastKind values
 const CAST_KEYWORDS: &[(&str, CastKind)] = &[
     ("int", CastKind::Int),
@@ -89,14 +124,13 @@ pub fn parse_expr_bp<'arena, 'src>(
                 }
             }
 
-            // Ternary operator (right-associative, special handling)
+            // Ternary operator (non-associative in PHP 8.0+)
             TokenKind::Question => {
                 if TERNARY_BP < min_bp {
                     break;
                 }
                 // PHP 8.0+: unparenthesized ternary chaining is a fatal parse error.
-                // `a ? b : c ? d : e` must be parenthesized; detect by checking
-                // whether the current lhs is already a completed ternary.
+                // Pattern B: `a ? b : c ? d : e` — LHS is already a ternary.
                 if parser.version >= PhpVersion::Php80 && matches!(lhs.kind, ExprKind::Ternary(_)) {
                     let span = parser.current_span();
                     parser.error(ParseError::Forbidden {
@@ -113,11 +147,23 @@ pub fn parse_expr_bp<'arena, 'src>(
                     None
                 } else {
                     let e = parse_expr_bp(parser, 0);
+                    // PHP 8.0+: Pattern A: `a ? b ? c : d : e` — then branch is an
+                    // unparenthesized ternary (Parenthesized wrapping is fine).
+                    if parser.version >= PhpVersion::Php80 && matches!(e.kind, ExprKind::Ternary(_))
+                    {
+                        parser.error(ParseError::Forbidden {
+                            message: "Unparenthesized `a ? b ? c : d : e` is not supported. \
+                                  Use parentheses to make the order explicit."
+                                .into(),
+                            span: e.span,
+                        });
+                    }
                     Some(parser.alloc(e))
                 };
 
                 parser.expect(TokenKind::Colon);
-                // Ternary is LEFT-associative in PHP, so use TERNARY_BP + 1
+                // Non-associative in PHP 8.0+; use TERNARY_BP + 1 to prevent
+                // the else branch from consuming another ternary at the same level.
                 let else_expr = parse_expr_bp(parser, TERNARY_BP + 1);
                 let span = lhs.span.merge(else_expr.span);
                 lhs = Expr {
@@ -494,6 +540,20 @@ pub fn parse_expr_bp<'arena, 'src>(
         if let Some((left_bp, right_bp)) = precedence::infix_binding_power(kind) {
             if left_bp < min_bp {
                 break;
+            }
+            // PHP 8.0+: chaining non-associative operators is a fatal error.
+            // Detect when the LHS is already a binary expression with a non-assoc op
+            // and the current token is also a non-assoc op at the same precedence level.
+            if parser.version >= PhpVersion::Php80
+                && is_nonassoc_token(kind)
+                && matches!(&lhs.kind, ExprKind::Binary(b) if is_nonassoc_binary_op(b.op))
+            {
+                let span = parser.current_span();
+                parser.error(ParseError::Forbidden {
+                    message: "Chaining non-associative operators requires explicit parentheses."
+                        .into(),
+                    span,
+                });
             }
             let op_token = parser.advance();
             if op_token.kind == TokenKind::PipeArrow {

--- a/crates/php-parser/tests/fixtures/complex_ternary_coalesce.phpt
+++ b/crates/php-parser/tests/fixtures/complex_ternary_coalesce.phpt
@@ -2,7 +2,6 @@
 <?php
 $a = $x ?: $y ?? $z;
 $b = $x ?? $y ?: $z;
-$c = $a ? $b ? $c : $d : $e;
 $d = ($a ?? $b) ? ($c ?: $d) : ($e ?? $f);
 ===ast===
 {
@@ -166,104 +165,11 @@ $d = ($a ?? $b) ? ($c ?: $d) : ($e ?? $f);
             "Assign": {
               "target": {
                 "kind": {
-                  "Variable": "c"
+                  "Variable": "d"
                 },
                 "span": {
                   "start": 48,
                   "end": 50
-                }
-              },
-              "op": "Assign",
-              "value": {
-                "kind": {
-                  "Ternary": {
-                    "condition": {
-                      "kind": {
-                        "Variable": "a"
-                      },
-                      "span": {
-                        "start": 53,
-                        "end": 55
-                      }
-                    },
-                    "then_expr": {
-                      "kind": {
-                        "Ternary": {
-                          "condition": {
-                            "kind": {
-                              "Variable": "b"
-                            },
-                            "span": {
-                              "start": 58,
-                              "end": 60
-                            }
-                          },
-                          "then_expr": {
-                            "kind": {
-                              "Variable": "c"
-                            },
-                            "span": {
-                              "start": 63,
-                              "end": 65
-                            }
-                          },
-                          "else_expr": {
-                            "kind": {
-                              "Variable": "d"
-                            },
-                            "span": {
-                              "start": 68,
-                              "end": 70
-                            }
-                          }
-                        }
-                      },
-                      "span": {
-                        "start": 58,
-                        "end": 70
-                      }
-                    },
-                    "else_expr": {
-                      "kind": {
-                        "Variable": "e"
-                      },
-                      "span": {
-                        "start": 73,
-                        "end": 75
-                      }
-                    }
-                  }
-                },
-                "span": {
-                  "start": 53,
-                  "end": 75
-                }
-              }
-            }
-          },
-          "span": {
-            "start": 48,
-            "end": 75
-          }
-        }
-      },
-      "span": {
-        "start": 48,
-        "end": 76
-      }
-    },
-    {
-      "kind": {
-        "Expression": {
-          "kind": {
-            "Assign": {
-              "target": {
-                "kind": {
-                  "Variable": "d"
-                },
-                "span": {
-                  "start": 77,
-                  "end": 79
                 }
               },
               "op": "Assign",
@@ -280,8 +186,8 @@ $d = ($a ?? $b) ? ($c ?: $d) : ($e ?? $f);
                                   "Variable": "a"
                                 },
                                 "span": {
-                                  "start": 83,
-                                  "end": 85
+                                  "start": 54,
+                                  "end": 56
                                 }
                               },
                               "right": {
@@ -289,21 +195,21 @@ $d = ($a ?? $b) ? ($c ?: $d) : ($e ?? $f);
                                   "Variable": "b"
                                 },
                                 "span": {
-                                  "start": 89,
-                                  "end": 91
+                                  "start": 60,
+                                  "end": 62
                                 }
                               }
                             }
                           },
                           "span": {
-                            "start": 83,
-                            "end": 91
+                            "start": 54,
+                            "end": 62
                           }
                         }
                       },
                       "span": {
-                        "start": 82,
-                        "end": 92
+                        "start": 53,
+                        "end": 63
                       }
                     },
                     "then_expr": {
@@ -316,8 +222,8 @@ $d = ($a ?? $b) ? ($c ?: $d) : ($e ?? $f);
                                   "Variable": "c"
                                 },
                                 "span": {
-                                  "start": 96,
-                                  "end": 98
+                                  "start": 67,
+                                  "end": 69
                                 }
                               },
                               "then_expr": null,
@@ -326,21 +232,21 @@ $d = ($a ?? $b) ? ($c ?: $d) : ($e ?? $f);
                                   "Variable": "d"
                                 },
                                 "span": {
-                                  "start": 102,
-                                  "end": 104
+                                  "start": 73,
+                                  "end": 75
                                 }
                               }
                             }
                           },
                           "span": {
-                            "start": 96,
-                            "end": 104
+                            "start": 67,
+                            "end": 75
                           }
                         }
                       },
                       "span": {
-                        "start": 95,
-                        "end": 105
+                        "start": 66,
+                        "end": 76
                       }
                     },
                     "else_expr": {
@@ -353,8 +259,8 @@ $d = ($a ?? $b) ? ($c ?: $d) : ($e ?? $f);
                                   "Variable": "e"
                                 },
                                 "span": {
-                                  "start": 109,
-                                  "end": 111
+                                  "start": 80,
+                                  "end": 82
                                 }
                               },
                               "right": {
@@ -362,46 +268,46 @@ $d = ($a ?? $b) ? ($c ?: $d) : ($e ?? $f);
                                   "Variable": "f"
                                 },
                                 "span": {
-                                  "start": 115,
-                                  "end": 117
+                                  "start": 86,
+                                  "end": 88
                                 }
                               }
                             }
                           },
                           "span": {
-                            "start": 109,
-                            "end": 117
+                            "start": 80,
+                            "end": 88
                           }
                         }
                       },
                       "span": {
-                        "start": 108,
-                        "end": 118
+                        "start": 79,
+                        "end": 89
                       }
                     }
                   }
                 },
                 "span": {
-                  "start": 82,
-                  "end": 118
+                  "start": 53,
+                  "end": 89
                 }
               }
             }
           },
           "span": {
-            "start": 77,
-            "end": 118
+            "start": 48,
+            "end": 89
           }
         }
       },
       "span": {
-        "start": 77,
-        "end": 119
+        "start": 48,
+        "end": 90
       }
     }
   ],
   "span": {
     "start": 0,
-    "end": 119
+    "end": 90
   }
 }

--- a/crates/php-parser/tests/fixtures/versioned/nonassoc_chaining_rejected_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/nonassoc_chaining_rejected_v80.phpt
@@ -1,0 +1,251 @@
+===config===
+parse_version=8.0
+===source===
+<?php
+$a = 1 < 2 < 3;
+$b = 1 == 1 == 1;
+$c = $x <=> $y <=> $z;
+===errors===
+Chaining non-associative operators requires explicit parentheses.
+Chaining non-associative operators requires explicit parentheses.
+Chaining non-associative operators requires explicit parentheses.
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "a"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Binary": {
+                    "left": {
+                      "kind": {
+                        "Binary": {
+                          "left": {
+                            "kind": {
+                              "Int": 1
+                            },
+                            "span": {
+                              "start": 11,
+                              "end": 12
+                            }
+                          },
+                          "op": "Less",
+                          "right": {
+                            "kind": {
+                              "Int": 2
+                            },
+                            "span": {
+                              "start": 15,
+                              "end": 16
+                            }
+                          }
+                        }
+                      },
+                      "span": {
+                        "start": 11,
+                        "end": 16
+                      }
+                    },
+                    "op": "Less",
+                    "right": {
+                      "kind": {
+                        "Int": 3
+                      },
+                      "span": {
+                        "start": 19,
+                        "end": 20
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 20
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 20
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 21
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "b"
+                },
+                "span": {
+                  "start": 22,
+                  "end": 24
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Binary": {
+                    "left": {
+                      "kind": {
+                        "Binary": {
+                          "left": {
+                            "kind": {
+                              "Int": 1
+                            },
+                            "span": {
+                              "start": 27,
+                              "end": 28
+                            }
+                          },
+                          "op": "Equal",
+                          "right": {
+                            "kind": {
+                              "Int": 1
+                            },
+                            "span": {
+                              "start": 32,
+                              "end": 33
+                            }
+                          }
+                        }
+                      },
+                      "span": {
+                        "start": 27,
+                        "end": 33
+                      }
+                    },
+                    "op": "Equal",
+                    "right": {
+                      "kind": {
+                        "Int": 1
+                      },
+                      "span": {
+                        "start": 37,
+                        "end": 38
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 27,
+                  "end": 38
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 22,
+            "end": 38
+          }
+        }
+      },
+      "span": {
+        "start": 22,
+        "end": 39
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "c"
+                },
+                "span": {
+                  "start": 40,
+                  "end": 42
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Binary": {
+                    "left": {
+                      "kind": {
+                        "Binary": {
+                          "left": {
+                            "kind": {
+                              "Variable": "x"
+                            },
+                            "span": {
+                              "start": 45,
+                              "end": 47
+                            }
+                          },
+                          "op": "Spaceship",
+                          "right": {
+                            "kind": {
+                              "Variable": "y"
+                            },
+                            "span": {
+                              "start": 52,
+                              "end": 54
+                            }
+                          }
+                        }
+                      },
+                      "span": {
+                        "start": 45,
+                        "end": 54
+                      }
+                    },
+                    "op": "Spaceship",
+                    "right": {
+                      "kind": {
+                        "Variable": "z"
+                      },
+                      "span": {
+                        "start": 59,
+                        "end": 61
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 45,
+                  "end": 61
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 40,
+            "end": 61
+          }
+        }
+      },
+      "span": {
+        "start": 40,
+        "end": 62
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 62
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/ternary_chaining_rejected_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/ternary_chaining_rejected_v80.phpt
@@ -1,0 +1,204 @@
+===config===
+parse_version=8.0
+===source===
+<?php
+$a = $x ? $y ? 1 : 2 : 3;
+$b = $x ? 1 : $y ? 2 : 3;
+===errors===
+Unparenthesized `a ? b ? c : d : e` is not supported. Use parentheses to make the order explicit.
+Unparenthesized `a ? b : c ? d : e` is not supported. Use parentheses to make the order explicit.
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "a"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Ternary": {
+                    "condition": {
+                      "kind": {
+                        "Variable": "x"
+                      },
+                      "span": {
+                        "start": 11,
+                        "end": 13
+                      }
+                    },
+                    "then_expr": {
+                      "kind": {
+                        "Ternary": {
+                          "condition": {
+                            "kind": {
+                              "Variable": "y"
+                            },
+                            "span": {
+                              "start": 16,
+                              "end": 18
+                            }
+                          },
+                          "then_expr": {
+                            "kind": {
+                              "Int": 1
+                            },
+                            "span": {
+                              "start": 21,
+                              "end": 22
+                            }
+                          },
+                          "else_expr": {
+                            "kind": {
+                              "Int": 2
+                            },
+                            "span": {
+                              "start": 25,
+                              "end": 26
+                            }
+                          }
+                        }
+                      },
+                      "span": {
+                        "start": 16,
+                        "end": 26
+                      }
+                    },
+                    "else_expr": {
+                      "kind": {
+                        "Int": 3
+                      },
+                      "span": {
+                        "start": 29,
+                        "end": 30
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 30
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 30
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 31
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "b"
+                },
+                "span": {
+                  "start": 32,
+                  "end": 34
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Ternary": {
+                    "condition": {
+                      "kind": {
+                        "Ternary": {
+                          "condition": {
+                            "kind": {
+                              "Variable": "x"
+                            },
+                            "span": {
+                              "start": 37,
+                              "end": 39
+                            }
+                          },
+                          "then_expr": {
+                            "kind": {
+                              "Int": 1
+                            },
+                            "span": {
+                              "start": 42,
+                              "end": 43
+                            }
+                          },
+                          "else_expr": {
+                            "kind": {
+                              "Variable": "y"
+                            },
+                            "span": {
+                              "start": 46,
+                              "end": 48
+                            }
+                          }
+                        }
+                      },
+                      "span": {
+                        "start": 37,
+                        "end": 48
+                      }
+                    },
+                    "then_expr": {
+                      "kind": {
+                        "Int": 2
+                      },
+                      "span": {
+                        "start": 51,
+                        "end": 52
+                      }
+                    },
+                    "else_expr": {
+                      "kind": {
+                        "Int": 3
+                      },
+                      "span": {
+                        "start": 55,
+                        "end": 56
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 37,
+                  "end": 56
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 32,
+            "end": 56
+          }
+        }
+      },
+      "span": {
+        "start": 32,
+        "end": 57
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 57
+  }
+}


### PR DESCRIPTION
## Summary

- Detect chained non-associative operators (`<`, `==`, `===`, `!=`, `!==`, `<=>`, `>=`, `<=`, `>`, `instanceof`) and emit `ParseError::Forbidden` when `version >= PHP 8.0`
- Detect both ternary chaining patterns:
  - Pattern A: `$a ? $b ? $c : $d : $e` (unparenthesized ternary in then-branch)
  - Pattern B: `$a ? $b : $c ? $d : $e` (ternary accumulated in LHS)
- Fix contradictory comments about ternary associativity
- Remove chained ternary from `complex_ternary_coalesce.phpt` (now covered by error fixtures)

Fixes #50
Fixes #71

## Test plan
- [x] All existing tests pass
- [x] New `versioned/nonassoc_chaining_rejected_v80.phpt` verifies `1 < 2 < 3`, `1 == 1 == 1`, `$x <=> $y <=> $z` produce errors
- [x] New `versioned/ternary_chaining_rejected_v80.phpt` verifies both ternary patterns produce errors
- [x] Pre-commit hooks (fmt + clippy) pass