### PR TITLE
fix(parser): prevent panic on string slice at non-char boundary

### DIFF
--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -927,7 +927,12 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                 .strip_prefix('b')
                 .or_else(|| text.strip_prefix('B'))
                 .unwrap_or(text);
-            let inner = &text[1..text.len() - 1];
+            // Use strip_prefix/strip_suffix to respect UTF-8 char boundaries.
+            // An unterminated string may end with a multi-byte character whose last
+            // byte coincidentally matches the closing delimiter byte; byte indexing
+            // would panic in that case.
+            let without_open = text.strip_prefix('\'').unwrap_or(text);
+            let inner = without_open.strip_suffix('\'').unwrap_or(without_open);
             // Fast path: if no backslash, inner is a verbatim source slice
             let value: &'arena str = if !inner.contains('\\') {
                 // inner is a subslice of `src` which has lifetime 'src
@@ -977,18 +982,22 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                 .strip_prefix('b')
                 .or_else(|| text.strip_prefix('B'))
                 .unwrap_or(text);
-            // Guard against unterminated strings (lexer already emitted an error)
-            if stripped.len() < 2 {
+            // Use strip_prefix/strip_suffix to respect UTF-8 char boundaries.
+            // An unterminated string may end with a multi-byte character; byte indexing
+            // would panic in that case. The lexer already emitted an error for unterminated
+            // strings, so it is safe to treat the missing closing quote as absent here.
+            let Some(without_open) = stripped.strip_prefix('"') else {
                 return Expr {
                     kind: ExprKind::String(parser.arena.alloc_str("")),
                     span: token.span,
                 };
-            }
-            let inner = &stripped[1..stripped.len() - 1];
+            };
+            let inner = without_open.strip_suffix('"').unwrap_or(without_open);
 
             if crate::interpolation::has_interpolation(inner) {
-                // Offset of first char of inner content in source
-                let inner_offset = token.span.end - 1 - inner.len() as u32;
+                // Compute the byte offset of inner within src via pointer arithmetic so
+                // the result is correct regardless of the b/B prefix or termination.
+                let inner_offset = (inner.as_ptr() as usize - src.as_ptr() as usize) as u32;
                 let parts = crate::interpolation::parse_interpolated_parts(
                     parser.arena,
                     src,
@@ -1049,14 +1058,14 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
             let token = parser.advance();
             let src = parser.source();
             let text = &src[token.span.start as usize..token.span.end as usize];
-            // Guard against unterminated backtick strings (lexer already emitted an error)
-            if text.len() < 2 {
+            // Use strip_prefix/strip_suffix to respect UTF-8 char boundaries.
+            let Some(without_open) = text.strip_prefix('`') else {
                 return Expr {
                     kind: ExprKind::ShellExec(parser.alloc_vec_with_capacity(0)),
                     span: token.span,
                 };
-            }
-            let inner = &text[1..text.len() - 1];
+            };
+            let inner = without_open.strip_suffix('`').unwrap_or(without_open);
 
             if crate::interpolation::has_interpolation(inner) {
                 let inner_offset = token.span.start + 1;

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_25.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_25.phpt
@@ -86,7 +86,7 @@ expected ';' after expression
       "kind": {
         "Expression": {
           "kind": {
-            "String": "]"
+            "String": "];"
           },
           "span": {
             "start": 21,

--- a/crates/php-parser/tests/fixtures/errors/unclosed_double_quote.phpt
+++ b/crates/php-parser/tests/fixtures/errors/unclosed_double_quote.phpt
@@ -10,7 +10,7 @@ expected ';' after expression
       "kind": {
         "Expression": {
           "kind": {
-            "String": "unclosed strin"
+            "String": "unclosed string"
           },
           "span": {
             "start": 6,

--- a/crates/php-parser/tests/fixtures/errors/unclosed_single_quote.phpt
+++ b/crates/php-parser/tests/fixtures/errors/unclosed_single_quote.phpt
@@ -10,7 +10,7 @@ expected ';' after expression
       "kind": {
         "Expression": {
           "kind": {
-            "String": "unclosed strin"
+            "String": "unclosed string"
           },
           "span": {
             "start": 6,

--- a/crates/php-parser/tests/fixtures/errors/unclosed_string_then_valid_echo.phpt
+++ b/crates/php-parser/tests/fixtures/errors/unclosed_string_then_valid_echo.phpt
@@ -67,7 +67,7 @@ expected ';' after expression
       "kind": {
         "Expression": {
           "kind": {
-            "String": ""
+            "String": ";"
           },
           "span": {
             "start": 37,

--- a/crates/php-parser/tests/fixtures/errors/unterminated_backtick_string.phpt
+++ b/crates/php-parser/tests/fixtures/errors/unterminated_backtick_string.phpt
@@ -25,7 +25,7 @@ expected ';' after expression
                 "kind": {
                   "ShellExec": [
                     {
-                      "Literal": "unclosed"
+                      "Literal": "unclosed;"
                     }
                   ]
                 },

--- a/crates/php-parser/tests/fixtures/errors/unterminated_double_quoted_string.phpt
+++ b/crates/php-parser/tests/fixtures/errors/unterminated_double_quoted_string.phpt
@@ -23,7 +23,7 @@ expected ';' after expression
               "op": "Assign",
               "value": {
                 "kind": {
-                  "String": "unclosed"
+                  "String": "unclosed;"
                 },
                 "span": {
                   "start": 11,

--- a/crates/php-parser/tests/fixtures/errors/unterminated_single_quoted_string.phpt
+++ b/crates/php-parser/tests/fixtures/errors/unterminated_single_quoted_string.phpt
@@ -23,7 +23,7 @@ expected ';' after expression
               "op": "Assign",
               "value": {
                 "kind": {
-                  "String": "unclosed"
+                  "String": "unclosed;"
                 },
                 "span": {
                   "start": 11,

--- a/crates/php-parser/tests/fixtures/no_hang/unterminated_backtick_string.phpt
+++ b/crates/php-parser/tests/fixtures/no_hang/unterminated_backtick_string.phpt
@@ -61,7 +61,11 @@ expected ';' after expression
               },
               "index": {
                 "kind": {
-                  "ShellExec": []
+                  "ShellExec": [
+                    {
+                      "Literal": ""
+                    }
+                  ]
                 },
                 "span": {
                   "start": 14,

--- a/crates/php-parser/tests/malformed_php.rs
+++ b/crates/php-parser/tests/malformed_php.rs
@@ -170,3 +170,57 @@ fn many_class_members() {
 fn null_bytes_in_source() {
     assert_has_errors("<?php $x = \0;");
 }
+
+// ============================================================================
+// UNTERMINATED STRINGS ENDING WITH MULTI-BYTE UTF-8 CHARACTERS
+// Slicing &str by byte index panics when the index lands inside a multi-byte
+// character (non-char boundary). These tests cover each string-literal kind.
+// ============================================================================
+
+/// Original fuzzer crash: unterminated double-quoted string whose last bytes
+/// are the 2-byte UTF-8 encoding of U+05C7 (ׇ, bytes 0xD7 0x87).
+#[test]
+fn fuzz_crash_repro_double_quoted_multibyte_end() {
+    let data = b"\x3c\x3f\x3c\x3f\x70\x68\x70\x20\x63\x6c\x61\x73\x12\x24\x78\x22\x68\x65\x20\x3d\x20\x5b\x74\x70\x68\x70\x20\xd7\x87";
+    if let Ok(src) = std::str::from_utf8(data) {
+        let arena = bumpalo::Bump::new();
+        let _ = php_rs_parser::parse(&arena, src);
+    }
+}
+
+/// Unterminated double-quoted string ending mid-3-byte character (U+4E16 世).
+#[test]
+fn unterminated_double_quoted_ends_with_3byte_char() {
+    // "世 — opening quote, then the first 2 of 3 bytes of 世 (0xE4 0xB8 0x96)
+    let src = "<?php \"世\u{4E16}";
+    let arena = bumpalo::Bump::new();
+    let _ = php_rs_parser::parse(&arena, src);
+}
+
+/// Unterminated single-quoted string ending with a 2-byte UTF-8 character.
+#[test]
+fn unterminated_single_quoted_ends_with_multibyte_char() {
+    let src = "<?php 'héllo"; // unterminated, ends with 'o' but has 2-byte é
+    let arena = bumpalo::Bump::new();
+    let _ = php_rs_parser::parse(&arena, src);
+    // Variant: last char is the multi-byte one
+    let src2 = "<?php 'hé"; // unterminated, last char is 2-byte é
+    let arena2 = bumpalo::Bump::new();
+    let _ = php_rs_parser::parse(&arena2, src2);
+}
+
+/// Unterminated backtick string ending with a 2-byte UTF-8 character.
+#[test]
+fn unterminated_backtick_ends_with_multibyte_char() {
+    let src = "<?php `cmd é"; // unterminated backtick, last char is 2-byte
+    let arena = bumpalo::Bump::new();
+    let _ = php_rs_parser::parse(&arena, src);
+}
+
+/// b-prefixed double-quoted string, unterminated, ending with multi-byte char.
+#[test]
+fn unterminated_b_prefixed_double_quoted_ends_with_multibyte_char() {
+    let src = "<?php b\"héllo"; // b-prefix, unterminated
+    let arena = bumpalo::Bump::new();
+    let _ = php_rs_parser::parse(&arena, src);
+}


### PR DESCRIPTION
## Summary

- Replaces `&text[1..text.len()-1]` byte-index slicing with `strip_prefix`/`strip_suffix` in the single-quoted, double-quoted, and backtick string parsing paths
- Fixes a panic that occurred when an unterminated string literal ended with a multi-byte UTF-8 character (e.g. U+05C7), because `text.len()-1` fell inside the character rather than on a char boundary
- Adds a `malformed_php` regression test for the exact fuzzer crash input
- Updates `recovery_25.phpt`: the unterminated token `"];` now correctly produces content `];` instead of `]` (the old code was accidentally stripping the last byte regardless of whether it was the closing quote)

Closes the fuzz smoke test failure introduced in the CI run for `9f767543`.