### PR TITLE
fix(parser): eliminate panic-prone unwrap() calls after explicit length checks

### DIFF
--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -1027,7 +1027,11 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                 );
                 // Collapse single literal part into String, or use InterpolatedString
                 if parts.len() == 1 {
-                    match parts.into_iter().next().unwrap() {
+                    match parts
+                        .into_iter()
+                        .next()
+                        .expect("parts.len() == 1 checked above")
+                    {
                         StringPart::Literal(s) => Expr {
                             kind: ExprKind::String(s),
                             span: token.span,
@@ -1509,7 +1513,11 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                             }
                         } else if args.len() == 1 && args[0].name.is_none() && !args[0].unpack {
                             // exit(expr)
-                            let value = args.into_iter().next().unwrap().value;
+                            let value = args
+                                .into_iter()
+                                .next()
+                                .expect("args.len() == 1 checked above")
+                                .value;
                             Expr {
                                 kind: ExprKind::Exit(Some(parser.alloc(value))),
                                 span,
@@ -1577,7 +1585,11 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                             && !args[1].unpack;
                         if is_simple {
                             // clone($obj) — parenthesised single-argument form
-                            let object = args.into_iter().next().unwrap().value;
+                            let object = args
+                                .into_iter()
+                                .next()
+                                .expect("is_simple: args.len() == 1 checked above")
+                                .value;
                             Expr {
                                 kind: ExprKind::Clone(parser.alloc(object)),
                                 span,
@@ -1590,8 +1602,14 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                                 token.span,
                             );
                             let mut iter = args.into_iter();
-                            let object = iter.next().unwrap().value;
-                            let overrides = iter.next().unwrap().value;
+                            let object = iter
+                                .next()
+                                .expect("is_clone_with: args.len() == 2 checked above")
+                                .value;
+                            let overrides = iter
+                                .next()
+                                .expect("is_clone_with: args.len() == 2 checked above")
+                                .value;
                             Expr {
                                 kind: ExprKind::CloneWith(
                                     parser.alloc(object),

--- a/crates/php-parser/src/parser.rs
+++ b/crates/php-parser/src/parser.rs
@@ -640,11 +640,14 @@ impl<'arena, 'src> Parser<'arena, 'src> {
         // Union: A|B|C or (A&B)|C (DNF)
         if self.check(TokenKind::Pipe) {
             self.require_version(PhpVersion::Php80, "union types", self.current_span());
+            let mut end = first.span.end;
             let mut types = self.alloc_vec_one(first);
             while self.eat(TokenKind::Pipe).is_some() {
-                types.push(self.parse_type_element());
+                let t = self.parse_type_element();
+                end = t.span.end;
+                types.push(t);
             }
-            let span = Span::new(start, types.last().unwrap().span.end);
+            let span = Span::new(start, end);
             let has_true = types
                 .iter()
                 .any(|t| matches!(t.kind, TypeHintKind::Keyword(BuiltinType::True, _)));
@@ -707,11 +710,14 @@ impl<'arena, 'src> Parser<'arena, 'src> {
             if looks_like_type {
                 let span = self.current_span();
                 self.require_version(PhpVersion::Php81, "intersection types", span);
+                let mut end = first.span.end;
                 let mut types = self.alloc_vec_one(first);
                 while self.eat(TokenKind::Ampersand).is_some() {
-                    types.push(self.parse_simple_type());
+                    let t = self.parse_simple_type();
+                    end = t.span.end;
+                    types.push(t);
                 }
-                let span = Span::new(start, types.last().unwrap().span.end);
+                let span = Span::new(start, end);
                 return TypeHint {
                     kind: TypeHintKind::Intersection(types),
                     span,
@@ -1016,7 +1022,14 @@ impl<'arena, 'src> Parser<'arena, 'src> {
         let span = if stmts.is_empty() {
             Span::new(start, self.current.span.end)
         } else {
-            Span::new(start, stmts.last().unwrap().span.end)
+            Span::new(
+                start,
+                stmts
+                    .last()
+                    .expect("stmts non-empty: checked above")
+                    .span
+                    .end,
+            )
         };
 
         Program { stmts, span }


### PR DESCRIPTION
## Summary

- Union/intersection type span tracking restructured to use a loop variable instead of `last().unwrap()` on a non-empty vec
- `stmts.last().unwrap()` replaced with `expect()` documenting the existing `is_empty()` guard above it
- `into_iter().next().unwrap()` in exit/clone/clone-with expressions replaced with `expect()` carrying the length-check condition

Closes #152