### PR TITLE
fix(parser): guard variable name extraction against empty-span tokens

### DIFF
--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -318,9 +318,7 @@ pub fn parse_expr_bp<'arena, 'src>(
             if parser.check(TokenKind::Variable) {
                 // Static property: Class::$prop
                 let token = parser.advance();
-                let src = parser.source;
-                let member =
-                    Cow::Borrowed(&src[token.span.start as usize + 1..token.span.end as usize]);
+                let member = Cow::Borrowed(parser.variable_name(token));
                 let span = Span::new(lhs.span.start, token.span.end);
                 lhs = Expr {
                     kind: ExprKind::StaticPropertyAccess(StaticAccessExpr {
@@ -681,8 +679,7 @@ fn parse_member_name<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr
         // Dynamic: $obj->$var
         TokenKind::Variable => {
             let token = parser.advance();
-            let src = parser.source;
-            let name = &src[token.span.start as usize + 1..token.span.end as usize];
+            let name = parser.variable_name(token);
             Expr {
                 kind: ExprKind::Variable(NameStr::Src(name)),
                 span: token.span,
@@ -1217,9 +1214,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
         // Variables
         TokenKind::Variable => {
             let token = parser.advance();
-            let src = parser.source;
-            // Strip the $ prefix
-            let name = &src[token.span.start as usize + 1..token.span.end as usize];
+            let name = parser.variable_name(token);
             Expr {
                 kind: ExprKind::Variable(NameStr::Src(name)),
                 span: token.span,
@@ -1838,11 +1833,8 @@ fn parse_new_expr<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'a
         TokenKind::Variable => {
             // new $className()
             let t = parser.advance();
-            let src = parser.source;
             Expr {
-                kind: ExprKind::Variable(NameStr::Src(
-                    &src[t.span.start as usize + 1..t.span.end as usize],
-                )),
+                kind: ExprKind::Variable(NameStr::Src(parser.variable_name(t))),
                 span: t.span,
             }
         }
@@ -1966,8 +1958,7 @@ fn parse_closure_use_list<'arena, 'src>(
         let var_start = parser.start_span();
         let by_ref = parser.eat(TokenKind::Ampersand).is_some();
         if let Some(token) = parser.eat(TokenKind::Variable) {
-            let src = parser.source;
-            let name = &src[token.span.start as usize + 1..token.span.end as usize];
+            let name = parser.variable_name(token);
             let span = Span::new(var_start, token.span.end);
             vars.push(ClosureUseVar { name, by_ref, span });
         }

--- a/crates/php-parser/src/parser.rs
+++ b/crates/php-parser/src/parser.rs
@@ -262,6 +262,23 @@ impl<'arena, 'src> Parser<'arena, 'src> {
         self.previous_end
     }
 
+    /// Strip the `$` prefix from a Variable token and return the bare name.
+    ///
+    /// For all tokens produced by the lexer `span.end >= span.start + 2` is an
+    /// invariant, so the guard is always eliminated by the optimiser in release
+    /// builds.  It exists solely to prevent a backwards-range panic if a
+    /// zero-length error-recovery token is ever introduced.
+    #[inline]
+    pub fn variable_name(&self, token: Token) -> &'src str {
+        let start = token.span.start as usize;
+        let end = token.span.end as usize;
+        if start < end {
+            &self.source[start + 1..end]
+        } else {
+            ""
+        }
+    }
+
     /// Check if the current token matches the given kind.
     #[inline]
     pub fn check(&self, kind: TokenKind) -> bool {

--- a/crates/php-parser/src/stmt.rs
+++ b/crates/php-parser/src/stmt.rs
@@ -1150,9 +1150,8 @@ pub fn parse_param_list<'arena, 'src>(
 
         let name_token = parser.expect(TokenKind::Variable);
         let name_span_end = name_token.as_ref().map(|t| t.span.end);
-        let src = parser.source;
         let name: &str = name_token
-            .map(|t| &src[t.span.start as usize + 1..t.span.end as usize])
+            .map(|t| parser.variable_name(t))
             .unwrap_or("<error>");
 
         let default = if parser.eat(TokenKind::Equals).is_some() {
@@ -1236,8 +1235,7 @@ fn try_parse_simple_param_fastpath_minimal<'arena, 'src>(
     // Safe to fast path. Now consume the tokens.
     let name_token = parser.advance();
     let name_span_end = name_token.span.end;
-    let src = parser.source;
-    let name: &str = &src[name_token.span.start as usize + 1..name_token.span.end as usize];
+    let name: &str = parser.variable_name(name_token);
 
     Some(Param {
         name,
@@ -1433,8 +1431,7 @@ fn parse_try_catch<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Stmt<'
 
         let var = if parser.check(TokenKind::Variable) {
             let t = parser.advance();
-            let src = parser.source;
-            Some(&src[t.span.start as usize + 1..t.span.end as usize])
+            Some(parser.variable_name(t))
         } else {
             None
         };
@@ -2407,8 +2404,7 @@ pub fn parse_class_members<'arena, 'src>(
 
         if parser.check(TokenKind::Variable) {
             let var_token = parser.advance();
-            let src = parser.source;
-            let prop_name = &src[var_token.span.start as usize + 1..var_token.span.end as usize];
+            let prop_name = parser.variable_name(var_token);
 
             let default = if parser.eat(TokenKind::Equals).is_some() {
                 Some(expr::parse_expr(parser))
@@ -2456,9 +2452,7 @@ pub fn parse_class_members<'arena, 'src>(
                 // Parse remaining comma-separated properties
                 while parser.check(TokenKind::Variable) {
                     let var_token = parser.advance();
-                    let src = parser.source;
-                    let pname =
-                        &src[var_token.span.start as usize + 1..var_token.span.end as usize];
+                    let pname = parser.variable_name(var_token);
 
                     let pdefault = if parser.eat(TokenKind::Equals).is_some() {
                         Some(expr::parse_expr(parser))
@@ -3222,9 +3216,8 @@ fn parse_static_var<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Stmt<
     loop {
         let var_start = parser.start_span();
         let var_token = parser.expect(TokenKind::Variable);
-        let src = parser.source;
         let name: &str = var_token
-            .map(|t| &src[t.span.start as usize + 1..t.span.end as usize])
+            .map(|t| parser.variable_name(t))
             .unwrap_or("<error>");
 
         let default = if parser.eat(TokenKind::Equals).is_some() {


### PR DESCRIPTION
## Summary

- Introduces `Parser::variable_name(token)` — a single `#[inline]` helper that strips the `$` prefix from a Variable token's span, replacing 11 open-coded `&src[span.start+1..span.end]` sites across `stmt.rs` and `expr.rs`
- Adds a `start < end` guard so a zero-length error-recovery token (`span.start == span.end`) returns `""` instead of a backwards-range panic
- For all tokens the lexer currently emits `span.end >= span.start + 2` is an invariant, so the branch is always-true and the optimiser eliminates it in release builds — no runtime cost

Closes #151

## Test plan

- [ ] `cargo test` passes (all fixture, visitor, printer, and malformed-PHP tests)
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] `cargo fmt --all -- --check` clean