### PR TITLE
refactor(ast): change ExprKind::Variable from Cow<'src, str> to &'src str

### DIFF
--- a/crates/php-ast/src/ast.rs
+++ b/crates/php-ast/src/ast.rs
@@ -998,7 +998,7 @@ pub enum ExprKind<'arena, 'src> {
     Null,
 
     /// Variable: `$name`
-    Variable(Cow<'src, str>),
+    Variable(&'src str),
 
     /// Variable variable: `$$var`, `$$$var`, `${expr}`
     VariableVariable(&'arena Expr<'arena, 'src>),

--- a/crates/php-ast/src/visitor.rs
+++ b/crates/php-ast/src/visitor.rs
@@ -693,8 +693,6 @@ fn walk_attributes<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
 mod tests {
     use super::*;
     use crate::Span;
-    use std::borrow::Cow;
-
     // =========================================================================
     // Unit tests with hand-built ASTs
     // =========================================================================
@@ -716,15 +714,15 @@ mod tests {
     fn counts_variables() {
         let arena = bumpalo::Bump::new();
         let var_x = arena.alloc(Expr {
-            kind: ExprKind::Variable(Cow::Borrowed("x")),
+            kind: ExprKind::Variable("x"),
             span: Span::DUMMY,
         });
         let var_y = arena.alloc(Expr {
-            kind: ExprKind::Variable(Cow::Borrowed("y")),
+            kind: ExprKind::Variable("y"),
             span: Span::DUMMY,
         });
         let var_z = arena.alloc(Expr {
-            kind: ExprKind::Variable(Cow::Borrowed("z")),
+            kind: ExprKind::Variable("z"),
             span: Span::DUMMY,
         });
         let binary = arena.alloc(Expr {
@@ -763,11 +761,11 @@ mod tests {
     fn early_termination() {
         let arena = bumpalo::Bump::new();
         let var_a = arena.alloc(Expr {
-            kind: ExprKind::Variable(Cow::Borrowed("a")),
+            kind: ExprKind::Variable("a"),
             span: Span::DUMMY,
         });
         let var_b = arena.alloc(Expr {
-            kind: ExprKind::Variable(Cow::Borrowed("b")),
+            kind: ExprKind::Variable("b"),
             span: Span::DUMMY,
         });
         let binary = arena.alloc(Expr {

--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -684,7 +684,7 @@ fn parse_member_name<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr
             let src = parser.source;
             let name = &src[token.span.start as usize + 1..token.span.end as usize];
             Expr {
-                kind: ExprKind::Variable(Cow::Borrowed(name)),
+                kind: ExprKind::Variable(name),
                 span: token.span,
             }
         }
@@ -1198,7 +1198,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
             // Strip the $ prefix
             let name = &src[token.span.start as usize + 1..token.span.end as usize];
             Expr {
-                kind: ExprKind::Variable(Cow::Borrowed(name)),
+                kind: ExprKind::Variable(name),
                 span: token.span,
             }
         }
@@ -1814,9 +1814,7 @@ fn parse_new_expr<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'a
             let t = parser.advance();
             let src = parser.source;
             Expr {
-                kind: ExprKind::Variable(Cow::Borrowed(
-                    &src[t.span.start as usize + 1..t.span.end as usize],
-                )),
+                kind: ExprKind::Variable(&src[t.span.start as usize + 1..t.span.end as usize]),
                 span: t.span,
             }
         }

--- a/crates/php-parser/src/interpolation.rs
+++ b/crates/php-parser/src/interpolation.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use php_ast::*;
 
 use crate::version::PhpVersion;
@@ -186,9 +184,8 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                         while i < len && is_var_char(bytes[i]) {
                             i += 1;
                         }
-                        let var_name: Cow<'src, str> = Cow::Borrowed(
-                            &source[base_offset as usize + name_start..base_offset as usize + i],
-                        );
+                        let var_name: &'src str =
+                            &source[base_offset as usize + name_start..base_offset as usize + i];
                         let mut expr = Expr {
                             kind: ExprKind::Variable(var_name),
                             span: Span::new(
@@ -250,9 +247,8 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                     while i < len && is_var_char(bytes[i]) {
                         i += 1;
                     }
-                    let var_name: Cow<'src, str> = Cow::Borrowed(
-                        &source[base_offset as usize + name_start..base_offset as usize + i],
-                    );
+                    let var_name: &'src str =
+                        &source[base_offset as usize + name_start..base_offset as usize + i];
                     let var_offset = base_offset + var_start as u32;
 
                     let mut expr = Expr {
@@ -566,7 +562,7 @@ pub fn parse_interpolated_parts_indented<'arena, 'src>(
                         i += 1;
                     }
                     // raw_body is &'src str so we can borrow directly
-                    let var_name: Cow<'src, str> = Cow::Borrowed(&raw_body[name_start..i]);
+                    let var_name: &'src str = &raw_body[name_start..i];
                     let var_offset = body_offset + var_start as u32;
 
                     let mut expr = Expr {
@@ -748,7 +744,7 @@ fn parse_simple_index<'arena, 'src>(
         let name_start = idx_offset as usize + 1;
         let name_end = idx_offset as usize + idx_str.len();
         return Expr {
-            kind: ExprKind::Variable(std::borrow::Cow::Borrowed(&source[name_start..name_end])),
+            kind: ExprKind::Variable(&source[name_start..name_end]),
             span,
         };
     }


### PR DESCRIPTION
## Summary

- `ExprKind::Variable` now holds `&'src str` instead of `Cow<'src, str>` — every construction site was already `Cow::Borrowed`, no owned path existed
- Variant shrinks from 24 → 16 bytes on 64-bit; aligns with the `&'src str` convention used by all other source-verbatim fields (`Goto`, `InlineHtml`, `HaltCompiler`, etc.)
- Removes the unused `Cow` import from `interpolation.rs`

Closes #86