### PR TITLE
feat(version): add PhpVersion::Php74 and gate deprecated casts on version

### DIFF
--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -2582,7 +2582,7 @@ fn try_parse_cast<'arena, 'src>(
     parser.advance(); // consume the cast keyword
     parser.eat(TokenKind::RightParen)?;
 
-    if cast_kind == CastKind::Unset {
+    if cast_kind == CastKind::Unset && parser.version >= PhpVersion::Php80 {
         parser.error(ParseError::Forbidden {
             message: "the (unset) cast is no longer supported".into(),
             span: kw_span,
@@ -2593,7 +2593,7 @@ fn try_parse_cast<'arena, 'src>(
     }
     // (real) was removed in PHP 8.0, (binary) is a PHP 5-era artifact
     let kw_text = &parser.source[kw_span.start as usize..kw_span.end as usize];
-    if kw_text.eq_ignore_ascii_case("real") {
+    if kw_text.eq_ignore_ascii_case("real") && parser.version >= PhpVersion::Php80 {
         parser.error(ParseError::Forbidden {
             message: "the (real) cast is no longer supported, use (float) instead".into(),
             span: kw_span,

--- a/crates/php-parser/src/version.rs
+++ b/crates/php-parser/src/version.rs
@@ -9,9 +9,11 @@ use std::fmt;
 ///
 /// Ordering is meaningful: `Php82 > Php81`, etc.
 ///
-/// Defaults to [`PhpVersion::Php84`] (the latest supported version).
+/// Defaults to [`PhpVersion::Php85`] (the latest supported version).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PhpVersion {
+    /// PHP 7.4 — arrow functions, typed properties, spread in array expressions, numeric literal separator.
+    Php74,
     /// PHP 8.0 — match, named arguments, constructor promotion, union types, nullsafe `?->`, throw expression, `mixed`/`false`/`null` types.
     Php80,
     /// PHP 8.1 — enums, `readonly` properties/parameters, intersection types, first-class callables, `never` type.
@@ -31,6 +33,7 @@ pub enum PhpVersion {
 impl fmt::Display for PhpVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            PhpVersion::Php74 => write!(f, "7.4"),
             PhpVersion::Php80 => write!(f, "8.0"),
             PhpVersion::Php81 => write!(f, "8.1"),
             PhpVersion::Php82 => write!(f, "8.2"),

--- a/crates/php-parser/tests/common.rs
+++ b/crates/php-parser/tests/common.rs
@@ -118,6 +118,7 @@ pub fn parse_fixture(content: &str) -> (FixtureConfig, &str) {
 /// Convert a `(major, minor)` version tuple to a `PhpVersion` enum.
 pub fn php_version(v: (u32, u32)) -> php_rs_parser::PhpVersion {
     match v {
+        (7, 4) => php_rs_parser::PhpVersion::Php74,
         (8, 0) => php_rs_parser::PhpVersion::Php80,
         (8, 1) => php_rs_parser::PhpVersion::Php81,
         (8, 2) => php_rs_parser::PhpVersion::Php82,

--- a/crates/php-parser/tests/fixtures/versioned/real_cast_allowed_in_74_v74.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/real_cast_allowed_in_74_v74.phpt
@@ -1,0 +1,61 @@
+===config===
+parse_version=7.4
+===source===
+<?php $a = (real) 1.5;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "a"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Cast": [
+                    "Float",
+                    {
+                      "kind": {
+                        "Float": 1.5
+                      },
+                      "span": {
+                        "start": 18,
+                        "end": 21
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 21
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 21
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 22
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 22
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/real_cast_rejected_in_80_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/real_cast_rejected_in_80_v80.phpt
@@ -1,0 +1,63 @@
+===config===
+parse_version=8.0
+===source===
+<?php $a = (real) 1.5;
+===errors===
+the (real) cast is no longer supported, use (float) instead
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "a"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Cast": [
+                    "Float",
+                    {
+                      "kind": {
+                        "Float": 1.5
+                      },
+                      "span": {
+                        "start": 18,
+                        "end": 21
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 21
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 21
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 22
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 22
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/unset_cast_allowed_in_74_v74.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/unset_cast_allowed_in_74_v74.phpt
@@ -1,0 +1,41 @@
+===config===
+parse_version=7.4
+===source===
+<?php (unset)$x;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Cast": [
+              "Unset",
+              {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 13,
+                  "end": 15
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 6,
+            "end": 15
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 16
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 16
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/unset_cast_rejected_in_80_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/unset_cast_rejected_in_80_v80.phpt
@@ -1,0 +1,43 @@
+===config===
+parse_version=8.0
+===source===
+<?php (unset)$x;
+===errors===
+the (unset) cast is no longer supported
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Cast": [
+              "Unset",
+              {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 13,
+                  "end": 15
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 6,
+            "end": 15
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 16
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 16
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `PhpVersion::Php74` as a targetable parse version (before `Php80` in the `Ord` ordering)
- `(unset)` and `(real)` casts are now only rejected when targeting PHP 8.0+; they parse without error under `parse_versioned(..., PhpVersion::Php74)`
- Adds 4 versioned fixtures covering the accept/reject boundary for both casts

Closes #91