### PR TITLE
fix: add missing version gates and cast diagnostics

### DIFF
--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -342,6 +342,12 @@ pub fn parse_expr_bp<'arena, 'src>(
                 };
             } else if parser.check(TokenKind::LeftBrace) {
                 // Dynamic class constant/method: A::{'b'}(), Foo::{bar()}
+                let brace_span = parser.current_span();
+                parser.require_version(
+                    PhpVersion::Php83,
+                    "dynamic class constant fetch",
+                    brace_span,
+                );
                 parser.advance(); // consume {
                 let member = parse_expr(parser);
                 parser.expect(TokenKind::RightBrace);
@@ -2554,6 +2560,20 @@ fn try_parse_cast<'arena, 'src>(
     }
     if cast_kind == CastKind::Void {
         parser.require_version(PhpVersion::Php85, "void cast", kw_span);
+    }
+    // (real) was removed in PHP 8.0, (binary) is a PHP 5-era artifact
+    let kw_text = &parser.source[kw_span.start as usize..kw_span.end as usize];
+    if kw_text.eq_ignore_ascii_case("real") {
+        parser.error(ParseError::Forbidden {
+            message: "the (real) cast is no longer supported, use (float) instead".into(),
+            span: kw_span,
+        });
+    }
+    if kw_text.eq_ignore_ascii_case("binary") {
+        parser.error(ParseError::Forbidden {
+            message: "the (binary) cast is not supported, use (string) instead".into(),
+            span: kw_span,
+        });
     }
 
     let operand = parse_expr_bp(parser, 41);

--- a/crates/php-parser/tests/fixtures/corpus/expr/cast.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/cast.phpt
@@ -12,6 +12,7 @@
 (string)  $a;
 (unset)   $a;
 ===errors===
+the (real) cast is no longer supported, use (float) instead
 the (unset) cast is no longer supported
 ===ast===
 {

--- a/crates/php-parser/tests/fixtures/corpus/formattingAttributes.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/formattingAttributes.phpt
@@ -48,6 +48,8 @@ list($x) = $y;
 (boolean) $boolean;
 (string) $string;
 (binary) $binary;
+===errors===
+the (binary) cast is not supported, use (string) instead
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/errors/cast_real_binary_rejected.phpt
+++ b/crates/php-parser/tests/fixtures/errors/cast_real_binary_rejected.phpt
@@ -1,0 +1,112 @@
+===source===
+<?php
+$a = (real) 1.5;
+$b = (binary) "hello";
+===errors===
+the (real) cast is no longer supported, use (float) instead
+the (binary) cast is not supported, use (string) instead
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "a"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Cast": [
+                    "Float",
+                    {
+                      "kind": {
+                        "Float": 1.5
+                      },
+                      "span": {
+                        "start": 18,
+                        "end": 21
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 21
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 21
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 22
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "b"
+                },
+                "span": {
+                  "start": 23,
+                  "end": 25
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Cast": [
+                    "String",
+                    {
+                      "kind": {
+                        "String": "hello"
+                      },
+                      "span": {
+                        "start": 37,
+                        "end": 44
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 28,
+                  "end": 44
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 23,
+            "end": 44
+          }
+        }
+      },
+      "span": {
+        "start": 23,
+        "end": 45
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 45
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/dynamic_class_const_requires_83_v82.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/dynamic_class_const_requires_83_v82.phpt
@@ -1,0 +1,72 @@
+===config===
+parse_version=8.2
+===source===
+<?php
+$x = Foo::{$name};
+===errors===
+'dynamic class constant fetch' requires PHP 8.3 or higher (targeting PHP 8.2)
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "ClassConstAccessDynamic": {
+                    "class": {
+                      "kind": {
+                        "Identifier": "Foo"
+                      },
+                      "span": {
+                        "start": 11,
+                        "end": 14
+                      }
+                    },
+                    "member": {
+                      "kind": {
+                        "Variable": "name"
+                      },
+                      "span": {
+                        "start": 17,
+                        "end": 22
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 23
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 23
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 24
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 24
+  }
+}


### PR DESCRIPTION
## Summary

- Add PHP 8.3 version gate for dynamic class constant fetch (`Foo::{$name}`)
- Reject `(real)` cast (removed in PHP 8.0, suggest `(float)`)
- Reject `(binary)` cast (PHP 5-era artifact, suggest `(string)`)

## Test plan
- [x] All existing tests pass (updated `cast.phpt`, `formattingAttributes.phpt`)
- [x] New `versioned/dynamic_class_const_requires_83_v82.phpt`
- [x] New `errors/cast_real_binary_rejected.phpt`
- [x] Pre-commit hooks (fmt + clippy) pass