### PR TITLE
fix(php_syntax): skip declare_in_conditional.phpt in php -l check

### DIFF
--- a/crates/php-parser/tests/php_syntax.rs
+++ b/crates/php-parser/tests/php_syntax.rs
@@ -122,6 +122,8 @@ fn fixture_files_are_valid_php() {
         "misc.phpt", // corpus/expr/uvs/misc.phpt
         // [parse-leniency] (void) cast — not valid in PHP.
         "voidCast.phpt",
+        // [semantic] declare() inside a conditional block — PHP rejects at compile time.
+        "declare_in_conditional.phpt",
         // [semantic] break/continue outside loop.
         "controlFlow.phpt",
         // [semantic] Unicode escape with codepoint too large.


### PR DESCRIPTION
## Summary

- PHP rejects `declare()` inside a conditional block at compile time, causing `fixture_files_are_valid_php` to fail
- Added `declare_in_conditional.phpt` to the `php_rejects` skip list in `php_syntax.rs` with a `[semantic]` label
- The fixture is preserved and continues to cover the parser's AST output for this construct

Closes #97