### PR TITLE
fix(parser): replace Box::leak arena pattern with scoped Bump allocators in tests

### DIFF
--- a/crates/php-parser/src/interpolation.rs
+++ b/crates/php-parser/src/interpolation.rs
@@ -781,32 +781,37 @@ mod tests {
     #[allow(unused_imports)]
     use super::*;
 
-    fn parse_src(src: &'static str) -> crate::ParseResult<'static, 'static> {
-        let arena: &'static bumpalo::Bump = Box::leak(Box::new(bumpalo::Bump::new()));
-        crate::parse(arena, src)
-    }
-
     #[test]
     fn indented_heredoc_simple_var() {
-        let result = parse_src("<?php\n$x = <<<END\n    Hello $name!\n    END;\n");
+        let arena = bumpalo::Bump::new();
+        let result = crate::parse(&arena, "<?php\n$x = <<<END\n    Hello $name!\n    END;\n");
         assert!(result.errors.is_empty(), "{:?}", result.errors);
     }
 
     #[test]
     fn indented_heredoc_complex_interpolation() {
-        let result = parse_src("<?php\n$x = <<<END\n    Hello {$obj->name}!\n    END;\n");
+        let arena = bumpalo::Bump::new();
+        let result = crate::parse(
+            &arena,
+            "<?php\n$x = <<<END\n    Hello {$obj->name}!\n    END;\n",
+        );
         assert!(result.errors.is_empty(), "{:?}", result.errors);
     }
 
     #[test]
     fn indented_heredoc_multiline_interpolation() {
-        let result = parse_src("<?php\n$x = <<<END\n    Line 1 {$a}\n    Line 2 {$b}\n    END;\n");
+        let arena = bumpalo::Bump::new();
+        let result = crate::parse(
+            &arena,
+            "<?php\n$x = <<<END\n    Line 1 {$a}\n    Line 2 {$b}\n    END;\n",
+        );
         assert!(result.errors.is_empty(), "{:?}", result.errors);
     }
 
     #[test]
     fn indented_nowdoc() {
-        let result = parse_src("<?php\n$x = <<<'END'\n    Hello world!\n    END;\n");
+        let arena = bumpalo::Bump::new();
+        let result = crate::parse(&arena, "<?php\n$x = <<<'END'\n    Hello world!\n    END;\n");
         assert!(result.errors.is_empty(), "{:?}", result.errors);
     }
 }

--- a/crates/php-parser/tests/integration.rs
+++ b/crates/php-parser/tests/integration.rs
@@ -30,15 +30,14 @@ fn fixtures() {
     let update = std::env::var("UPDATE_FIXTURES").is_ok();
     for path in paths {
         let rel = path.strip_prefix(&dir).unwrap().to_string_lossy();
-        let content: &'static str =
-            Box::leak(std::fs::read_to_string(&path).unwrap().into_boxed_str());
-        let (config, source) = common::parse_fixture(content);
-        let arena: &'static bumpalo::Bump = Box::leak(Box::new(bumpalo::Bump::new()));
+        let content = std::fs::read_to_string(&path).unwrap();
+        let (config, source) = common::parse_fixture(&content);
+        let arena = bumpalo::Bump::new();
 
         let result = if let Some(ver) = config.parse_version {
-            php_rs_parser::parse_versioned(arena, source, common::php_version(ver))
+            php_rs_parser::parse_versioned(&arena, source, common::php_version(ver))
         } else {
-            php_rs_parser::parse(arena, source)
+            php_rs_parser::parse(&arena, source)
         };
 
         if config.expect_errors {

--- a/crates/php-parser/tests/malformed_php.rs
+++ b/crates/php-parser/tests/malformed_php.rs
@@ -3,11 +3,6 @@
 //! All other error-case tests live in `tests/fixtures/errors/*.phpt` and are
 //! run automatically by `integration::fixtures()`.
 
-fn parse(code: &str) -> php_rs_parser::ParseResult<'_, '_> {
-    let arena = Box::leak(Box::new(bumpalo::Bump::new()));
-    php_rs_parser::parse(arena, code)
-}
-
 fn format_errors(result: &php_rs_parser::ParseResult) -> String {
     result
         .errors
@@ -28,7 +23,8 @@ fn with_large_stack<F: FnOnce() + Send + 'static>(f: F) {
 }
 
 fn assert_has_errors(code: &str) {
-    let result = parse(code);
+    let arena = bumpalo::Bump::new();
+    let result = php_rs_parser::parse(&arena, code);
     assert!(
         !result.errors.is_empty(),
         "expected parse errors but got none for: {}...",
@@ -37,7 +33,8 @@ fn assert_has_errors(code: &str) {
 }
 
 fn assert_depth_exceeded(code: &str) {
-    let result = parse(code);
+    let arena = bumpalo::Bump::new();
+    let result = php_rs_parser::parse(&arena, code);
     let msgs = format_errors(&result);
     assert!(
         msgs.contains("maximum expression nesting depth exceeded"),
@@ -46,7 +43,8 @@ fn assert_depth_exceeded(code: &str) {
 }
 
 fn assert_no_errors(code: &str) {
-    let result = parse(code);
+    let arena = bumpalo::Bump::new();
+    let result = php_rs_parser::parse(&arena, code);
     assert!(
         result.errors.is_empty(),
         "unexpected errors: {}",
@@ -112,7 +110,8 @@ fn deeply_nested_match_hit_depth_limit() {
 #[test]
 fn many_sequential_statements() {
     let code = format!("<?php {}", "$x = 1;\n".repeat(10_000));
-    let result = parse(&code);
+    let arena = bumpalo::Bump::new();
+    let result = php_rs_parser::parse(&arena, &code);
     assert!(result.errors.is_empty());
 }
 


### PR DESCRIPTION
## Summary

- Removes `Box::leak` from three test helpers (`interpolation.rs`, `malformed_php.rs`, `integration.rs`) that permanently leaked a `bumpalo::Bump` arena per test invocation
- Replaces each with a scoped `let arena = bumpalo::Bump::new()` local whose lifetime covers the parse call, so the allocator is properly freed after each test

Closes #155