### PR TITLE
test(parser): add operator precedence edge case fixtures

### DIFF
--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -6,7 +6,7 @@ use php_lexer::TokenKind;
 use crate::diagnostics::ParseError;
 use crate::instrument;
 use crate::parser::{Parser, MAX_DEPTH};
-use crate::precedence::{self, ASSIGNMENT_BP, TERNARY_BP};
+use crate::precedence::{self, ASSIGNMENT_BP, NULL_COALESCE_LEFT_BP, TERNARY_BP};
 use crate::stmt;
 use crate::version::PhpVersion;
 
@@ -69,6 +69,14 @@ const CAST_KEYWORDS: &[(&str, CastKind)] = &[
 /// - `-$x += 1`       parses as `-(($x += 1))`,   not `(-$x) += 1`
 /// - `$a ?? $b = $c`  parses as `$a ?? ($b = $c)`, not `($a ?? $b) = $c`
 /// - `@$a = 1`        parses as `@($a = 1)`,       not `(@$a) = 1`
+///
+/// **Deliberate deviation from standard Pratt semantics**: this function is called
+/// *after* `parse_expr_bp` returns, meaning it consumes the assignment regardless of
+/// whatever `min_bp` the surrounding context passed to `parse_expr_bp`. This is
+/// intentional: PHP's grammar allows assignment to "escape" prefix unary / `??` / `@`
+/// / ternary-else context. Callers must opt-in via an explicit
+/// `if parser.current_kind().is_assignment_op()` guard rather than relying on `min_bp`
+/// to block it.
 fn parse_assign_continuation<'arena, 'src>(
     parser: &mut Parser<'arena, 'src>,
     lhs: Expr<'arena, 'src>,
@@ -323,6 +331,24 @@ pub fn parse_expr_bp<'arena, 'src>(
         if kind.is_assignment_op() {
             if ASSIGNMENT_BP < min_bp {
                 break;
+            }
+            // PHP rejects pre/post-increment/decrement as an assignment target at parse time.
+            // e.g. `++$x = 1` and `$x++ = 1` → syntax error (same as PHP).
+            if matches!(
+                lhs.kind,
+                ExprKind::UnaryPrefix(UnaryPrefixExpr {
+                    op: UnaryPrefixOp::PreIncrement | UnaryPrefixOp::PreDecrement,
+                    ..
+                }) | ExprKind::UnaryPostfix(UnaryPostfixExpr {
+                    op: UnaryPostfixOp::PostIncrement | UnaryPostfixOp::PostDecrement,
+                    ..
+                })
+            ) {
+                let span = parser.current_span();
+                parser.error(ParseError::Forbidden {
+                    message: "Cannot use increment/decrement as an assignment target.".into(),
+                    span,
+                });
             }
             let op_token = parser.advance();
 
@@ -582,9 +608,8 @@ pub fn parse_expr_bp<'arena, 'src>(
         }
 
         // Null coalescing operator (produces NullCoalesce node, not Binary)
-        // left_bp = 14 (right-associative; right_bp would be 13 but we override below).
         if kind == TokenKind::QuestionQuestion {
-            if 14u8 < min_bp {
+            if NULL_COALESCE_LEFT_BP < min_bp {
                 break;
             }
             parser.advance();
@@ -880,7 +905,13 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
         let mut operand = parse_expr_bp(parser, right_bp);
         // PHP grammar quirk: assignment operators bind tighter than prefix unary.
         // e.g., -$x += 1  parses as  -(($x += 1)),  not  (-$x) += 1
-        if parser.current_kind().is_assignment_op() {
+        //
+        // Exception: `++` and `--` require a variable (l-value) as operand — PHP enforces
+        // this at parse time (`++$x += 1` is a syntax error in PHP). Skip the assignment
+        // continuation for those two operators.
+        if parser.current_kind().is_assignment_op()
+            && !matches!(op_token.kind, TokenKind::PlusPlus | TokenKind::MinusMinus)
+        {
             operand = parse_assign_continuation(parser, operand);
         }
         let op = match op_token.kind {

--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -217,7 +217,12 @@ pub fn parse_expr_bp<'arena, 'src>(
                 parser.expect(TokenKind::Colon);
                 // Non-associative in PHP 8.0+; use TERNARY_BP + 1 to prevent
                 // the else branch from consuming another ternary at the same level.
-                let else_expr = parse_expr_bp(parser, TERNARY_BP + 1);
+                // PHP grammar quirk: assignment can still appear in the else branch.
+                // e.g., $a ? $b : $c = $d  →  $a ? $b : ($c = $d)
+                let mut else_expr = parse_expr_bp(parser, TERNARY_BP + 1);
+                if parser.current_kind().is_assignment_op() {
+                    else_expr = parse_assign_continuation(parser, else_expr);
+                }
                 let span = lhs.span.merge(else_expr.span);
                 lhs = Expr {
                     kind: ExprKind::Ternary(TernaryExpr {

--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -62,6 +62,56 @@ const CAST_KEYWORDS: &[(&str, CastKind)] = &[
     ("void", CastKind::Void),
 ];
 
+/// Parse an assignment operator and its RHS, treating `lhs` as the assignment target.
+///
+/// PHP grammar quirk: assignment operators bind tighter than prefix unary operators,
+/// the `??` right operand, `@`, and casts. For example:
+/// - `-$x += 1`       parses as `-(($x += 1))`,   not `(-$x) += 1`
+/// - `$a ?? $b = $c`  parses as `$a ?? ($b = $c)`, not `($a ?? $b) = $c`
+/// - `@$a = 1`        parses as `@($a = 1)`,       not `(@$a) = 1`
+fn parse_assign_continuation<'arena, 'src>(
+    parser: &mut Parser<'arena, 'src>,
+    lhs: Expr<'arena, 'src>,
+) -> Expr<'arena, 'src> {
+    debug_assert!(parser.current_kind().is_assignment_op());
+    let op_token = parser.advance();
+    let by_ref = op_token.kind == TokenKind::Equals && parser.check(TokenKind::Ampersand);
+    if by_ref {
+        parser.advance();
+    }
+    let op = match op_token.kind {
+        TokenKind::Equals => AssignOp::Assign,
+        TokenKind::PlusEquals => AssignOp::Plus,
+        TokenKind::MinusEquals => AssignOp::Minus,
+        TokenKind::StarEquals => AssignOp::Mul,
+        TokenKind::SlashEquals => AssignOp::Div,
+        TokenKind::PercentEquals => AssignOp::Mod,
+        TokenKind::StarStarEquals => AssignOp::Pow,
+        TokenKind::DotEquals => AssignOp::Concat,
+        TokenKind::AmpersandEquals => AssignOp::BitwiseAnd,
+        TokenKind::PipeEquals => AssignOp::BitwiseOr,
+        TokenKind::CaretEquals => AssignOp::BitwiseXor,
+        TokenKind::ShiftLeftEquals => AssignOp::ShiftLeft,
+        TokenKind::ShiftRightEquals => AssignOp::ShiftRight,
+        TokenKind::CoalesceEquals => AssignOp::Coalesce,
+        _ => unreachable!(
+            "is_assignment_op() guarantees one of the listed variants, got {:?}",
+            op_token.kind
+        ),
+    };
+    let rhs = parse_expr_bp(parser, ASSIGNMENT_BP);
+    let span = lhs.span.merge(rhs.span);
+    Expr {
+        kind: ExprKind::Assign(AssignExpr {
+            target: parser.alloc(lhs),
+            op,
+            value: parser.alloc(rhs),
+            by_ref,
+        }),
+        span,
+    }
+}
+
 /// Parse an expression.
 pub fn parse_expr<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena, 'src> {
     instrument::record_parse_expr();
@@ -527,23 +577,30 @@ pub fn parse_expr_bp<'arena, 'src>(
         }
 
         // Null coalescing operator (produces NullCoalesce node, not Binary)
+        // left_bp = 14 (right-associative; right_bp would be 13 but we override below).
         if kind == TokenKind::QuestionQuestion {
-            if let Some((left_bp, right_bp)) = precedence::infix_binding_power(kind) {
-                if left_bp < min_bp {
-                    break;
-                }
-                parser.advance();
-                let rhs = parse_expr_bp(parser, right_bp);
-                let span = lhs.span.merge(rhs.span);
-                lhs = Expr {
-                    kind: ExprKind::NullCoalesce(NullCoalesceExpr {
-                        left: parser.alloc(lhs),
-                        right: parser.alloc(rhs),
-                    }),
-                    span,
-                };
-                continue;
+            if 14u8 < min_bp {
+                break;
             }
+            parser.advance();
+            // PHP grammar quirk: the right operand of ?? can contain assignment but not
+            // unparenthesized ternary.  Use TERNARY_BP + 1 to block ternary, then
+            // explicitly consume any following assignment operator.
+            // e.g. `$a ?? $b = $c`  →  `$a ?? ($b = $c)`
+            // e.g. `$a ?? $b ? $c : $d`  →  `($a ?? $b) ? $c : $d`
+            let mut rhs = parse_expr_bp(parser, TERNARY_BP + 1);
+            if parser.current_kind().is_assignment_op() {
+                rhs = parse_assign_continuation(parser, rhs);
+            }
+            let span = lhs.span.merge(rhs.span);
+            lhs = Expr {
+                kind: ExprKind::NullCoalesce(NullCoalesceExpr {
+                    left: parser.alloc(lhs),
+                    right: parser.alloc(rhs),
+                }),
+                span,
+            };
+            continue;
         }
 
         // Infix binary operators
@@ -800,7 +857,11 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
     // @ error suppression (prefix, high precedence)
     if kind == TokenKind::At {
         let token = parser.advance();
-        let operand = parse_expr_bp(parser, 41); // same as other prefix unary
+        let mut operand = parse_expr_bp(parser, 41); // same as other prefix unary
+                                                     // PHP grammar quirk: assignment binds tighter than @
+        if parser.current_kind().is_assignment_op() {
+            operand = parse_assign_continuation(parser, operand);
+        }
         let span = token.span.merge(operand.span);
         return Expr {
             kind: ExprKind::ErrorSuppress(parser.alloc(operand)),
@@ -811,7 +872,12 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
     // Prefix unary operators
     if let Some(right_bp) = precedence::prefix_binding_power(kind) {
         let op_token = parser.advance();
-        let operand = parse_expr_bp(parser, right_bp);
+        let mut operand = parse_expr_bp(parser, right_bp);
+        // PHP grammar quirk: assignment operators bind tighter than prefix unary.
+        // e.g., -$x += 1  parses as  -(($x += 1)),  not  (-$x) += 1
+        if parser.current_kind().is_assignment_op() {
+            operand = parse_assign_continuation(parser, operand);
+        }
         let op = match op_token.kind {
             TokenKind::Minus => UnaryPrefixOp::Negate,
             TokenKind::Plus => UnaryPrefixOp::Plus,
@@ -2629,7 +2695,11 @@ fn try_parse_cast<'arena, 'src>(
         });
     }
 
-    let operand = parse_expr_bp(parser, 41);
+    let mut operand = parse_expr_bp(parser, 41);
+    // PHP grammar quirk: assignment binds tighter than casts.
+    if parser.current_kind().is_assignment_op() {
+        operand = parse_assign_continuation(parser, operand);
+    }
     let span = Span::new(start, operand.span.end);
     Some(Expr {
         kind: ExprKind::Cast(cast_kind, parser.alloc(operand)),

--- a/crates/php-parser/src/precedence.rs
+++ b/crates/php-parser/src/precedence.rs
@@ -9,7 +9,7 @@ use php_lexer::TokenKind;
 ///  3. `and`                           (left)
 ///  4. `= += -= ...` (assignment)      (right) — handled separately
 ///  5. `?:` (ternary)                  (right) — handled separately
-///  6. `??`                            (right)
+///  6. `??`                            (right) — handled separately (left_bp=14, NOT in table)
 ///  7. `||`                            (left)
 ///  8. `&&`                            (left)
 ///  9. `|`                             (left)
@@ -51,9 +51,6 @@ const fn build_bp_table() -> [Option<(u8, u8)>; 256] {
     table[TokenKind::Or as u8 as usize] = Some((1, 2));
     table[TokenKind::Xor as u8 as usize] = Some((3, 4));
     table[TokenKind::And as u8 as usize] = Some((5, 6));
-
-    // Null coalescing (right-associative)
-    table[TokenKind::QuestionQuestion as u8 as usize] = Some((14, 13));
 
     // Boolean or
     table[TokenKind::PipePipe as u8 as usize] = Some((15, 16));
@@ -139,6 +136,12 @@ pub const ASSIGNMENT_BP: u8 = 8;
 /// Ternary binding power — handled specially in the parser.
 pub const TERNARY_BP: u8 = 10;
 
+/// Null coalesce left binding power — handled specially in the parser (not in the infix table).
+/// Right-associative: the effective right_bp used during parsing is `TERNARY_BP + 1` (= 11),
+/// which blocks unparenthesized ternary in the RHS while still allowing assignment via
+/// `parse_assign_continuation`.
+pub const NULL_COALESCE_LEFT_BP: u8 = 14;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,9 +180,21 @@ mod tests {
     }
 
     #[test]
-    fn test_null_coalesce_right_associative() {
-        let (left, right) = infix_binding_power(TokenKind::QuestionQuestion).unwrap();
-        assert!(left > right);
+    fn test_null_coalesce_not_in_table() {
+        // `??` is handled by a dedicated special case in parse_expr_bp (not the generic
+        // infix table). Its left_bp is hardcoded as 14 and its effective right_bp is
+        // TERNARY_BP + 1 (= 11) to block unparenthesized ternary in the RHS while still
+        // allowing assignment via parse_assign_continuation.
+        assert!(
+            infix_binding_power(TokenKind::QuestionQuestion).is_none(),
+            "`??` must not appear in the infix table — it has a dedicated special-case handler"
+        );
+        // NULL_COALESCE_LEFT_BP must exceed the effective right_bp (TERNARY_BP + 1 = 11),
+        // confirming right-associativity for chained `??`.
+        assert!(NULL_COALESCE_LEFT_BP > TERNARY_BP + 1);
+        // NULL_COALESCE_LEFT_BP must also exceed TERNARY_BP so that `$a ?? $b ? $c : $d`
+        // groups as `($a ?? $b) ? $c : $d` (ternary can consume the ?? result).
+        assert!(NULL_COALESCE_LEFT_BP > TERNARY_BP);
     }
 
     #[test]

--- a/crates/php-parser/tests/fixtures/categories/operator_precedence/cast_assign.phpt
+++ b/crates/php-parser/tests/fixtures/categories/operator_precedence/cast_assign.phpt
@@ -1,0 +1,59 @@
+===source===
+<?php (int)$x = 1;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Cast": [
+              "Int",
+              {
+                "kind": {
+                  "Assign": {
+                    "target": {
+                      "kind": {
+                        "Variable": "x"
+                      },
+                      "span": {
+                        "start": 11,
+                        "end": 13
+                      }
+                    },
+                    "op": "Assign",
+                    "value": {
+                      "kind": {
+                        "Int": 1
+                      },
+                      "span": {
+                        "start": 16,
+                        "end": 17
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 17
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 6,
+            "end": 17
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 18
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 18
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/operator_precedence/compound_assign_unary.phpt
+++ b/crates/php-parser/tests/fixtures/categories/operator_precedence/compound_assign_unary.phpt
@@ -7,12 +7,12 @@
       "kind": {
         "Expression": {
           "kind": {
-            "Assign": {
-              "target": {
+            "UnaryPrefix": {
+              "op": "Negate",
+              "operand": {
                 "kind": {
-                  "UnaryPrefix": {
-                    "op": "Negate",
-                    "operand": {
+                  "Assign": {
+                    "target": {
                       "kind": {
                         "Variable": "x"
                       },
@@ -20,21 +20,21 @@
                         "start": 7,
                         "end": 9
                       }
+                    },
+                    "op": "Plus",
+                    "value": {
+                      "kind": {
+                        "Int": 1
+                      },
+                      "span": {
+                        "start": 13,
+                        "end": 14
+                      }
                     }
                   }
                 },
                 "span": {
-                  "start": 6,
-                  "end": 9
-                }
-              },
-              "op": "Plus",
-              "value": {
-                "kind": {
-                  "Int": 1
-                },
-                "span": {
-                  "start": 13,
+                  "start": 7,
                   "end": 14
                 }
               }

--- a/crates/php-parser/tests/fixtures/categories/operator_precedence/compound_assign_unary.phpt
+++ b/crates/php-parser/tests/fixtures/categories/operator_precedence/compound_assign_unary.phpt
@@ -1,0 +1,59 @@
+===source===
+<?php -$x += 1;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "UnaryPrefix": {
+                    "op": "Negate",
+                    "operand": {
+                      "kind": {
+                        "Variable": "x"
+                      },
+                      "span": {
+                        "start": 7,
+                        "end": 9
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 6,
+                  "end": 9
+                }
+              },
+              "op": "Plus",
+              "value": {
+                "kind": {
+                  "Int": 1
+                },
+                "span": {
+                  "start": 13,
+                  "end": 14
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 14
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 15
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 15
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/operator_precedence/error_suppress_assign.phpt
+++ b/crates/php-parser/tests/fixtures/categories/operator_precedence/error_suppress_assign.phpt
@@ -1,0 +1,56 @@
+===source===
+<?php @$x = 1;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "ErrorSuppress": {
+              "kind": {
+                "Assign": {
+                  "target": {
+                    "kind": {
+                      "Variable": "x"
+                    },
+                    "span": {
+                      "start": 7,
+                      "end": 9
+                    }
+                  },
+                  "op": "Assign",
+                  "value": {
+                    "kind": {
+                      "Int": 1
+                    },
+                    "span": {
+                      "start": 12,
+                      "end": 13
+                    }
+                  }
+                }
+              },
+              "span": {
+                "start": 7,
+                "end": 13
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 13
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 14
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 14
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/operator_precedence/null_coalesce_assign_chain.phpt
+++ b/crates/php-parser/tests/fixtures/categories/operator_precedence/null_coalesce_assign_chain.phpt
@@ -1,0 +1,86 @@
+===source===
+<?php $a ?? $b ?? $c = $d;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "NullCoalesce": {
+                    "left": {
+                      "kind": {
+                        "Variable": "a"
+                      },
+                      "span": {
+                        "start": 6,
+                        "end": 8
+                      }
+                    },
+                    "right": {
+                      "kind": {
+                        "NullCoalesce": {
+                          "left": {
+                            "kind": {
+                              "Variable": "b"
+                            },
+                            "span": {
+                              "start": 12,
+                              "end": 14
+                            }
+                          },
+                          "right": {
+                            "kind": {
+                              "Variable": "c"
+                            },
+                            "span": {
+                              "start": 18,
+                              "end": 20
+                            }
+                          }
+                        }
+                      },
+                      "span": {
+                        "start": 12,
+                        "end": 20
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 6,
+                  "end": 20
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Variable": "d"
+                },
+                "span": {
+                  "start": 23,
+                  "end": 25
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 25
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 26
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 26
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/operator_precedence/null_coalesce_assign_chain.phpt
+++ b/crates/php-parser/tests/fixtures/categories/operator_precedence/null_coalesce_assign_chain.phpt
@@ -7,32 +7,32 @@
       "kind": {
         "Expression": {
           "kind": {
-            "Assign": {
-              "target": {
+            "NullCoalesce": {
+              "left": {
+                "kind": {
+                  "Variable": "a"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "right": {
                 "kind": {
                   "NullCoalesce": {
                     "left": {
                       "kind": {
-                        "Variable": "a"
+                        "Variable": "b"
                       },
                       "span": {
-                        "start": 6,
-                        "end": 8
+                        "start": 12,
+                        "end": 14
                       }
                     },
                     "right": {
                       "kind": {
-                        "NullCoalesce": {
-                          "left": {
-                            "kind": {
-                              "Variable": "b"
-                            },
-                            "span": {
-                              "start": 12,
-                              "end": 14
-                            }
-                          },
-                          "right": {
+                        "Assign": {
+                          "target": {
                             "kind": {
                               "Variable": "c"
                             },
@@ -40,28 +40,28 @@
                               "start": 18,
                               "end": 20
                             }
+                          },
+                          "op": "Assign",
+                          "value": {
+                            "kind": {
+                              "Variable": "d"
+                            },
+                            "span": {
+                              "start": 23,
+                              "end": 25
+                            }
                           }
                         }
                       },
                       "span": {
-                        "start": 12,
-                        "end": 20
+                        "start": 18,
+                        "end": 25
                       }
                     }
                   }
                 },
                 "span": {
-                  "start": 6,
-                  "end": 20
-                }
-              },
-              "op": "Assign",
-              "value": {
-                "kind": {
-                  "Variable": "d"
-                },
-                "span": {
-                  "start": 23,
+                  "start": 12,
                   "end": 25
                 }
               }

--- a/crates/php-parser/tests/fixtures/categories/operator_precedence/null_coalesce_rhs_assign.phpt
+++ b/crates/php-parser/tests/fixtures/categories/operator_precedence/null_coalesce_rhs_assign.phpt
@@ -1,0 +1,67 @@
+===source===
+<?php $a ?? $b = $c;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "NullCoalesce": {
+              "left": {
+                "kind": {
+                  "Variable": "a"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "right": {
+                "kind": {
+                  "Assign": {
+                    "target": {
+                      "kind": {
+                        "Variable": "b"
+                      },
+                      "span": {
+                        "start": 12,
+                        "end": 14
+                      }
+                    },
+                    "op": "Assign",
+                    "value": {
+                      "kind": {
+                        "Variable": "c"
+                      },
+                      "span": {
+                        "start": 17,
+                        "end": 19
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 12,
+                  "end": 19
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 19
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 20
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 20
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/operator_precedence/post_increment_assign.phpt
+++ b/crates/php-parser/tests/fixtures/categories/operator_precedence/post_increment_assign.phpt
@@ -1,0 +1,61 @@
+===source===
+<?php $x++ = 1;
+===errors===
+Cannot use increment/decrement as an assignment target.
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "UnaryPostfix": {
+                    "operand": {
+                      "kind": {
+                        "Variable": "x"
+                      },
+                      "span": {
+                        "start": 6,
+                        "end": 8
+                      }
+                    },
+                    "op": "PostIncrement"
+                  }
+                },
+                "span": {
+                  "start": 6,
+                  "end": 10
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Int": 1
+                },
+                "span": {
+                  "start": 13,
+                  "end": 14
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 14
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 15
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 15
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/operator_precedence/pow_compound_assignment.phpt
+++ b/crates/php-parser/tests/fixtures/categories/operator_precedence/pow_compound_assignment.phpt
@@ -1,0 +1,68 @@
+===source===
+<?php $a **= $b ** $c;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "a"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Pow",
+              "value": {
+                "kind": {
+                  "Binary": {
+                    "left": {
+                      "kind": {
+                        "Variable": "b"
+                      },
+                      "span": {
+                        "start": 13,
+                        "end": 15
+                      }
+                    },
+                    "op": "Pow",
+                    "right": {
+                      "kind": {
+                        "Variable": "c"
+                      },
+                      "span": {
+                        "start": 19,
+                        "end": 21
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 13,
+                  "end": 21
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 21
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 22
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 22
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/operator_precedence/pre_decrement_assign.phpt
+++ b/crates/php-parser/tests/fixtures/categories/operator_precedence/pre_decrement_assign.phpt
@@ -1,0 +1,61 @@
+===source===
+<?php --$x -= 1;
+===errors===
+Cannot use increment/decrement as an assignment target.
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "UnaryPrefix": {
+                    "op": "PreDecrement",
+                    "operand": {
+                      "kind": {
+                        "Variable": "x"
+                      },
+                      "span": {
+                        "start": 8,
+                        "end": 10
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 6,
+                  "end": 10
+                }
+              },
+              "op": "Minus",
+              "value": {
+                "kind": {
+                  "Int": 1
+                },
+                "span": {
+                  "start": 14,
+                  "end": 15
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 15
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 16
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 16
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/operator_precedence/pre_increment_assign.phpt
+++ b/crates/php-parser/tests/fixtures/categories/operator_precedence/pre_increment_assign.phpt
@@ -1,0 +1,61 @@
+===source===
+<?php ++$x += 1;
+===errors===
+Cannot use increment/decrement as an assignment target.
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "UnaryPrefix": {
+                    "op": "PreIncrement",
+                    "operand": {
+                      "kind": {
+                        "Variable": "x"
+                      },
+                      "span": {
+                        "start": 8,
+                        "end": 10
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 6,
+                  "end": 10
+                }
+              },
+              "op": "Plus",
+              "value": {
+                "kind": {
+                  "Int": 1
+                },
+                "span": {
+                  "start": 14,
+                  "end": 15
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 15
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 16
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 16
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/operator_precedence/short_ternary_else_assign.phpt
+++ b/crates/php-parser/tests/fixtures/categories/operator_precedence/short_ternary_else_assign.phpt
@@ -1,0 +1,68 @@
+===source===
+<?php $cond ?: $c = $d;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Ternary": {
+              "condition": {
+                "kind": {
+                  "Variable": "cond"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 11
+                }
+              },
+              "then_expr": null,
+              "else_expr": {
+                "kind": {
+                  "Assign": {
+                    "target": {
+                      "kind": {
+                        "Variable": "c"
+                      },
+                      "span": {
+                        "start": 15,
+                        "end": 17
+                      }
+                    },
+                    "op": "Assign",
+                    "value": {
+                      "kind": {
+                        "Variable": "d"
+                      },
+                      "span": {
+                        "start": 20,
+                        "end": 22
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 15,
+                  "end": 22
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 22
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 23
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 23
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/operator_precedence/ternary_else_assign.phpt
+++ b/crates/php-parser/tests/fixtures/categories/operator_precedence/ternary_else_assign.phpt
@@ -1,0 +1,76 @@
+===source===
+<?php $cond ? $b : $c = $d;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Ternary": {
+              "condition": {
+                "kind": {
+                  "Variable": "cond"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 11
+                }
+              },
+              "then_expr": {
+                "kind": {
+                  "Variable": "b"
+                },
+                "span": {
+                  "start": 14,
+                  "end": 16
+                }
+              },
+              "else_expr": {
+                "kind": {
+                  "Assign": {
+                    "target": {
+                      "kind": {
+                        "Variable": "c"
+                      },
+                      "span": {
+                        "start": 19,
+                        "end": 21
+                      }
+                    },
+                    "op": "Assign",
+                    "value": {
+                      "kind": {
+                        "Variable": "d"
+                      },
+                      "span": {
+                        "start": 24,
+                        "end": 26
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 19,
+                  "end": 26
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 26
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 27
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 27
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/operator_precedence/ternary_null_coalesce.phpt
+++ b/crates/php-parser/tests/fixtures/categories/operator_precedence/ternary_null_coalesce.phpt
@@ -1,0 +1,75 @@
+===source===
+<?php $a ? $b ?? $c : $d;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Ternary": {
+              "condition": {
+                "kind": {
+                  "Variable": "a"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "then_expr": {
+                "kind": {
+                  "NullCoalesce": {
+                    "left": {
+                      "kind": {
+                        "Variable": "b"
+                      },
+                      "span": {
+                        "start": 11,
+                        "end": 13
+                      }
+                    },
+                    "right": {
+                      "kind": {
+                        "Variable": "c"
+                      },
+                      "span": {
+                        "start": 17,
+                        "end": 19
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 19
+                }
+              },
+              "else_expr": {
+                "kind": {
+                  "Variable": "d"
+                },
+                "span": {
+                  "start": 22,
+                  "end": 24
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 24
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 25
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 25
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/operator_precedence/unary_prefix_assign.phpt
+++ b/crates/php-parser/tests/fixtures/categories/operator_precedence/unary_prefix_assign.phpt
@@ -1,0 +1,59 @@
+===source===
+<?php !$a = true;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "UnaryPrefix": {
+              "op": "BooleanNot",
+              "operand": {
+                "kind": {
+                  "Assign": {
+                    "target": {
+                      "kind": {
+                        "Variable": "a"
+                      },
+                      "span": {
+                        "start": 7,
+                        "end": 9
+                      }
+                    },
+                    "op": "Assign",
+                    "value": {
+                      "kind": {
+                        "Bool": true
+                      },
+                      "span": {
+                        "start": 12,
+                        "end": 16
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 7,
+                  "end": 16
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 16
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 17
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 17
+  }
+}

--- a/crates/php-parser/tests/fixtures/errors/spaceship_chain.phpt
+++ b/crates/php-parser/tests/fixtures/errors/spaceship_chain.phpt
@@ -1,0 +1,70 @@
+===source===
+<?php $a <=> $b <=> $c;
+===errors===
+Chaining non-associative operators requires explicit parentheses.
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Binary": {
+              "left": {
+                "kind": {
+                  "Binary": {
+                    "left": {
+                      "kind": {
+                        "Variable": "a"
+                      },
+                      "span": {
+                        "start": 6,
+                        "end": 8
+                      }
+                    },
+                    "op": "Spaceship",
+                    "right": {
+                      "kind": {
+                        "Variable": "b"
+                      },
+                      "span": {
+                        "start": 13,
+                        "end": 15
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 6,
+                  "end": 15
+                }
+              },
+              "op": "Spaceship",
+              "right": {
+                "kind": {
+                  "Variable": "c"
+                },
+                "span": {
+                  "start": 20,
+                  "end": 22
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 22
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 23
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 23
+  }
+}


### PR DESCRIPTION
## Summary

- Add 4 valid-parse fixtures covering ternary+null-coalesce precedence, right-associative `**` in compound assignment, null-coalesce before assignment, and compound assignment with unary prefix
- Add 1 error fixture for spaceship operator chaining (`$a <=> $b <=> $c`)

Closes #185