### PR TITLE
test(parser): add list/array destructuring edge case fixtures

### DIFF
--- a/crates/php-parser/tests/fixtures/categories/destructuring/list_empty.phpt
+++ b/crates/php-parser/tests/fixtures/categories/destructuring/list_empty.phpt
@@ -1,0 +1,52 @@
+===source===
+<?php list() = $arr;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Array": []
+                },
+                "span": {
+                  "start": 6,
+                  "end": 12
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Variable": "arr"
+                },
+                "span": {
+                  "start": 15,
+                  "end": 19
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 19
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 20
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 20
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use empty list in Standard input code on line 1
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/categories/destructuring/list_empty_nested.phpt
+++ b/crates/php-parser/tests/fixtures/categories/destructuring/list_empty_nested.phpt
@@ -1,0 +1,70 @@
+===source===
+<?php list(list()) = $arr;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Array": [
+                    {
+                      "key": null,
+                      "value": {
+                        "kind": {
+                          "Array": []
+                        },
+                        "span": {
+                          "start": 11,
+                          "end": 17
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 11,
+                        "end": 17
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 6,
+                  "end": 18
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Variable": "arr"
+                },
+                "span": {
+                  "start": 21,
+                  "end": 25
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 25
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 26
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 26
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use empty list in Standard input code on line 1
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/categories/destructuring/list_shorthand_only_commas.phpt
+++ b/crates/php-parser/tests/fixtures/categories/destructuring/list_shorthand_only_commas.phpt
@@ -1,0 +1,98 @@
+===source===
+<?php [, , ,] = $arr;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Array": [
+                    {
+                      "key": null,
+                      "value": {
+                        "kind": "Omit",
+                        "span": {
+                          "start": 7,
+                          "end": 8
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 7,
+                        "end": 8
+                      }
+                    },
+                    {
+                      "key": null,
+                      "value": {
+                        "kind": "Omit",
+                        "span": {
+                          "start": 9,
+                          "end": 10
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 9,
+                        "end": 10
+                      }
+                    },
+                    {
+                      "key": null,
+                      "value": {
+                        "kind": "Omit",
+                        "span": {
+                          "start": 11,
+                          "end": 12
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 11,
+                        "end": 12
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 6,
+                  "end": 13
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Variable": "arr"
+                },
+                "span": {
+                  "start": 16,
+                  "end": 20
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 20
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 21
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 21
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use empty list in Standard input code on line 1
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/errors/list_spread.phpt
+++ b/crates/php-parser/tests/fixtures/errors/list_spread.phpt
@@ -1,0 +1,56 @@
+===source===
+<?php list(...$x) = $arr;
+===errors===
+expected expression
+expected ')', found '...'
+expected ';' after expression
+expected expression
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Array": [
+              {
+                "key": null,
+                "value": {
+                  "kind": "Error",
+                  "span": {
+                    "start": 11,
+                    "end": 14
+                  }
+                },
+                "unpack": false,
+                "span": {
+                  "start": 11,
+                  "end": 14
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 6,
+            "end": 11
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 11
+      }
+    },
+    {
+      "kind": "Error",
+      "span": {
+        "start": 11,
+        "end": 25
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 25
+  }
+}

--- a/crates/php-parser/tests/fixtures/errors/list_spread.phpt
+++ b/crates/php-parser/tests/fixtures/errors/list_spread.phpt
@@ -54,3 +54,7 @@ expected expression
     "end": 25
   }
 }
+===php_error===
+PHP Fatal error:  Spread operator is not supported in assignments in Standard input code on line 1
+Stack trace:
+#0 {main}


### PR DESCRIPTION
## Summary

- Adds fixtures for all four edge cases from #184: `list()`, `list(list())`, `[, , ,]`, and `list(...$x)`
- The first three parse successfully (our parser is lenient vs PHP's semantic rejection) and are placed in `categories/destructuring/` with entries in the `php_rejects` skip list
- `list(...$x)` produces parser errors and lives in `errors/` with a documented `===errors===` section

Closes #184