### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-04-12
+
+### Fixed
+
+- Root `CHANGELOG.md` was stale at v0.3.2; synced through v0.6.0, including the v0.6.0 breaking changes and `ScopeVisitor`/`ScopeWalker` migration guidance (#146).
+
+---
+
 ## [0.6.0] - 2026-04-11
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -24,10 +24,10 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.6.0" }
-php-lexer = { path = "crates/php-lexer", version = "0.6.0" }
-php-rs-parser = { path = "crates/php-parser", version = "0.6.0" }
-php-printer = { path = "crates/php-printer", version = "0.6.0" }
+php-ast = { path = "crates/php-ast", version = "0.6.1" }
+php-lexer = { path = "crates/php-lexer", version = "0.6.1" }
+php-rs-parser = { path = "crates/php-parser", version = "0.6.1" }
+php-printer = { path = "crates/php-printer", version = "0.6.1" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }

--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-04-12
+
+### Fixed
+
+- Root `CHANGELOG.md` was stale at v0.3.2; synced through v0.6.0, including the v0.6.0 breaking changes and `ScopeVisitor`/`ScopeWalker` migration guidance (#146).
+
+---
+
 ## [0.6.0] - 2026-04-11
 
 ### Added


### PR DESCRIPTION
## Summary

Patch release fixing the stale root `CHANGELOG.md`.

- Bump workspace version `0.6.0` → `0.6.1`
- Add `v0.6.1` changelog entry to both `CHANGELOG.md` and `docs/development/CHANGELOG.md`

No functional changes. The only change is documentation — the root `CHANGELOG.md` was synced through v0.6.0 in #146.