### PR TITLE
chore: release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2026-04-12
+
+### Fixed
+
+- `php-printer` published package excluded test fixtures (`tests/`), reducing package size from 198 files to 7.
+
+---
+
 ## [0.6.1] - 2026-04-12
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -24,10 +24,10 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.6.1" }
-php-lexer = { path = "crates/php-lexer", version = "0.6.1" }
-php-rs-parser = { path = "crates/php-parser", version = "0.6.1" }
-php-printer = { path = "crates/php-printer", version = "0.6.1" }
+php-ast = { path = "crates/php-ast", version = "0.6.2" }
+php-lexer = { path = "crates/php-lexer", version = "0.6.2" }
+php-rs-parser = { path = "crates/php-parser", version = "0.6.2" }
+php-printer = { path = "crates/php-printer", version = "0.6.2" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }

--- a/crates/php-printer/Cargo.toml
+++ b/crates/php-printer/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Pretty printer for PHP AST — converts parsed AST back to PHP source code"
+exclude = ["tests/"]
 
 [dependencies]
 php-ast.workspace = true

--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2026-04-12
+
+### Fixed
+
+- `php-printer` published package excluded test fixtures (`tests/`), reducing package size from 198 files to 7.
+
+---
+
 ## [0.6.1] - 2026-04-12
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Add `exclude = ["tests/"]` to `php-printer/Cargo.toml` — published package was 198 files due to `.phpt` fixtures; now 7 files, matching the other crates
- Bump workspace version `0.6.1` → `0.6.2`
- Update both changelogs