### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -24,10 +24,10 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.5.0" }
-php-lexer = { path = "crates/php-lexer", version = "0.5.0" }
-php-rs-parser = { path = "crates/php-parser", version = "0.5.0" }
-php-printer = { path = "crates/php-printer", version = "0.5.0" }
+php-ast = { path = "crates/php-ast", version = "0.6.0" }
+php-lexer = { path = "crates/php-lexer", version = "0.6.0" }
+php-rs-parser = { path = "crates/php-parser", version = "0.6.0" }
+php-printer = { path = "crates/php-printer", version = "0.6.0" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,71 +1,146 @@
 # Rust PHP Parser
 
-A fast, fault-tolerant PHP parser written in Rust. Produces a full AST with source spans, recovers from syntax errors, and covers the vast majority of PHP 8.x syntax.
+A fast, fault-tolerant PHP parser written in Rust. Produces a full typed AST with source spans, recovers from syntax errors, and covers PHP 8.0–8.5 syntax.
 
 Includes a corpus of test fixtures adapted from the [nikic/PHP-Parser](https://github.com/nikic/PHP-Parser) test suite.
 
-> **Note:** The parser targets **PHP 8.5** by default — all supported syntax from PHP 5.x through 8.5 is accepted.
+> **Note:** The parser targets **PHP 8.5** by default. Use `parse_versioned()` to target an earlier version.
 
 ## Architecture
 
-Cargo workspace with three crates:
+Cargo workspace with four crates:
 
 | Crate | crates.io | Purpose |
 |-------|-----------|---------|
 | **php-lexer** | [![crates.io](https://img.shields.io/crates/v/php-lexer)](https://crates.io/crates/php-lexer) | Hand-written tokenizer with handling for strings, heredoc/nowdoc, and inline HTML |
-| **php-ast** | [![crates.io](https://img.shields.io/crates/v/php-ast)](https://crates.io/crates/php-ast) | AST type definitions, visitor trait, source map, comment map, symbol table |
-| **php-rs-parser** | [![crates.io](https://img.shields.io/crates/v/php-rs-parser)](https://crates.io/crates/php-rs-parser) | Pratt-based recursive descent parser with panic-mode error recovery |
+| **php-ast** | [![crates.io](https://img.shields.io/crates/v/php-ast)](https://crates.io/crates/php-ast) | AST type definitions, `Visitor` trait, `ScopeVisitor` trait |
+| **php-rs-parser** | [![crates.io](https://img.shields.io/crates/v/php-rs-parser)](https://crates.io/crates/php-rs-parser) | Pratt-based recursive descent parser with panic-mode error recovery, PHPDoc parser, source map |
+| **php-printer** | [![crates.io](https://img.shields.io/crates/v/php-printer)](https://crates.io/crates/php-printer) | Pretty printer — converts an AST back to PHP source |
 
 ## Usage
 
 ```rust
 use php_rs_parser::parse;
 
-let result = parse("<?php echo 'Hello, world!';");
+let arena = bumpalo::Bump::new();
+let result = parse(&arena, "<?php echo 'Hello, world!';");
 
 println!("{:#?}", result.program);
 
 for err in &result.errors {
     println!("error at {:?}: {}", err.span(), err);
 }
+
+// Resolve byte offsets to line/column
+let pos = result.source_map.offset_to_line_col(6);
 ```
 
-### LSP / Static Analysis Utilities
+### Version-aware parsing
 
-`php-ast` includes utilities for building analysis tools on top of the AST:
+Target a specific PHP version to catch version-gated syntax:
 
 ```rust
-use php_ast::source_map::SourceMap;
-use php_ast::comment_map::CommentMap;
-use php_ast::symbol_table::SymbolTable;
+use php_rs_parser::{parse_versioned, PhpVersion};
 
-let source = "<?php\nnamespace App;\nclass User { public function getName(): string {} }";
-let result = php_rs_parser::parse(source);
-
-// Byte offset → line/column
-let map = SourceMap::new(source);
-let pos = map.offset_to_line_col(6); // line 1, col 0
-
-// Attach comments to AST nodes
-let comments = CommentMap::build(&result.comments, &result.program.stmts);
-
-// Extract declarations with namespace-aware FQNs
-let symbols = SymbolTable::build(&result.program);
-let classes = symbols.classes().collect::<Vec<_>>();
-// classes[0].fqn == "App\\User"
+let arena = bumpalo::Bump::new();
+let result = parse_versioned(
+    &arena,
+    "<?php enum Status { case Active; }",
+    PhpVersion::Php80,
+);
+// Enums require PHP 8.1 — a VersionTooLow diagnostic is emitted.
+assert!(!result.errors.is_empty());
 ```
+
+Supported versions: `Php74`, `Php80`, `Php81`, `Php82`, `Php83`, `Php84`, `Php85`.
+
+### Visitor API
+
+Implement `Visitor` to walk the AST depth-first. Override only the node types you care about; the default implementations recurse into children automatically.
+
+```rust
+use php_ast::visitor::{Visitor, walk_expr};
+use php_ast::ast::*;
+use std::ops::ControlFlow;
+
+struct VarCounter { count: usize }
+
+impl<'arena, 'src> Visitor<'arena, 'src> for VarCounter {
+    fn visit_expr(&mut self, expr: &Expr<'arena, 'src>) -> ControlFlow<()> {
+        if matches!(&expr.kind, ExprKind::Variable(_)) {
+            self.count += 1;
+        }
+        walk_expr(self, expr)
+    }
+}
+```
+
+Return `ControlFlow::Break(())` to stop traversal early. Return `ControlFlow::Continue(())` without calling `walk_*` to skip a subtree.
+
+### Scope-aware traversal
+
+`ScopeVisitor` and `ScopeWalker` provide zero-allocation lexical scope context — namespace, class name, and function/method name — at every node:
+
+```rust
+use php_ast::visitor::{ScopeVisitor, ScopeWalker, Scope};
+use php_ast::ast::*;
+use std::ops::ControlFlow;
+
+struct MethodCollector { methods: Vec<String> }
+
+impl<'arena, 'src> ScopeVisitor<'arena, 'src> for MethodCollector {
+    fn visit_class_member(
+        &mut self,
+        member: &ClassMember<'arena, 'src>,
+        scope: &Scope<'src>,
+    ) -> ControlFlow<()> {
+        if let ClassMemberKind::Method(m) = &member.kind {
+            self.methods.push(format!(
+                "{}::{}",
+                scope.class_name.unwrap_or("<anon>"),
+                m.name
+            ));
+        }
+        ControlFlow::Continue(())
+    }
+}
+
+let arena = bumpalo::Bump::new();
+let result = php_rs_parser::parse(&arena, "<?php class Foo { public function bar() {} }");
+let mut walker = ScopeWalker::new(MethodCollector { methods: vec![] });
+let _ = walker.walk(&result.program);
+// walker.into_inner().methods == ["Foo::bar"]
+```
+
+`Scope` fields:
+- `namespace: Option<Cow<'src, str>>` — current namespace, `None` in the global namespace
+- `class_name: Option<&'src str>` — enclosing class/interface/trait/enum name, `None` outside or in anonymous classes
+- `function_name: Option<&'src str>` — enclosing named function/method name, `None` in closures/arrow functions
+
+### Pretty printer
+
+```rust
+let arena = bumpalo::Bump::new();
+let result = php_rs_parser::parse(&arena, "<?php echo 1 + 2;");
+let output = php_printer::pretty_print(&result.program);
+// output == "echo 1 + 2;"
+```
+
+`pretty_print_file` prepends `<?php\n\n` and appends a trailing newline.
+
+### PHPDoc parser
+
+```rust
+let tags = php_rs_parser::phpdoc::parse("/** @param int $id The user ID\n * @return User */");
+```
+
+Produces typed `PhpDocTag` variants for `@param`, `@return`, `@var`, `@throws`, `@template`, `@property`, `@method`, `@deprecated`, and Psalm/PHPStan annotations. Doc comments are attached to function, class, method, property, and constant AST nodes.
 
 ## Performance
 
-This parser is optimized for **modern PHP applications with full typing** (PHP 7.4+, 8.x). It delivers fastest performance on Symfony, Laravel, and other typed codebases.
+This parser is optimised for **modern PHP applications with full typing** (PHP 7.4+, 8.x). It delivers the fastest performance on Symfony, Laravel, and other typed codebases.
 
-The parser prioritizes performance on contemporary PHP patterns:
-- **Type hints** — Full coverage (union types, mixed, never, readonly, attributes, etc.)
-- **Complex expressions** — Method chains, array access, spread operators
-- **Arrays & collections** — Configuration-heavy code (Symfony/Laravel patterns)
-- **Structured OOP** — Classes, traits, interfaces with complete feature support
-
-**The fastest full-featured PHP parser.** For detailed analysis, see [docs/performance/](docs/performance/) directory. For comparative benchmarks against other PHP parsers, see [php-parser-benchmark](https://github.com/jorgsowa/php-parser-benchmark).
+**The fastest full-featured PHP parser.** For detailed analysis see [docs/performance/](docs/performance/). For comparative benchmarks against other PHP parsers see [php-parser-benchmark](https://github.com/jorgsowa/php-parser-benchmark).
 
 ## Testing
 
@@ -73,18 +148,18 @@ The parser prioritizes performance on contemporary PHP patterns:
 cargo test --test integration   # all .phpt fixture tests (including corpus)
 cargo test --test php_syntax    # validate fixtures via php -l
 cargo test --test malformed_php # error recovery and diagnostics
+cargo test --test visitor       # visitor and scope-aware traversal
 ```
 
-Fixture files live in `crates/php-parser/tests/fixtures/`. All fixtures are validated against `php -l` in CI across PHP 8.2–8.5. Fixtures using version-gated syntax should include a `===config===` section with `min_php=X.Y`.
+Fixture files live in `crates/php-parser/tests/fixtures/`. All fixtures are validated against `php -l` in CI across PHP 8.2–8.5. Fixtures using version-gated syntax must include `===config===` with `min_php=X.Y`.
 
 ## Documentation
 
-Full documentation is organized in the [docs/](docs/) directory:
-- **[docs/INDEX.md](docs/INDEX.md)** — Documentation index and navigation
+Full documentation is in the [docs/](docs/) directory:
+- **[docs/INDEX.md](docs/INDEX.md)** — Documentation index
 - **[docs/architecture/](docs/architecture/)** — Design and roadmap
 - **[docs/performance/](docs/performance/)** — Performance analysis and profiling
-- **[docs/analysis/](docs/analysis/)** — Coverage and testing analysis
-- **[docs/development/](docs/development/)** — Changelog and release notes
+- **[docs/development/CHANGELOG.md](docs/development/CHANGELOG.md)** — Release history
 
 ## License
 

--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -5,6 +5,89 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-11
+
+### Added
+
+- **`ScopeVisitor` trait and `ScopeWalker`** (`php-ast`) — zero-allocation scope-aware AST traversal. Every visit method now receives a `&Scope<'src>` with the current namespace, class name, and function/method name. `ScopeWalker` wraps any `ScopeVisitor`, maintains scope automatically, and handles all PHP scope transitions (braced/simple namespaces, classes, interfaces, traits, enums, methods, closures, arrow functions, anonymous classes).
+
+- **`NameStr<'arena, 'src>`** (`php-ast`) — unified binding type for `Variable` and `Identifier` expression nodes, replacing the previous `Cow<'src, str>` in `Variable`. Zero-copy for source-borrowed names; arena-owned for synthesised names.
+
+- **`PhpVersion::Php74`** (`php-rs-parser`) — PHP 7.4 target added to `PhpVersion` enum. Deprecated casts (`(real)`, `(unset)`) are now gated on version and emit `VersionTooLow` diagnostics when targeting PHP 8.0+.
+
+- **PHPDoc continuation lines** (`php-rs-parser`) — tag descriptions now accumulate indented continuation lines, matching PHPStan/Psalm behaviour.
+
+### Fixed
+
+- Panic on string slice at non-char boundary in the lexer (#139).
+- Unterminated string literals now emit a proper `ParseError` instead of silently producing a malformed AST (#133).
+- Missing version gates for deprecated casts and several PHP 8.x-only constructs (#131).
+- Diagnostics: reject `void`/`never`/`mixed` in union positions, `static readonly`, and `abstract final` class (#130).
+- Chained non-associative operators and bare ternary chains now emit errors in PHP 8 mode (#129).
+- PHP version not threaded correctly through the interpolation sub-parser (#128).
+- `declare(…)` in conditional position skipped in `php -l` validation to avoid false failures (#141).
+
+### Changed (breaking)
+
+- `ExprKind::Variable` changed from `Cow<'src, str>` to `NameStr<'arena, 'src>` (#132, #138). Code matching on `Variable(name)` should use `name.as_str()` or `name.deref()` instead of `name.as_ref()`.
+- LSP utilities (`CommentMap`, `SymbolTable`) removed from `php-ast`; `SourceMap` moved to `php-rs-parser` and is now included directly in `ParseResult` (#117).
+
+---
+
+## [0.5.0] - 2026-04-01
+
+### Added
+
+- **`SourceMap` in `ParseResult`** — `parse()` and `parse_versioned()` now return a pre-built `SourceMap` in `result.source_map`, eliminating the need for callers to construct one manually.
+- **Source string in `ParseResult`** — `result.source` exposes the original source string, enabling span-to-text extraction without holding a separate reference.
+
+### Fixed
+
+- Unterminated block comments now emit a `ParseError` instead of silently truncating the token stream.
+
+---
+
+## [0.4.0] - 2026-03-28
+
+### Added
+
+- **`php-printer` crate** — new `php-printer` crate provides `pretty_print(&program)` and `pretty_print_file(&program)` for round-tripping AST back to PHP source. Round-trip stability is verified in the printer test suite.
+- **PHPDoc parser** (`php-rs-parser`) — `php_rs_parser::phpdoc::parse()` parses structured doc comments into typed `PhpDocTag` variants (param, return, var, throws, template, property, method, deprecated, psalm/phpstan annotations). Doc comments are attached to function, class, method, property, and constant AST nodes.
+- **Visitor API improvements** (`php-ast`) — `Visitor` trait upgraded to use `ControlFlow<()>` for early termination, with support for type hints, attributes, catch clauses, match arms, and closure use-vars. All walk functions are public.
+- **LSP foundation utilities** (`php-rs-parser`) — `SourceMap` (byte offset ↔ line/column), `CommentMap` (attach comments to nearest AST node), and `SymbolTable` (namespace-aware FQN extraction for classes, functions, constants).
+- **Corpus test suite** — nikic/PHP-Parser fixtures integrated into the unified `.phpt` test runner; all fixtures validated via `php -l` in CI.
+- **Fuzz target** — `cargo-fuzz` target with CI smoke test to catch panics on arbitrary input.
+- **Nesting depth guard** — expression parser enforces a recursion limit to prevent stack overflow on deeply nested input.
+
+### Fixed
+
+- Incorrect AST for `=&` assignment, `&$var` array elements, and empty destructuring slots.
+- Precedence bugs for concat, shift, and `instanceof` operators.
+- Octal literals with digits 8 or 9 now parsed correctly.
+- Trailing-dot float literals (`1.`) tokenised as `FloatLiteralSimple`.
+- `<?php` opening tag is now matched case-insensitively.
+- `abstract` modifier on properties and abstract methods in enums now rejected.
+
+---
+
+## [0.3.0] - 2026-03-20
+
+### Added
+
+- **PHP version system** — `PhpVersion` enum (`Php80`–`Php85`); `parse_versioned()` API for version-targeted parsing. Syntax requiring a higher version is parsed into the AST but emits `VersionTooLow` diagnostics.
+- **PHP 8.5 support** — `CloneWith` expression node, version-gated `clone()` argument forms.
+- **`.phpt` fixture system** — all integration tests migrated to structured `.phpt` files (`===source===`, `===ast===`, `===errors===`, `===config===`). `UPDATE_FIXTURES=1` regenerates expected output.
+- **Documentation structure** — `docs/` directory with architecture, performance, and development subdirectories.
+
+### Fixed
+
+- Ternary chaining rejected in PHP 8 mode.
+- Overflowing integer literals promoted to float.
+- Multi-byte UTF-8 characters preserved in single-quoted strings with escape sequences.
+- `instanceof` operator precedence corrected.
+
+---
+
 ## [0.2.1] - 2026-03-18
 
 ### Added


### PR DESCRIPTION
## Summary

- Bumps workspace version `0.5.0` → `0.6.0`
- Updates `README.md`: corrects the `parse()` API (arena-first), adds `php-printer` to the crate table, documents `ScopeVisitor`/`ScopeWalker`, `PhpVersion`/`parse_versioned`, pretty printer, and PHPDoc parser; removes the stale LSP utilities section (`CommentMap`/`SymbolTable` no longer exist in `php-ast`)
- Updates `CHANGELOG.md`: adds `v0.6.0` entry; backfills `v0.3.0`, `v0.4.0`, `v0.5.0` (previously undocumented)