### PR TITLE
feat(ast): introduce NameStr to unify Variable and Identifier binding types

### DIFF
--- a/crates/php-ast/src/ast.rs
+++ b/crates/php-ast/src/ast.rs
@@ -835,6 +835,58 @@ pub struct StaticVar<'arena, 'src> {
 // Expressions
 // =============================================================================
 
+/// A name string that originates either from the source buffer (`&'src str`) or was
+/// constructed in the arena (`&'arena str`).
+///
+/// Using this as the payload for both `ExprKind::Variable` and `ExprKind::Identifier`
+/// gives them the same binding type, so or-patterns compile natively:
+///
+/// ```
+/// # use php_ast::ast::{ExprKind, NameStr};
+/// # fn example<'a, 'b>(kind: &ExprKind<'a, 'b>) {
+/// if let ExprKind::Variable(name) | ExprKind::Identifier(name) = kind {
+///     let _s: &str = name.as_str();
+/// }
+/// # }
+/// ```
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NameStr<'arena, 'src> {
+    /// Borrowed directly from the source buffer.
+    Src(&'src str),
+    /// Allocated in the bump arena (e.g. a joined qualified name).
+    Arena(&'arena str),
+}
+
+impl<'arena, 'src> NameStr<'arena, 'src> {
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        match self {
+            NameStr::Src(s) => s,
+            NameStr::Arena(s) => s,
+        }
+    }
+}
+
+impl<'arena, 'src> std::ops::Deref for NameStr<'arena, 'src> {
+    type Target = str;
+    #[inline]
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<'arena, 'src> std::fmt::Debug for NameStr<'arena, 'src> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+impl<'arena, 'src> serde::Serialize for NameStr<'arena, 'src> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.as_str().serialize(serializer)
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct Expr<'arena, 'src> {
     pub kind: ExprKind<'arena, 'src>,
@@ -877,13 +929,13 @@ pub enum ExprKind<'arena, 'src> {
     Null,
 
     /// Variable: `$name`
-    Variable(&'src str),
+    Variable(NameStr<'arena, 'src>),
 
     /// Variable variable: `$$var`, `$$$var`, `${expr}`
     VariableVariable(&'arena Expr<'arena, 'src>),
 
     /// Identifier (bare name, e.g. function name in a call)
-    Identifier(&'arena str),
+    Identifier(NameStr<'arena, 'src>),
 
     /// Assignment: `$x = expr` or `$x += expr`
     Assign(AssignExpr<'arena, 'src>),
@@ -1014,13 +1066,9 @@ pub enum ExprKind<'arena, 'src> {
 
 impl<'arena, 'src> Expr<'arena, 'src> {
     /// Returns the name string for `Variable` and `Identifier` nodes, `None` for everything else.
-    ///
-    /// This is the idiomatic way to extract a name when you need to handle both cases without
-    /// writing two separate match arms with incompatible binding types (`&'src str` vs `&'arena str`).
     pub fn name_str(&self) -> Option<&str> {
         match &self.kind {
-            ExprKind::Variable(s) => Some(s),
-            ExprKind::Identifier(s) => Some(s),
+            ExprKind::Variable(s) | ExprKind::Identifier(s) => Some(s.as_str()),
             _ => None,
         }
     }

--- a/crates/php-ast/src/ast.rs
+++ b/crates/php-ast/src/ast.rs
@@ -1012,6 +1012,20 @@ pub enum ExprKind<'arena, 'src> {
     Error,
 }
 
+impl<'arena, 'src> Expr<'arena, 'src> {
+    /// Returns the name string for `Variable` and `Identifier` nodes, `None` for everything else.
+    ///
+    /// This is the idiomatic way to extract a name when you need to handle both cases without
+    /// writing two separate match arms with incompatible binding types (`&'src str` vs `&'arena str`).
+    pub fn name_str(&self) -> Option<&str> {
+        match &self.kind {
+            ExprKind::Variable(s) => Some(s),
+            ExprKind::Identifier(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum CastKind {
     Int,

--- a/crates/php-ast/src/visitor.rs
+++ b/crates/php-ast/src/visitor.rs
@@ -714,15 +714,15 @@ mod tests {
     fn counts_variables() {
         let arena = bumpalo::Bump::new();
         let var_x = arena.alloc(Expr {
-            kind: ExprKind::Variable("x"),
+            kind: ExprKind::Variable(NameStr::Src("x")),
             span: Span::DUMMY,
         });
         let var_y = arena.alloc(Expr {
-            kind: ExprKind::Variable("y"),
+            kind: ExprKind::Variable(NameStr::Src("y")),
             span: Span::DUMMY,
         });
         let var_z = arena.alloc(Expr {
-            kind: ExprKind::Variable("z"),
+            kind: ExprKind::Variable(NameStr::Src("z")),
             span: Span::DUMMY,
         });
         let binary = arena.alloc(Expr {
@@ -761,11 +761,11 @@ mod tests {
     fn early_termination() {
         let arena = bumpalo::Bump::new();
         let var_a = arena.alloc(Expr {
-            kind: ExprKind::Variable("a"),
+            kind: ExprKind::Variable(NameStr::Src("a")),
             span: Span::DUMMY,
         });
         let var_b = arena.alloc(Expr {
-            kind: ExprKind::Variable("b"),
+            kind: ExprKind::Variable(NameStr::Src("b")),
             span: Span::DUMMY,
         });
         let binary = arena.alloc(Expr {

--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -674,7 +674,7 @@ fn parse_member_name<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr
             let token = parser.advance();
             let text = &parser.source[token.span.start as usize..token.span.end as usize];
             Expr {
-                kind: ExprKind::Identifier(parser.arena.alloc_str(text)),
+                kind: ExprKind::Identifier(NameStr::Src(text)),
                 span: token.span,
             }
         }
@@ -684,7 +684,7 @@ fn parse_member_name<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr
             let src = parser.source;
             let name = &src[token.span.start as usize + 1..token.span.end as usize];
             Expr {
-                kind: ExprKind::Variable(name),
+                kind: ExprKind::Variable(NameStr::Src(name)),
                 span: token.span,
             }
         }
@@ -735,9 +735,9 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
         }
         let span = Span::new(token.span.start, parser.previous_end());
         let ident = if parts.len() == 1 {
-            parser.arena.alloc_str(parts[0])
+            NameStr::Src(parts[0])
         } else {
-            parser.arena.alloc_str(&parts.join("\\"))
+            NameStr::Arena(parser.arena.alloc_str(&parts.join("\\")))
         };
         return Expr {
             kind: ExprKind::Identifier(ident),
@@ -1212,7 +1212,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
             // Strip the $ prefix
             let name = &src[token.span.start as usize + 1..token.span.end as usize];
             Expr {
-                kind: ExprKind::Variable(name),
+                kind: ExprKind::Variable(NameStr::Src(name)),
                 span: token.span,
             }
         }
@@ -1254,12 +1254,14 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                 }
                 let span = Span::new(token.span.start, parser.previous_end());
                 Expr {
-                    kind: ExprKind::Identifier(parser.arena.alloc_str(&parts.join("\\"))),
+                    kind: ExprKind::Identifier(NameStr::Arena(
+                        parser.arena.alloc_str(&parts.join("\\")),
+                    )),
                     span,
                 }
             } else {
                 Expr {
-                    kind: ExprKind::Identifier(parser.arena.alloc_str(text)),
+                    kind: ExprKind::Identifier(NameStr::Src(text)),
                     span: token.span,
                 }
             }
@@ -1269,8 +1271,12 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
         TokenKind::Backslash => {
             let start = parser.start_span();
             let name = parser.parse_name();
+            let ident = match name.to_string_repr() {
+                Cow::Borrowed(s) => NameStr::Src(s),
+                Cow::Owned(ref s) => NameStr::Arena(parser.arena.alloc_str(s)),
+            };
             Expr {
-                kind: ExprKind::Identifier(parser.arena.alloc_str(&name.to_string_repr())),
+                kind: ExprKind::Identifier(ident),
                 span: Span::new(start, name.span().end),
             }
         }
@@ -1279,14 +1285,14 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
         TokenKind::Self_ => {
             let token = parser.advance();
             Expr {
-                kind: ExprKind::Identifier("self"),
+                kind: ExprKind::Identifier(NameStr::Arena("self")),
                 span: token.span,
             }
         }
         TokenKind::Parent_ => {
             let token = parser.advance();
             Expr {
-                kind: ExprKind::Identifier("parent"),
+                kind: ExprKind::Identifier(NameStr::Arena("parent")),
                 span: token.span,
             }
         }
@@ -1301,7 +1307,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                 return parse_arrow_function(parser, true, token.span.start, parser.alloc_vec());
             }
             Expr {
-                kind: ExprKind::Identifier("static"),
+                kind: ExprKind::Identifier(NameStr::Arena("static")),
                 span: token.span,
             }
         }
@@ -1472,9 +1478,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
         TokenKind::Exit | TokenKind::Die => {
             let token = parser.advance();
             let src = parser.source;
-            let name_text = parser
-                .arena
-                .alloc_str(&src[token.span.start as usize..token.span.end as usize]);
+            let name_text = NameStr::Src(&src[token.span.start as usize..token.span.end as usize]);
             if parser.check(TokenKind::LeftParen) {
                 match parse_arg_list_or_callable(parser) {
                     ArgListResult::CallableMarker => {
@@ -1536,9 +1540,8 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
             let token = parser.advance();
             if parser.check(TokenKind::LeftParen) {
                 let src = parser.source;
-                let name_text = parser
-                    .arena
-                    .alloc_str(&src[token.span.start as usize..token.span.end as usize]);
+                let name_text =
+                    NameStr::Src(&src[token.span.start as usize..token.span.end as usize]);
                 match parse_arg_list_or_callable(parser) {
                     ArgListResult::CallableMarker => {
                         // clone(...) — first-class callable (PHP 8.5)
@@ -1692,7 +1695,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                     .arena
                     .alloc_str(&format!("namespace\\{}", name.join_parts()));
                 Expr {
-                    kind: ExprKind::Identifier(text),
+                    kind: ExprKind::Identifier(NameStr::Arena(text)),
                     span: Span::new(start, name.span().end),
                 }
             } else {
@@ -1709,7 +1712,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
         TokenKind::Readonly => {
             let token = parser.advance();
             Expr {
-                kind: ExprKind::Identifier("readonly"),
+                kind: ExprKind::Identifier(NameStr::Arena("readonly")),
                 span: token.span,
             }
         }
@@ -1805,21 +1808,21 @@ fn parse_new_expr<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'a
         TokenKind::Self_ => {
             let t = parser.advance();
             Expr {
-                kind: ExprKind::Identifier("self"),
+                kind: ExprKind::Identifier(NameStr::Arena("self")),
                 span: t.span,
             }
         }
         TokenKind::Parent_ => {
             let t = parser.advance();
             Expr {
-                kind: ExprKind::Identifier("parent"),
+                kind: ExprKind::Identifier(NameStr::Arena("parent")),
                 span: t.span,
             }
         }
         TokenKind::Static => {
             let t = parser.advance();
             Expr {
-                kind: ExprKind::Identifier("static"),
+                kind: ExprKind::Identifier(NameStr::Arena("static")),
                 span: t.span,
             }
         }
@@ -1828,7 +1831,9 @@ fn parse_new_expr<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'a
             let t = parser.advance();
             let src = parser.source;
             Expr {
-                kind: ExprKind::Variable(&src[t.span.start as usize + 1..t.span.end as usize]),
+                kind: ExprKind::Variable(NameStr::Src(
+                    &src[t.span.start as usize + 1..t.span.end as usize],
+                )),
                 span: t.span,
             }
         }
@@ -1847,8 +1852,12 @@ fn parse_new_expr<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'a
         _ => {
             // Parse as a name (possibly qualified)
             let name = parser.parse_name();
+            let ident = match name.to_string_repr() {
+                Cow::Borrowed(s) => NameStr::Src(s),
+                Cow::Owned(ref s) => NameStr::Arena(parser.arena.alloc_str(s)),
+            };
             Expr {
-                kind: ExprKind::Identifier(parser.arena.alloc_str(&name.to_string_repr())),
+                kind: ExprKind::Identifier(ident),
                 span: name.span(),
             }
         }

--- a/crates/php-parser/src/interpolation.rs
+++ b/crates/php-parser/src/interpolation.rs
@@ -187,7 +187,7 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                         let var_name: &'src str =
                             &source[base_offset as usize + name_start..base_offset as usize + i];
                         let mut expr = Expr {
-                            kind: ExprKind::Variable(var_name),
+                            kind: ExprKind::Variable(NameStr::Src(var_name)),
                             span: Span::new(
                                 base_offset + name_start as u32,
                                 base_offset + i as u32,
@@ -252,7 +252,7 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                     let var_offset = base_offset + var_start as u32;
 
                     let mut expr = Expr {
-                        kind: ExprKind::Variable(var_name),
+                        kind: ExprKind::Variable(NameStr::Src(var_name)),
                         span: Span::new(var_offset, base_offset + i as u32),
                     };
 
@@ -265,10 +265,8 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                             while i < len && is_var_char(bytes[i]) {
                                 i += 1;
                             }
-                            let prop_name: &'arena str = arena.alloc_str(
-                                &source
-                                    [base_offset as usize + pname_start..base_offset as usize + i],
-                            );
+                            let prop_name: &'src str = &source
+                                [base_offset as usize + pname_start..base_offset as usize + i];
                             let prop_span =
                                 Span::new(base_offset + pname_start as u32, base_offset + i as u32);
                             let span = Span::new(var_offset, base_offset + i as u32);
@@ -276,7 +274,7 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                                 kind: ExprKind::PropertyAccess(PropertyAccessExpr {
                                     object: arena.alloc(expr),
                                     property: arena.alloc(Expr {
-                                        kind: ExprKind::Identifier(prop_name),
+                                        kind: ExprKind::Identifier(NameStr::Src(prop_name)),
                                         span: prop_span,
                                     }),
                                 }),
@@ -566,7 +564,7 @@ pub fn parse_interpolated_parts_indented<'arena, 'src>(
                     let var_offset = body_offset + var_start as u32;
 
                     let mut expr = Expr {
-                        kind: ExprKind::Variable(var_name),
+                        kind: ExprKind::Variable(NameStr::Src(var_name)),
                         span: Span::new(var_offset, body_offset + i as u32),
                     };
 
@@ -578,7 +576,7 @@ pub fn parse_interpolated_parts_indented<'arena, 'src>(
                             while i < len && is_var_char(bytes[i]) {
                                 i += 1;
                             }
-                            let prop_name: &'arena str = arena.alloc_str(&raw_body[pname_start..i]);
+                            let prop_name: &'src str = &raw_body[pname_start..i];
                             let prop_span =
                                 Span::new(body_offset + pname_start as u32, body_offset + i as u32);
                             let span = Span::new(var_offset, body_offset + i as u32);
@@ -586,7 +584,7 @@ pub fn parse_interpolated_parts_indented<'arena, 'src>(
                                 kind: ExprKind::PropertyAccess(PropertyAccessExpr {
                                     object: arena.alloc(expr),
                                     property: arena.alloc(Expr {
-                                        kind: ExprKind::Identifier(prop_name),
+                                        kind: ExprKind::Identifier(NameStr::Src(prop_name)),
                                         span: prop_span,
                                     }),
                                 }),
@@ -744,7 +742,7 @@ fn parse_simple_index<'arena, 'src>(
         let name_start = idx_offset as usize + 1;
         let name_end = idx_offset as usize + idx_str.len();
         return Expr {
-            kind: ExprKind::Variable(&source[name_start..name_end]),
+            kind: ExprKind::Variable(NameStr::Src(&source[name_start..name_end])),
             span,
         };
     }

--- a/crates/php-parser/src/stmt.rs
+++ b/crates/php-parser/src/stmt.rs
@@ -3275,10 +3275,12 @@ fn parse_expression_stmt_or_label<'arena, 'src>(
     if let ExprKind::Identifier(name) = expr.kind {
         if parser.eat(TokenKind::Colon).is_some() {
             let span = Span::new(start, parser.previous_end());
-            // Label names are always simple identifiers borrowed from source
-            // If somehow it's owned (qualified name), we can't get &'src str easily;
+            let label: &'arena str = match name {
+                NameStr::Src(s) => parser.arena.alloc_str(s),
+                NameStr::Arena(s) => s,
+            };
             return Stmt {
-                kind: StmtKind::Label(name),
+                kind: StmtKind::Label(label),
                 span,
             };
         }

--- a/crates/php-printer/src/printer.rs
+++ b/crates/php-printer/src/printer.rs
@@ -476,7 +476,7 @@ impl Printer {
             ExprKind::Null => self.w("null"),
             ExprKind::Variable(name) => {
                 self.w("$");
-                self.w(name);
+                self.w(name.as_str());
             }
             ExprKind::VariableVariable(inner) => {
                 self.w("$");
@@ -488,7 +488,7 @@ impl Printer {
                     self.w("}");
                 }
             }
-            ExprKind::Identifier(name) => self.w(name),
+            ExprKind::Identifier(name) => self.w(name.as_str()),
             ExprKind::Assign(assign) => {
                 let (_, lhs_prec, rhs_prec) = assign_op_precedence(assign.op);
                 self.print_expr(assign.target, lhs_prec);
@@ -1435,7 +1435,7 @@ impl Printer {
                 StringPart::Expr(expr) => match &expr.kind {
                     ExprKind::Variable(name) => {
                         self.w("$");
-                        self.w(name);
+                        self.w(name.as_str());
                     }
                     _ => {
                         self.w("{");


### PR DESCRIPTION
## Summary

- Adds `NameStr<'arena, 'src>` enum to `php-ast`: either `Src(&'src str)` (borrowed from the source buffer) or `Arena(&'arena str)` (constructed in the bump arena)
- Changes `ExprKind::Variable` and `ExprKind::Identifier` to both hold `NameStr<'arena, 'src>` — the same type — so or-pattern bindings compile natively without a helper:
  ```rust
  if let ExprKind::Variable(name) | ExprKind::Identifier(name) = &expr.kind {
      let s: &str = name.as_str();
  }
  ```
- Eliminates several `arena.alloc_str()` calls that were unnecessary for simple identifiers (net allocation reduction)
- `NameStr` is `Copy`, implements `Deref<Target=str>`, `Debug`, `Serialize`, `PartialEq`, `Eq`, `Hash` — serialized as a plain string so JSON output is unchanged

Closes #87