### PR TITLE
refactor(ast): remove redundant len/last methods from ArenaVec

### DIFF
--- a/crates/php-ast/src/ast.rs
+++ b/crates/php-ast/src/ast.rs
@@ -24,11 +24,8 @@ impl<'arena, T> ArenaVec<'arena, T> {
     pub fn push(&mut self, val: T) {
         self.0.push(val)
     }
-    /// Returns `true` if the vec contains no elements.
-    ///
-    /// Kept as a named method (rather than relying on `Deref<Target=[T]>`) so
-    /// that the path `"ArenaVec::is_empty"` is usable in serde's
-    /// `skip_serializing_if` attribute.
+    /// Kept as an explicit method so `"ArenaVec::is_empty"` works as a serde
+    /// `skip_serializing_if` path (deref-inherited methods don't resolve via UFCS).
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()

--- a/crates/php-ast/src/ast.rs
+++ b/crates/php-ast/src/ast.rs
@@ -24,17 +24,14 @@ impl<'arena, T> ArenaVec<'arena, T> {
     pub fn push(&mut self, val: T) {
         self.0.push(val)
     }
+    /// Returns `true` if the vec contains no elements.
+    ///
+    /// Kept as a named method (rather than relying on `Deref<Target=[T]>`) so
+    /// that the path `"ArenaVec::is_empty"` is usable in serde's
+    /// `skip_serializing_if` attribute.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
-    }
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-    #[inline]
-    pub fn last(&self) -> Option<&T> {
-        self.0.last()
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove `len` and `last` forwarding methods from `ArenaVec` — already available via `Deref<Target=[T]>`
- Keep `is_empty` as an explicit method; serde's `skip_serializing_if = "ArenaVec::is_empty"` requires a direct UFCS-resolvable path which deref-inherited methods don't satisfy

Closes #157