### PR TITLE
fix(diagnostics): reject void/never/mixed in unions, static readonly, abstract final class

### DIFF
--- a/crates/php-parser/src/parser.rs
+++ b/crates/php-parser/src/parser.rs
@@ -632,6 +632,23 @@ impl<'arena, 'src> Parser<'arena, 'src> {
                     span,
                 });
             }
+            // void, never, and mixed cannot appear in union types
+            for ty in types.iter() {
+                if let TypeHintKind::Keyword(builtin, _) = &ty.kind {
+                    let msg = match builtin {
+                        BuiltinType::Void => Some("void cannot be used as part of a union type"),
+                        BuiltinType::Never => Some("never cannot be used as part of a union type"),
+                        BuiltinType::Mixed => Some("mixed cannot be used as part of a union type"),
+                        _ => None,
+                    };
+                    if let Some(msg) = msg {
+                        self.error(ParseError::Forbidden {
+                            message: msg.into(),
+                            span: ty.span,
+                        });
+                    }
+                }
+            }
             // DNF types (parenthesized intersection in union) require PHP 8.2
             let has_dnf = types
                 .iter()

--- a/crates/php-parser/src/stmt.rs
+++ b/crates/php-parser/src/stmt.rs
@@ -146,6 +146,26 @@ pub fn parse_stmt<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Stmt<'a
                     },
                     parser.alloc_vec(),
                 )
+            } else if parser.check(TokenKind::Final) {
+                // `abstract final class` — collect both modifiers and emit diagnostic
+                parser.advance(); // consume 'final'
+                parser.error(ParseError::Forbidden {
+                    message: "cannot use 'abstract' and 'final' together on a class".into(),
+                    span: Span::new(start, parser.previous_end()),
+                });
+                if parser.check(TokenKind::Class) {
+                    parse_class(
+                        parser,
+                        ClassModifiers {
+                            is_abstract: true,
+                            is_final: true,
+                            ..Default::default()
+                        },
+                        parser.alloc_vec(),
+                    )
+                } else {
+                    class_modifier_error(parser, start)
+                }
             } else {
                 // abstract without class - error recovery
                 class_modifier_error(parser, start)
@@ -173,6 +193,26 @@ pub fn parse_stmt<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Stmt<'a
                         ClassModifiers {
                             is_final: true,
                             is_readonly: true,
+                            ..Default::default()
+                        },
+                        parser.alloc_vec(),
+                    )
+                } else {
+                    class_modifier_error(parser, start)
+                }
+            } else if parser.check(TokenKind::Abstract) {
+                // `final abstract class` — collect both modifiers and emit diagnostic
+                parser.advance(); // consume 'abstract'
+                parser.error(ParseError::Forbidden {
+                    message: "cannot use 'abstract' and 'final' together on a class".into(),
+                    span: Span::new(start, parser.previous_end()),
+                });
+                if parser.check(TokenKind::Class) {
+                    parse_class(
+                        parser,
+                        ClassModifiers {
+                            is_abstract: true,
+                            is_final: true,
                             ..Default::default()
                         },
                         parser.alloc_vec(),
@@ -313,11 +353,31 @@ fn parse_attributed_stmt<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> 
                     },
                     attributes,
                 );
+            } else if parser.check(TokenKind::Final) {
+                parser.advance();
+                parser.error(ParseError::Forbidden {
+                    message: "cannot use 'abstract' and 'final' together on a class".into(),
+                    span: Span::new(start, parser.previous_end()),
+                });
+                if parser.check(TokenKind::Class) {
+                    return parse_class(
+                        parser,
+                        ClassModifiers {
+                            is_abstract: true,
+                            is_final: true,
+                            ..Default::default()
+                        },
+                        attributes,
+                    );
+                } else {
+                    class_modifier_error(parser, start)
+                }
             } else {
                 class_modifier_error(parser, start)
             }
         }
         TokenKind::Final => {
+            let start = parser.start_span();
             parser.advance();
             if parser.check(TokenKind::Class) {
                 parse_class(
@@ -341,18 +401,27 @@ fn parse_attributed_stmt<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> 
                     },
                     attributes,
                 )
-            } else {
-                let span = parser.current_span();
-                parser.error(ParseError::Expected {
-                    expected: "'class'".into(),
-                    found: parser.current_kind(),
-                    span,
+            } else if parser.check(TokenKind::Abstract) {
+                parser.advance();
+                parser.error(ParseError::Forbidden {
+                    message: "cannot use 'abstract' and 'final' together on a class".into(),
+                    span: Span::new(start, parser.previous_end()),
                 });
-                parser.synchronize();
-                Stmt {
-                    kind: StmtKind::Error,
-                    span,
+                if parser.check(TokenKind::Class) {
+                    parse_class(
+                        parser,
+                        ClassModifiers {
+                            is_abstract: true,
+                            is_final: true,
+                            ..Default::default()
+                        },
+                        attributes,
+                    )
+                } else {
+                    class_modifier_error(parser, start)
                 }
+            } else {
+                class_modifier_error(parser, start)
             }
         }
         TokenKind::Readonly => {
@@ -2109,6 +2178,12 @@ pub fn parse_class_members<'arena, 'src>(
         if is_abstract && is_final {
             parser.error(ParseError::Forbidden {
                 message: "cannot use 'abstract' and 'final' together".into(),
+                span: Span::new(member_start, parser.previous_end()),
+            });
+        }
+        if is_static && is_readonly {
+            parser.error(ParseError::Forbidden {
+                message: "static properties cannot be readonly".into(),
                 span: Span::new(member_start, parser.previous_end()),
             });
         }

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_8.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_8.phpt
@@ -1,23 +1,16 @@
 ===source===
 <?php abstract final class A { }
 ===errors===
-expected 'class', found 'final'
+cannot use 'abstract' and 'final' together on a class
 ===ast===
 {
   "stmts": [
-    {
-      "kind": "Error",
-      "span": {
-        "start": 6,
-        "end": 14
-      }
-    },
     {
       "kind": {
         "Class": {
           "name": "A",
           "modifiers": {
-            "is_abstract": false,
+            "is_abstract": true,
             "is_final": true,
             "is_readonly": false
           },

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/propertyTypes.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/propertyTypes.phpt
@@ -7,6 +7,8 @@ class A {
     private ?float $c;
     readonly static public ?int $d;
 }
+===errors===
+static properties cannot be readonly
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/errors/abstract_final_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_final_class.phpt
@@ -1,6 +1,9 @@
 ===source===
-<?php abstract final class Foo {}
+<?php
+abstract final class Foo {}
+final abstract class Bar {}
 ===errors===
+cannot use 'abstract' and 'final' together on a class
 cannot use 'abstract' and 'final' together on a class
 ===ast===
 {
@@ -24,10 +27,30 @@ cannot use 'abstract' and 'final' together on a class
         "start": 21,
         "end": 33
       }
+    },
+    {
+      "kind": {
+        "Class": {
+          "name": "Bar",
+          "modifiers": {
+            "is_abstract": true,
+            "is_final": true,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 49,
+        "end": 61
+      }
     }
   ],
   "span": {
     "start": 0,
-    "end": 33
+    "end": 61
   }
 }

--- a/crates/php-parser/tests/fixtures/errors/static_readonly_property.phpt
+++ b/crates/php-parser/tests/fixtures/errors/static_readonly_property.phpt
@@ -1,0 +1,80 @@
+===source===
+<?php
+class Foo {
+    public static readonly int $x = 1;
+}
+===errors===
+static properties cannot be readonly
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "x",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": true,
+                  "is_readonly": true,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "int"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 45,
+                          "end": 48
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 45,
+                      "end": 48
+                    }
+                  },
+                  "default": {
+                    "kind": {
+                      "Int": 1
+                    },
+                    "span": {
+                      "start": 54,
+                      "end": 55
+                    }
+                  },
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 22,
+                "end": 55
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 58
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 58
+  }
+}

--- a/crates/php-parser/tests/fixtures/errors/void_never_mixed_in_union.phpt
+++ b/crates/php-parser/tests/fixtures/errors/void_never_mixed_in_union.phpt
@@ -1,0 +1,201 @@
+===source===
+<?php
+function a(): int|void {}
+function b(): int|never {}
+function c(): int|mixed {}
+===errors===
+void cannot be used as part of a union type
+never cannot be used as part of a union type
+mixed cannot be used as part of a union type
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Function": {
+          "name": "a",
+          "params": [],
+          "body": [],
+          "return_type": {
+            "kind": {
+              "Union": [
+                {
+                  "kind": {
+                    "Named": {
+                      "parts": [
+                        "int"
+                      ],
+                      "kind": "Unqualified",
+                      "span": {
+                        "start": 20,
+                        "end": 23
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 20,
+                    "end": 23
+                  }
+                },
+                {
+                  "kind": {
+                    "Named": {
+                      "parts": [
+                        "void"
+                      ],
+                      "kind": "Unqualified",
+                      "span": {
+                        "start": 24,
+                        "end": 28
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 24,
+                    "end": 28
+                  }
+                }
+              ]
+            },
+            "span": {
+              "start": 20,
+              "end": 28
+            }
+          },
+          "by_ref": false,
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 31
+      }
+    },
+    {
+      "kind": {
+        "Function": {
+          "name": "b",
+          "params": [],
+          "body": [],
+          "return_type": {
+            "kind": {
+              "Union": [
+                {
+                  "kind": {
+                    "Named": {
+                      "parts": [
+                        "int"
+                      ],
+                      "kind": "Unqualified",
+                      "span": {
+                        "start": 46,
+                        "end": 49
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 46,
+                    "end": 49
+                  }
+                },
+                {
+                  "kind": {
+                    "Named": {
+                      "parts": [
+                        "never"
+                      ],
+                      "kind": "Unqualified",
+                      "span": {
+                        "start": 50,
+                        "end": 55
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 50,
+                    "end": 55
+                  }
+                }
+              ]
+            },
+            "span": {
+              "start": 46,
+              "end": 55
+            }
+          },
+          "by_ref": false,
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 32,
+        "end": 58
+      }
+    },
+    {
+      "kind": {
+        "Function": {
+          "name": "c",
+          "params": [],
+          "body": [],
+          "return_type": {
+            "kind": {
+              "Union": [
+                {
+                  "kind": {
+                    "Named": {
+                      "parts": [
+                        "int"
+                      ],
+                      "kind": "Unqualified",
+                      "span": {
+                        "start": 73,
+                        "end": 76
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 73,
+                    "end": 76
+                  }
+                },
+                {
+                  "kind": {
+                    "Named": {
+                      "parts": [
+                        "mixed"
+                      ],
+                      "kind": "Unqualified",
+                      "span": {
+                        "start": 77,
+                        "end": 82
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 77,
+                    "end": 82
+                  }
+                }
+              ]
+            },
+            "span": {
+              "start": 73,
+              "end": 82
+            }
+          },
+          "by_ref": false,
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 59,
+        "end": 85
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 85
+  }
+}


### PR DESCRIPTION
## Summary

- **#56**: Reject `void`, `never`, and `mixed` in union types — these are standalone-only types
- **#55**: Reject `static readonly` properties — readonly is meaningless on static properties
- **#88**: `abstract final class` now produces a single Class node with both modifiers + a Forbidden diagnostic (instead of Error node + incomplete Class). Handles both orderings.

Fixes #56
Fixes #55
Fixes #88

## Test plan
- [x] All existing tests pass (updated `propertyTypes.phpt`, `modifier_error_8.phpt`, `invalid_abstract_final_class.phpt`)
- [x] New `errors/void_never_mixed_in_union.phpt`
- [x] New `errors/static_readonly_property.phpt`
- [x] New `errors/abstract_final_class.phpt`
- [x] Pre-commit hooks (fmt + clippy) pass