### PR TITLE
refactor(tests): replace php_rejects config key with php_error section convention

### DIFF
--- a/crates/php-parser/tests/common.rs
+++ b/crates/php-parser/tests/common.rs
@@ -20,21 +20,26 @@ pub struct FixtureConfig {
     /// Set via `php_rejects=<category>` in `===config===`.
     /// Categories: `parse-leniency`, `semantic`, `deprecated`.
     pub php_rejects: Option<String>,
+    /// Expected `php -l` stderr from the `===php_error===` section.
+    pub php_error: Option<String>,
 }
 
 /// Parse a fixture file with optional `===config===` and mandatory `===source===` sections.
 ///
 /// Format:
 /// ```text
-/// ===config===       <- optional
+/// ===config===          <- optional
 /// min_php=8.5
-/// ===source===       <- required
+/// php_rejects=semantic
+/// ===source===          <- required
 /// <?php
 /// ...
-/// ===errors===       <- optional; presence means expect_errors = true
-/// error message 1    <- optional error content
-/// ===ast===          <- optional; contains expected JSON AST
+/// ===errors===          <- optional; presence means expect_errors = true
+/// error message 1       <- optional error content
+/// ===ast===             <- optional; contains expected JSON AST
 /// { ... }
+/// ===php_error===       <- optional; expected `php -l` stderr for php_rejects fixtures
+/// Fatal error: ...
 /// ```
 ///
 /// Returns the parsed config and a slice of `content` containing only the PHP source
@@ -69,6 +74,7 @@ pub fn parse_fixture(content: &str) -> (FixtureConfig, &str) {
     // Find section markers
     let errors_pos = after_source_marker.find("===errors===\n");
     let ast_pos = after_source_marker.find("===ast===\n");
+    let php_error_pos = after_source_marker.find("===php_error===\n");
 
     // Source ends at the earliest section marker or EOF.
     // Strip one trailing '\n' when ending at a marker: that newline is the line
@@ -104,10 +110,19 @@ pub fn parse_fixture(content: &str) -> (FixtureConfig, &str) {
         })
         .flatten();
 
-    // Extract expected AST JSON
+    // Extract expected AST JSON (ends at ===php_error=== or EOF)
     let expected_ast = ast_pos.map(|a| {
         let after_ast = &after_source_marker[a + "===ast===\n".len()..];
-        after_ast.trim_end_matches('\n').to_string()
+        let end = after_ast
+            .find("===php_error===\n")
+            .unwrap_or(after_ast.len());
+        after_ast[..end].trim_end_matches('\n').to_string()
+    });
+
+    // Extract expected php -l stderr (between ===php_error=== and EOF)
+    let php_error = php_error_pos.map(|p| {
+        let after = &after_source_marker[p + "===php_error===\n".len()..];
+        after.trim_end_matches('\n').to_string()
     });
 
     (
@@ -118,6 +133,7 @@ pub fn parse_fixture(content: &str) -> (FixtureConfig, &str) {
             expected_errors,
             expected_ast,
             php_rejects,
+            php_error,
         },
         source,
     )
@@ -147,10 +163,16 @@ pub fn format_errors(result: &php_rs_parser::ParseResult) -> String {
 }
 
 /// Rewrite the `===errors===` and `===ast===` sections of a fixture file.
+/// Preserves any existing `===php_error===` section that follows.
 /// Called when `UPDATE_FIXTURES=1` is set in the environment.
 pub fn update_fixture(path: &str, errors: &str, new_ast: &str) {
     let content =
         std::fs::read_to_string(path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
+
+    // Preserve any ===php_error=== section that was written by php_syntax tests.
+    let php_error_section = content
+        .find("===php_error===\n")
+        .map(|p| content[p..].trim_end_matches('\n').to_string() + "\n");
 
     // Find the end of the ===source=== section (first marker after it)
     let source_marker = "===source===\n";
@@ -168,10 +190,31 @@ pub fn update_fixture(path: &str, errors: &str, new_ast: &str) {
         .unwrap_or(content.len());
 
     let before_sections = &content[..source_end];
+    let php_error_tail = php_error_section.as_deref().unwrap_or("");
     let new_content = if errors.is_empty() {
-        format!("{before_sections}===ast===\n{new_ast}\n")
+        format!("{before_sections}===ast===\n{new_ast}\n{php_error_tail}")
     } else {
-        format!("{before_sections}===errors===\n{errors}\n===ast===\n{new_ast}\n")
+        format!("{before_sections}===errors===\n{errors}\n===ast===\n{new_ast}\n{php_error_tail}")
+    };
+    std::fs::write(path, new_content).unwrap_or_else(|e| panic!("failed to write {path}: {e}"));
+}
+
+/// Write or replace the `===php_error===` section of a fixture file.
+/// Called when `UPDATE_FIXTURES=1` is set in the environment during php_syntax tests.
+pub fn update_fixture_php_error(path: &str, php_error: &str) {
+    let content =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
+
+    let new_content = if let Some(p) = content.find("===php_error===\n") {
+        // Replace existing section.
+        format!("{}===php_error===\n{}\n", &content[..p], php_error)
+    } else {
+        // Append after ===ast=== (or at EOF if absent).
+        format!(
+            "{}\n===php_error===\n{}\n",
+            content.trim_end_matches('\n'),
+            php_error
+        )
     };
     std::fs::write(path, new_content).unwrap_or_else(|e| panic!("failed to write {path}: {e}"));
 }

--- a/crates/php-parser/tests/common.rs
+++ b/crates/php-parser/tests/common.rs
@@ -16,11 +16,8 @@ pub struct FixtureConfig {
     pub expected_errors: Option<String>,
     /// Expected AST JSON from the `===ast===` section.
     pub expected_ast: Option<String>,
-    /// Why `php -l` would reject this fixture.
-    /// Set via `php_rejects=<category>` in `===config===`.
-    /// Categories: `parse-leniency`, `semantic`, `deprecated`.
-    pub php_rejects: Option<String>,
     /// Expected `php -l` stderr from the `===php_error===` section.
+    /// When `Some`, the fixture represents code that PHP intentionally rejects.
     pub php_error: Option<String>,
 }
 
@@ -30,7 +27,6 @@ pub struct FixtureConfig {
 /// ```text
 /// ===config===          <- optional
 /// min_php=8.5
-/// php_rejects=semantic
 /// ===source===          <- required
 /// <?php
 /// ...
@@ -38,7 +34,7 @@ pub struct FixtureConfig {
 /// error message 1       <- optional error content
 /// ===ast===             <- optional; contains expected JSON AST
 /// { ... }
-/// ===php_error===       <- optional; expected `php -l` stderr for php_rejects fixtures
+/// ===php_error===       <- optional; expected `php -l` stderr (marks fixture as PHP-rejected)
 /// Fatal error: ...
 /// ```
 ///
@@ -47,7 +43,6 @@ pub struct FixtureConfig {
 pub fn parse_fixture(content: &str) -> (FixtureConfig, &str) {
     let mut min_php = None;
     let mut parse_version = None;
-    let mut php_rejects = None;
 
     let rest = if let Some(rest) = content.strip_prefix("===config===\n") {
         let source_marker = rest.find("===source===\n").unwrap_or(rest.len());
@@ -60,8 +55,6 @@ pub fn parse_fixture(content: &str) -> (FixtureConfig, &str) {
                 min_php = parse_ver(val);
             } else if let Some(val) = line.strip_prefix("parse_version=") {
                 parse_version = parse_ver(val);
-            } else if let Some(val) = line.strip_prefix("php_rejects=") {
-                php_rejects = Some(val.to_string());
             }
         }
         &rest[source_marker..]
@@ -132,7 +125,6 @@ pub fn parse_fixture(content: &str) -> (FixtureConfig, &str) {
             expect_errors,
             expected_errors,
             expected_ast,
-            php_rejects,
             php_error,
         },
         source,

--- a/crates/php-parser/tests/common.rs
+++ b/crates/php-parser/tests/common.rs
@@ -16,6 +16,10 @@ pub struct FixtureConfig {
     pub expected_errors: Option<String>,
     /// Expected AST JSON from the `===ast===` section.
     pub expected_ast: Option<String>,
+    /// Why `php -l` would reject this fixture.
+    /// Set via `php_rejects=<category>` in `===config===`.
+    /// Categories: `parse-leniency`, `semantic`, `deprecated`.
+    pub php_rejects: Option<String>,
 }
 
 /// Parse a fixture file with optional `===config===` and mandatory `===source===` sections.
@@ -38,6 +42,7 @@ pub struct FixtureConfig {
 pub fn parse_fixture(content: &str) -> (FixtureConfig, &str) {
     let mut min_php = None;
     let mut parse_version = None;
+    let mut php_rejects = None;
 
     let rest = if let Some(rest) = content.strip_prefix("===config===\n") {
         let source_marker = rest.find("===source===\n").unwrap_or(rest.len());
@@ -50,6 +55,8 @@ pub fn parse_fixture(content: &str) -> (FixtureConfig, &str) {
                 min_php = parse_ver(val);
             } else if let Some(val) = line.strip_prefix("parse_version=") {
                 parse_version = parse_ver(val);
+            } else if let Some(val) = line.strip_prefix("php_rejects=") {
+                php_rejects = Some(val.to_string());
             }
         }
         &rest[source_marker..]
@@ -110,6 +117,7 @@ pub fn parse_fixture(content: &str) -> (FixtureConfig, &str) {
             expect_errors,
             expected_errors,
             expected_ast,
+            php_rejects,
         },
         source,
     )

--- a/crates/php-parser/tests/fixtures/arg_by_ref.phpt
+++ b/crates/php-parser/tests/fixtures/arg_by_ref.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=deprecated
 ===source===
 <?php f(&$a);
 ===ast===

--- a/crates/php-parser/tests/fixtures/arg_by_ref.phpt
+++ b/crates/php-parser/tests/fixtures/arg_by_ref.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=deprecated
 ===source===
 <?php f(&$a);
 ===ast===

--- a/crates/php-parser/tests/fixtures/arg_by_ref.phpt
+++ b/crates/php-parser/tests/fixtures/arg_by_ref.phpt
@@ -58,3 +58,5 @@ php_rejects=deprecated
     "end": 13
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "&" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/arg_by_ref_preserved.phpt
+++ b/crates/php-parser/tests/fixtures/arg_by_ref_preserved.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=deprecated
 ===source===
 <?php f(&$a);
 ===ast===

--- a/crates/php-parser/tests/fixtures/arg_by_ref_preserved.phpt
+++ b/crates/php-parser/tests/fixtures/arg_by_ref_preserved.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=deprecated
 ===source===
 <?php f(&$a);
 ===ast===

--- a/crates/php-parser/tests/fixtures/arg_by_ref_preserved.phpt
+++ b/crates/php-parser/tests/fixtures/arg_by_ref_preserved.phpt
@@ -58,3 +58,5 @@ php_rejects=deprecated
     "end": 13
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "&" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_18.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_18.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=parse-leniency
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_18.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_18.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=parse-leniency
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_18.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_18.phpt
@@ -510,3 +510,5 @@ for ($a, ; $b, ; $c, );
     "end": 324
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token ";", expecting identifier or fully qualified name or namespaced name in Standard input code on line 5

--- a/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_1.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=deprecated
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_1.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=deprecated
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_1.phpt
@@ -469,3 +469,5 @@ new $a->b{'c'}();
     "end": 122
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "{" in Standard input code on line 3

--- a/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_2.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=deprecated
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_2.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=deprecated
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_2.phpt
@@ -469,3 +469,5 @@ new $a->b{'c'}();
     "end": 122
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "{" in Standard input code on line 3

--- a/crates/php-parser/tests/fixtures/corpus/expr/assignNewByRef_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/assignNewByRef_1.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=deprecated
 ===source===
 <?php
 $a =& new B;

--- a/crates/php-parser/tests/fixtures/corpus/expr/assignNewByRef_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/assignNewByRef_1.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=deprecated
 ===source===
 <?php
 $a =& new B;

--- a/crates/php-parser/tests/fixtures/corpus/expr/assignNewByRef_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/assignNewByRef_1.phpt
@@ -61,3 +61,5 @@ $a =& new B;
     "end": 18
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token ";", expecting "(" in Standard input code on line 2

--- a/crates/php-parser/tests/fixtures/corpus/expr/assignNewByRef_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/assignNewByRef_2.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=deprecated
 ===source===
 <?php
 $a =& new B;

--- a/crates/php-parser/tests/fixtures/corpus/expr/assignNewByRef_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/assignNewByRef_2.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=deprecated
 ===source===
 <?php
 $a =& new B;

--- a/crates/php-parser/tests/fixtures/corpus/expr/assignNewByRef_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/assignNewByRef_2.phpt
@@ -61,3 +61,5 @@ $a =& new B;
     "end": 18
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token ";", expecting "(" in Standard input code on line 2

--- a/crates/php-parser/tests/fixtures/corpus/expr/exprInIsset.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/exprInIsset.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 // This is legal.

--- a/crates/php-parser/tests/fixtures/corpus/expr/exprInIsset.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/exprInIsset.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 // This is legal.

--- a/crates/php-parser/tests/fixtures/corpus/expr/exprInIsset.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/exprInIsset.phpt
@@ -122,3 +122,7 @@ isset(1 + 1);
     "end": 102
   }
 }
+===php_error===
+PHP Fatal error:  Cannot use isset() on the result of an expression (you can use "null !== expression" instead) in Standard input code on line 5
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/expr/exprInList.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/exprInList.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/expr/exprInList.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/exprInList.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/expr/exprInList.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/exprInList.phpt
@@ -195,3 +195,7 @@ list(1 + 1) = $x;
     "end": 113
   }
 }
+===php_error===
+PHP Fatal error:  Assignments can only happen to writable values in Standard input code on line 6
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/args.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/args.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=deprecated
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/args.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/args.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=deprecated
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/args.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/args.phpt
@@ -269,3 +269,5 @@ f($a, ...$b);
     "end": 51
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "&" in Standard input code on line 6

--- a/crates/php-parser/tests/fixtures/corpus/expr/firstClassCallables.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/firstClassCallables.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 foo(...);

--- a/crates/php-parser/tests/fixtures/corpus/expr/firstClassCallables.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/firstClassCallables.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 foo(...);

--- a/crates/php-parser/tests/fixtures/corpus/expr/firstClassCallables.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/firstClassCallables.phpt
@@ -224,3 +224,7 @@ function foo() {}
     "end": 165
   }
 }
+===php_error===
+PHP Fatal error:  Cannot create Closure for new expression in Standard input code on line 7
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/expr/uvs/misc.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/uvs/misc.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/expr/uvs/misc.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/uvs/misc.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/expr/uvs/misc.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/uvs/misc.phpt
@@ -349,3 +349,7 @@ php_rejects=semantic
     "end": 99
   }
 }
+===php_error===
+PHP Fatal error:  Cannot use temporary expression in write context in Standard input code on line 7
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/scalar/float.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/scalar/float.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=deprecated
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/scalar/float.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/scalar/float.phpt
@@ -303,3 +303,5 @@ php_rejects=deprecated
     "end": 367
   }
 }
+===php_error===
+PHP Parse error:  Invalid numeric literal in Standard input code on line 20

--- a/crates/php-parser/tests/fixtures/corpus/scalar/float.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/scalar/float.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=deprecated
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/scalar/invalidOctal_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/scalar/invalidOctal_1.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=deprecated
 ===source===
 <?php
 0787;

--- a/crates/php-parser/tests/fixtures/corpus/scalar/invalidOctal_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/scalar/invalidOctal_1.phpt
@@ -29,3 +29,5 @@ php_rejects=deprecated
     "end": 11
   }
 }
+===php_error===
+PHP Parse error:  Invalid numeric literal in Standard input code on line 2

--- a/crates/php-parser/tests/fixtures/corpus/scalar/invalidOctal_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/scalar/invalidOctal_1.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=deprecated
 ===source===
 <?php
 0787;

--- a/crates/php-parser/tests/fixtures/corpus/scalar/invalidOctal_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/scalar/invalidOctal_2.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=deprecated
 ===source===
 <?php
 0787;

--- a/crates/php-parser/tests/fixtures/corpus/scalar/invalidOctal_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/scalar/invalidOctal_2.phpt
@@ -29,3 +29,5 @@ php_rejects=deprecated
     "end": 11
   }
 }
+===php_error===
+PHP Parse error:  Invalid numeric literal in Standard input code on line 2

--- a/crates/php-parser/tests/fixtures/corpus/scalar/invalidOctal_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/scalar/invalidOctal_2.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=deprecated
 ===source===
 <?php
 0787;

--- a/crates/php-parser/tests/fixtures/corpus/scalar/unicodeEscape_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/scalar/unicodeEscape_3.phpt
@@ -29,3 +29,5 @@ php_rejects=semantic
     "end": 29
   }
 }
+===php_error===
+PHP Parse error:  Invalid UTF-8 codepoint escape sequence: Codepoint too large in Standard input code on line 2

--- a/crates/php-parser/tests/fixtures/corpus/scalar/unicodeEscape_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/scalar/unicodeEscape_3.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 "\u{FFFFFFFFFFFFFFFF}";

--- a/crates/php-parser/tests/fixtures/corpus/scalar/unicodeEscape_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/scalar/unicodeEscape_3.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 "\u{FFFFFFFFFFFFFFFF}";

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/asymmetric_visibility_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/asymmetric_visibility_1.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/asymmetric_visibility_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/asymmetric_visibility_1.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/asymmetric_visibility_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/asymmetric_visibility_1.phpt
@@ -221,3 +221,7 @@ class Test {
     "end": 240
   }
 }
+===php_error===
+PHP Fatal error:  Property with asymmetric visibility Test::$a must have type in Standard input code on line 4
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/asymmetric_visibility_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/asymmetric_visibility_2.phpt
@@ -126,3 +126,5 @@ class Test {
     "end": 87
   }
 }
+===php_error===
+PHP Fatal error:  Multiple access type modifiers are not allowed in Standard input code on line 3

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/asymmetric_visibility_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/asymmetric_visibility_2.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 class Test {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/asymmetric_visibility_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/asymmetric_visibility_2.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 class Test {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/enum_with_string.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/enum_with_string.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/enum_with_string.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/enum_with_string.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/enum_with_string.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/enum_with_string.phpt
@@ -120,3 +120,7 @@ enum Suit: string
     "end": 115
   }
 }
+===php_error===
+PHP Fatal error:  Case Diamonds of backed enum Suit must have a value in Standard input code on line 6
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/propertyTypes.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/propertyTypes.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/propertyTypes.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/propertyTypes.phpt
@@ -197,3 +197,7 @@ static properties cannot be readonly
     "end": 126
   }
 }
+===php_error===
+PHP Fatal error:  Static property A::$d cannot be readonly in Standard input code on line 7
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/propertyTypes.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/propertyTypes.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_1.phpt
@@ -344,3 +344,7 @@ class Test {
     "end": 315
   }
 }
+===php_error===
+PHP Fatal error:  Type of parameter $value of hook Test::$prop4::set must be compatible with property type in Standard input code on line 17
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_1.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 class Test {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_1.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 class Test {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_2.phpt
@@ -91,3 +91,7 @@ class Test {
     "end": 93
   }
 }
+===php_error===
+PHP Fatal error:  Property hook list must not be empty in Standard input code on line 3
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_2.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 class Test {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_2.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 class Test {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_3.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 class Test {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_3.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 class Test {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_3.phpt
@@ -79,3 +79,7 @@ class Test {
     "end": 66
   }
 }
+===php_error===
+PHP Fatal error:  get hook of property Test::$prop must not have a parameter list in Standard input code on line 4
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_modifiers.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_modifiers.phpt
@@ -91,3 +91,7 @@ class Test {
     "end": 90
   }
 }
+===php_error===
+PHP Fatal error:  Cannot redeclare Test::$prop in Standard input code on line 4
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_modifiers.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_modifiers.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 class Test {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_modifiers.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_modifiers.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 class Test {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/readonlyMethod.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/readonlyMethod.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php class A { readonly function foo() {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/readonlyMethod.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/readonlyMethod.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php class A { readonly function foo() {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/readonlyMethod.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/readonlyMethod.phpt
@@ -52,3 +52,5 @@ php_rejects=semantic
     "end": 44
   }
 }
+===php_error===
+PHP Fatal error:  Cannot use the readonly modifier on a method in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_1.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php class A { static function __construct() {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_1.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php class A { static function __construct() {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_1.phpt
@@ -52,3 +52,7 @@ php_rejects=semantic
     "end": 50
   }
 }
+===php_error===
+PHP Fatal error:  Method A::__construct() cannot be static in Standard input code on line 1
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_2.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php class A { static function __destruct() {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_2.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php class A { static function __destruct() {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_2.phpt
@@ -52,3 +52,7 @@ php_rejects=semantic
     "end": 49
   }
 }
+===php_error===
+PHP Fatal error:  Method A::__destruct() cannot be static in Standard input code on line 1
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_3.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php class A { static function __clone() {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_3.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php class A { static function __clone() {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_3.phpt
@@ -52,3 +52,7 @@ php_rejects=semantic
     "end": 46
   }
 }
+===php_error===
+PHP Fatal error:  Method A::__clone() cannot be static in Standard input code on line 1
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_4.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_4.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php class A { static function __CONSTRUCT() {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_4.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_4.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php class A { static function __CONSTRUCT() {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_4.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_4.phpt
@@ -52,3 +52,7 @@ php_rejects=semantic
     "end": 50
   }
 }
+===php_error===
+PHP Fatal error:  Method A::__CONSTRUCT() cannot be static in Standard input code on line 1
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_5.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_5.phpt
@@ -52,3 +52,7 @@ php_rejects=semantic
     "end": 49
   }
 }
+===php_error===
+PHP Fatal error:  Method A::__Destruct() cannot be static in Standard input code on line 1
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_5.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_5.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php class A { static function __Destruct() {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_5.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_5.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php class A { static function __Destruct() {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_6.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_6.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php class A { static function __cLoNe() {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_6.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_6.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php class A { static function __cLoNe() {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_6.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/staticMethod_6.phpt
@@ -52,3 +52,7 @@ php_rejects=semantic
     "end": 46
   }
 }
+===php_error===
+PHP Fatal error:  Method A::__cLoNe() cannot be static in Standard input code on line 1
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/controlFlow.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/controlFlow.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/controlFlow.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/controlFlow.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/controlFlow.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/controlFlow.phpt
@@ -138,3 +138,7 @@ goto label;
     "end": 96
   }
 }
+===php_error===
+PHP Fatal error:  'break' not in the 'loop' or 'switch' context in Standard input code on line 3
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/clone_function.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/clone_function.phpt
@@ -1005,3 +1005,5 @@ clone(...);
     "end": 524
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "clone", expecting "(" in Standard input code on line 3

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/clone_function.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/clone_function.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=parse-leniency
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/clone_function.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/clone_function.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=parse-leniency
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/exit_die_function.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/exit_die_function.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=parse-leniency
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/exit_die_function.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/exit_die_function.phpt
@@ -221,3 +221,5 @@ function die(string|int $status = 0): never {}
     "end": 102
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "exit", expecting "(" in Standard input code on line 3

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/exit_die_function.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/exit_die_function.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=parse-leniency
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/variadicDefaultValue.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/variadicDefaultValue.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 function foo(...$foo = []) {}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/variadicDefaultValue.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/variadicDefaultValue.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 function foo(...$foo = []) {}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/variadicDefaultValue.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/variadicDefaultValue.phpt
@@ -53,3 +53,7 @@ function foo(...$foo = []) {}
     "end": 35
   }
 }
+===php_error===
+PHP Fatal error:  Variadic parameter cannot have a default value in Standard input code on line 2
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/alias.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/alias.phpt
@@ -319,3 +319,9 @@ use const foo\BAR as BAZ;
     "end": 235
   }
 }
+===php_error===
+PHP Warning:  The use statement with non-compound name 'J' has no effect in Standard input code on line 5
+PHP Warning:  The use statement with non-compound name 'A' has no effect in Standard input code on line 8
+PHP Fatal error:  Cannot use A as B because the name is already in use in Standard input code on line 9
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/alias.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/alias.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/alias.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/alias.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/groupUse.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/groupUse.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 use A\{B};

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/groupUse.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/groupUse.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 use A\{B};

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/groupUse.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/groupUse.phpt
@@ -324,3 +324,7 @@ use A\B\{C\D, function b\c, const D};
     "end": 137
   }
 }
+===php_error===
+PHP Fatal error:  Cannot use A\B\C\D as D because the name is already in use in Standard input code on line 4
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_1.phpt
@@ -119,3 +119,7 @@ echo 3;
     "end": 62
   }
 }
+===php_error===
+PHP Fatal error:  Cannot mix bracketed namespace declarations with unbracketed namespace declarations in Standard input code on line 4
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_1.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 namespace A;

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_1.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 namespace A;

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_2.phpt
@@ -119,3 +119,7 @@ echo 3;
     "end": 62
   }
 }
+===php_error===
+PHP Fatal error:  No code may exist outside of namespace {} in Standard input code on line 5
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_2.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 namespace A {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/mix_2.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 namespace A {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/nested.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/nested.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 namespace A {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/nested.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/nested.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 namespace A {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/nested.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/nested.phpt
@@ -63,3 +63,7 @@ namespace A {
     "end": 46
   }
 }
+===php_error===
+PHP Fatal error:  Namespace declarations cannot be nested in Standard input code on line 3
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_1.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 echo 1;

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_1.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 echo 1;

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_1.phpt
@@ -73,3 +73,7 @@ namespace A;
     "end": 34
   }
 }
+===php_error===
+PHP Fatal error:  Namespace declaration statement has to be the very first statement or after any declare call in the script in Standard input code on line 4
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_2.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 namespace A {}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_2.phpt
@@ -55,3 +55,7 @@ echo 1;
     "end": 28
   }
 }
+===php_error===
+PHP Fatal error:  No code may exist outside of namespace {} in Standard input code on line 3
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_2.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 namespace A {}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_3.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 namespace A {}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_3.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 namespace A {}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/namespace/outsideStmtInvalid_3.phpt
@@ -114,3 +114,7 @@ namespace B {}
     "end": 60
   }
 }
+===php_error===
+PHP Fatal error:  No code may exist outside of namespace {} in Standard input code on line 3
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/newInInitializer.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/newInInitializer.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/newInInitializer.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/newInInitializer.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/newInInitializer.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/newInInitializer.phpt
@@ -290,3 +290,7 @@ class Bar {
     "end": 163
   }
 }
+===php_error===
+PHP Fatal error:  New expressions are not supported in this context in Standard input code on line 11
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/voidCast.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/voidCast.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=parse-leniency
 ===source===
 <?php
 (void)foo();

--- a/crates/php-parser/tests/fixtures/corpus/stmt/voidCast.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/voidCast.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=parse-leniency
 ===source===
 <?php
 (void)foo();

--- a/crates/php-parser/tests/fixtures/corpus/stmt/voidCast.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/voidCast.phpt
@@ -280,3 +280,5 @@ $x = (void) $y;
     "end": 188
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "(void)" in Standard input code on line 11

--- a/crates/php-parser/tests/fixtures/declare_in_conditional.phpt
+++ b/crates/php-parser/tests/fixtures/declare_in_conditional.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php if (true) { declare(ticks=1); }
 ===ast===

--- a/crates/php-parser/tests/fixtures/declare_in_conditional.phpt
+++ b/crates/php-parser/tests/fixtures/declare_in_conditional.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php if (true) { declare(ticks=1); }
 ===ast===

--- a/crates/php-parser/tests/fixtures/destructuring_null_vs_omit.phpt
+++ b/crates/php-parser/tests/fixtures/destructuring_null_vs_omit.phpt
@@ -98,3 +98,7 @@ php_rejects=semantic
     "end": 28
   }
 }
+===php_error===
+PHP Fatal error:  Assignments can only happen to writable values in Standard input code on line 1
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/destructuring_null_vs_omit.phpt
+++ b/crates/php-parser/tests/fixtures/destructuring_null_vs_omit.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php [$a, null, $c] = $arr;
 ===ast===

--- a/crates/php-parser/tests/fixtures/destructuring_null_vs_omit.phpt
+++ b/crates/php-parser/tests/fixtures/destructuring_null_vs_omit.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php [$a, null, $c] = $arr;
 ===ast===

--- a/crates/php-parser/tests/fixtures/keyword_as_function_clone.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_clone.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=parse-leniency
 ===source===
 <?php function clone(object $object): object {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/keyword_as_function_clone.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_clone.phpt
@@ -78,3 +78,5 @@ php_rejects=parse-leniency
     "end": 47
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "clone", expecting "(" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/keyword_as_function_clone.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_clone.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=parse-leniency
 ===source===
 <?php function clone(object $object): object {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/keyword_as_function_die.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_die.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=parse-leniency
 ===source===
 <?php function die(string|int $status = 0): never {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/keyword_as_function_die.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_die.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=parse-leniency
 ===source===
 <?php function die(string|int $status = 0): never {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/keyword_as_function_die.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_die.phpt
@@ -114,3 +114,5 @@ php_rejects=parse-leniency
     "end": 52
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "exit", expecting "(" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/keyword_as_function_exit.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_exit.phpt
@@ -114,3 +114,5 @@ php_rejects=parse-leniency
     "end": 53
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "exit", expecting "(" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/keyword_as_function_exit.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_exit.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=parse-leniency
 ===source===
 <?php function exit(string|int $status = 0): never {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/keyword_as_function_exit.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_exit.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=parse-leniency
 ===source===
 <?php function exit(string|int $status = 0): never {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/keyword_as_function_fn.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_fn.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=parse-leniency
 ===source===
 <?php function fn() {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/keyword_as_function_fn.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_fn.phpt
@@ -27,3 +27,5 @@ php_rejects=parse-leniency
     "end": 22
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "fn", expecting "(" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/keyword_as_function_fn.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_fn.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=parse-leniency
 ===source===
 <?php function fn() {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/keyword_as_function_match.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_match.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=parse-leniency
 ===source===
 <?php function match() {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/keyword_as_function_match.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_match.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=parse-leniency
 ===source===
 <?php function match() {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/keyword_as_function_match.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_match.phpt
@@ -27,3 +27,5 @@ php_rejects=parse-leniency
     "end": 25
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "match", expecting "(" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/keyword_as_function_readonly.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_readonly.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=parse-leniency
 ===source===
 <?php function readonly() {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/keyword_as_function_readonly.phpt
+++ b/crates/php-parser/tests/fixtures/keyword_as_function_readonly.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=parse-leniency
 ===source===
 <?php function readonly() {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/legacy_octal_invalid_digits.phpt
+++ b/crates/php-parser/tests/fixtures/legacy_octal_invalid_digits.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=deprecated
 ===source===
 <?php 0778; 019; 09;
 ===ast===

--- a/crates/php-parser/tests/fixtures/legacy_octal_invalid_digits.phpt
+++ b/crates/php-parser/tests/fixtures/legacy_octal_invalid_digits.phpt
@@ -62,3 +62,5 @@ php_rejects=deprecated
     "end": 20
   }
 }
+===php_error===
+PHP Parse error:  Invalid numeric literal in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/legacy_octal_invalid_digits.phpt
+++ b/crates/php-parser/tests/fixtures/legacy_octal_invalid_digits.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=deprecated
 ===source===
 <?php 0778; 019; 09;
 ===ast===

--- a/crates/php-parser/tests/fixtures/named_args_mixed_with_spread.phpt
+++ b/crates/php-parser/tests/fixtures/named_args_mixed_with_spread.phpt
@@ -102,3 +102,7 @@ php_rejects=parse-leniency
     "end": 32
   }
 }
+===php_error===
+PHP Fatal error:  Cannot use argument unpacking after named arguments in Standard input code on line 1
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/named_args_mixed_with_spread.phpt
+++ b/crates/php-parser/tests/fixtures/named_args_mixed_with_spread.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=parse-leniency
 ===source===
 <?php func(a: 1, ...['b' => 2]);
 ===ast===

--- a/crates/php-parser/tests/fixtures/named_args_mixed_with_spread.phpt
+++ b/crates/php-parser/tests/fixtures/named_args_mixed_with_spread.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=parse-leniency
 ===source===
 <?php func(a: 1, ...['b' => 2]);
 ===ast===

--- a/crates/php-parser/tests/fixtures/nested_list_destructuring.phpt
+++ b/crates/php-parser/tests/fixtures/nested_list_destructuring.phpt
@@ -333,3 +333,7 @@ list($a, [[$b, $c]]) = [[1, [2, 3]]];
     "end": 67
   }
 }
+===php_error===
+PHP Fatal error:  Cannot mix [] and list() in Standard input code on line 2
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/nested_list_destructuring.phpt
+++ b/crates/php-parser/tests/fixtures/nested_list_destructuring.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=parse-leniency
 ===source===
 <?php
 list($a, [[$b, $c]]) = [[1, [2, 3]]];

--- a/crates/php-parser/tests/fixtures/nested_list_destructuring.phpt
+++ b/crates/php-parser/tests/fixtures/nested_list_destructuring.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=parse-leniency
 ===source===
 <?php
 list($a, [[$b, $c]]) = [[1, [2, 3]]];

--- a/crates/php-parser/tests/fixtures/new_in_complex_initializers.phpt
+++ b/crates/php-parser/tests/fixtures/new_in_complex_initializers.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 function foo(

--- a/crates/php-parser/tests/fixtures/new_in_complex_initializers.phpt
+++ b/crates/php-parser/tests/fixtures/new_in_complex_initializers.phpt
@@ -270,3 +270,7 @@ class Config {
     "end": 167
   }
 }
+===php_error===
+PHP Fatal error:  New expressions are not supported in this context in Standard input code on line 8
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/new_in_complex_initializers.phpt
+++ b/crates/php-parser/tests/fixtures/new_in_complex_initializers.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 function foo(

--- a/crates/php-parser/tests/fixtures/new_in_initializers.phpt
+++ b/crates/php-parser/tests/fixtures/new_in_initializers.phpt
@@ -587,3 +587,7 @@ $g = fn($x = new Foo()) => $x;
     "end": 348
   }
 }
+===php_error===
+PHP Fatal error:  New expressions are not supported in this context in Standard input code on line 5
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/new_in_initializers.phpt
+++ b/crates/php-parser/tests/fixtures/new_in_initializers.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php
 function foo($x = new Foo(), $y = new Bar(1, 2)) {}

--- a/crates/php-parser/tests/fixtures/new_in_initializers.phpt
+++ b/crates/php-parser/tests/fixtures/new_in_initializers.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php
 function foo($x = new Foo(), $y = new Bar(1, 2)) {}

--- a/crates/php-parser/tests/fixtures/null_in_destructuring.phpt
+++ b/crates/php-parser/tests/fixtures/null_in_destructuring.phpt
@@ -98,3 +98,7 @@ php_rejects=semantic
     "end": 28
   }
 }
+===php_error===
+PHP Fatal error:  Assignments can only happen to writable values in Standard input code on line 1
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/fixtures/null_in_destructuring.phpt
+++ b/crates/php-parser/tests/fixtures/null_in_destructuring.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php [$a, null, $c] = $arr;
 ===ast===

--- a/crates/php-parser/tests/fixtures/null_in_destructuring.phpt
+++ b/crates/php-parser/tests/fixtures/null_in_destructuring.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php [$a, null, $c] = $arr;
 ===ast===

--- a/crates/php-parser/tests/fixtures/return_type_self_intersection.phpt
+++ b/crates/php-parser/tests/fixtures/return_type_self_intersection.phpt
@@ -72,3 +72,5 @@ php_rejects=semantic
     "end": 42
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "{", expecting "|" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/return_type_self_intersection.phpt
+++ b/crates/php-parser/tests/fixtures/return_type_self_intersection.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php function foo(): (self&Stringable) {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/return_type_self_intersection.phpt
+++ b/crates/php-parser/tests/fixtures/return_type_self_intersection.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php function foo(): (self&Stringable) {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/static_semicolon_as_stmt.phpt
+++ b/crates/php-parser/tests/fixtures/static_semicolon_as_stmt.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=parse-leniency
 ===source===
 <?php static;
 ===ast===

--- a/crates/php-parser/tests/fixtures/static_semicolon_as_stmt.phpt
+++ b/crates/php-parser/tests/fixtures/static_semicolon_as_stmt.phpt
@@ -28,3 +28,5 @@ php_rejects=parse-leniency
     "end": 13
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token ";", expecting "::" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/static_semicolon_as_stmt.phpt
+++ b/crates/php-parser/tests/fixtures/static_semicolon_as_stmt.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=parse-leniency
 ===source===
 <?php static;
 ===ast===

--- a/crates/php-parser/tests/fixtures/switch_multiple_defaults.phpt
+++ b/crates/php-parser/tests/fixtures/switch_multiple_defaults.phpt
@@ -1,3 +1,5 @@
+===config===
+php_rejects=semantic
 ===source===
 <?php switch ($x) { default: break; case 1: break; default: break; }
 ===ast===

--- a/crates/php-parser/tests/fixtures/switch_multiple_defaults.phpt
+++ b/crates/php-parser/tests/fixtures/switch_multiple_defaults.phpt
@@ -1,5 +1,3 @@
-===config===
-php_rejects=semantic
 ===source===
 <?php switch ($x) { default: break; case 1: break; default: break; }
 ===ast===

--- a/crates/php-parser/tests/fixtures/switch_multiple_defaults.phpt
+++ b/crates/php-parser/tests/fixtures/switch_multiple_defaults.phpt
@@ -94,3 +94,7 @@ php_rejects=semantic
     "end": 68
   }
 }
+===php_error===
+PHP Fatal error:  Switch statements may only contain one default clause in Standard input code on line 1
+Stack trace:
+#0 {main}

--- a/crates/php-parser/tests/php_syntax.rs
+++ b/crates/php-parser/tests/php_syntax.rs
@@ -46,13 +46,8 @@ fn collect_phpt_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
 }
 
 /// Validates every `.phpt` fixture file through `php -l` (recursive, including corpus/).
-/// Skips error-expected fixtures, version-specific fixtures, and fixtures that declare
-/// `php_rejects=<category>` in their `===config===` section (intentional parser leniency).
-///
-/// Categories used in `php_rejects`:
-///   `parse-leniency` — syntax PHP rejects at parse time; we accept for AST completeness
-///   `semantic`        — syntactically valid but PHP rejects at compile time (Fatal error)
-///   `deprecated`      — removed syntax our parser still accepts for compatibility
+/// Skips error-expected fixtures, version-specific fixtures, and fixtures that have a
+/// `===php_error===` section (intentional parser leniency — PHP rejects these).
 #[cfg_attr(not(php_available), ignore)]
 #[test]
 fn fixture_files_are_valid_php() {
@@ -72,7 +67,7 @@ fn fixture_files_are_valid_php() {
         let src = std::fs::read_to_string(&path).unwrap();
         let (config, source) = common::parse_fixture(&src);
 
-        if config.php_rejects.is_some() {
+        if config.php_error.is_some() {
             continue;
         }
         if let Some(min_php) = config.min_php {
@@ -107,8 +102,8 @@ fn fixture_files_are_valid_php() {
     }
 }
 
-/// Asserts that every `php_rejects` fixture is actually rejected by `php -l` and that
-/// its `===php_error===` section matches the real stderr output.
+/// Asserts that every fixture with a `===php_error===` section is actually rejected by
+/// `php -l` and that its `===php_error===` content matches the real stderr output.
 ///
 /// Run `UPDATE_FIXTURES=1 cargo test` to populate or refresh `===php_error===` sections.
 #[cfg_attr(not(php_available), ignore)]
@@ -131,7 +126,7 @@ fn php_rejects_fixtures_fail_lint() {
         let src = std::fs::read_to_string(&path).unwrap();
         let (config, source) = common::parse_fixture(&src);
 
-        if config.php_rejects.is_none() {
+        if config.php_error.is_none() {
             continue;
         }
 

--- a/crates/php-parser/tests/php_syntax.rs
+++ b/crates/php-parser/tests/php_syntax.rs
@@ -31,16 +31,6 @@ fn php_lint(code: &str) -> std::process::Output {
     child.wait_with_output().unwrap()
 }
 
-fn assert_php_syntax_labeled(label: &str, code: &str) {
-    let out = php_lint(code);
-    if !out.status.success() {
-        panic!(
-            "php -l failed ({label}):\n{}",
-            String::from_utf8_lossy(&out.stderr)
-        );
-    }
-}
-
 /// Recursively collect all `.phpt` files under `dir`.
 fn collect_phpt_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
     let mut paths = Vec::new();
@@ -56,106 +46,17 @@ fn collect_phpt_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
 }
 
 /// Validates every `.phpt` fixture file through `php -l` (recursive, including corpus/).
-/// Skips error-expected fixtures, version-specific fixtures, and known divergences.
+/// Skips error-expected fixtures, version-specific fixtures, and fixtures that declare
+/// `php_rejects=<category>` in their `===config===` section (intentional parser leniency).
+///
+/// Categories used in `php_rejects`:
+///   `parse-leniency` — syntax PHP rejects at parse time; we accept for AST completeness
+///   `semantic`        — syntactically valid but PHP rejects at compile time (Fatal error)
+///   `deprecated`      — removed syntax our parser still accepts for compatibility
 #[cfg_attr(not(php_available), ignore)]
 #[test]
 fn fixture_files_are_valid_php() {
     let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
-    // Fixtures where the Rust parser is intentionally more lenient than PHP.
-    // PHP rejects these at parse time or compile time, but our parser accepts
-    // the syntax and defers enforcement to semantic analysis.
-    //
-    // Categories:
-    //   [parse-leniency] — syntax PHP rejects at parse time; we accept for AST completeness
-    //   [semantic]        — syntactically valid but PHP rejects at compile time (Fatal error)
-    //   [deprecated]      — removed syntax our parser still accepts for compatibility
-    let php_rejects: &[&str] = &[
-        // [deprecated] Calling with & at call-site was removed in PHP 5.4.
-        "arg_by_ref.phpt",
-        "arg_by_ref_preserved.phpt",
-        "args.phpt", // corpus: &$arg at call-site
-        // [parse-leniency] Reserved keywords as function names.
-        "keyword_as_function_clone.phpt",
-        "keyword_as_function_die.phpt",
-        "keyword_as_function_exit.phpt",
-        "keyword_as_function_fn.phpt",
-        "keyword_as_function_match.phpt",
-        "keyword_as_function_readonly.phpt",
-        "clone_function.phpt",    // corpus: function clone()
-        "exit_die_function.phpt", // corpus: function exit() / die()
-        // [semantic] Destructuring edge cases.
-        "null_in_destructuring.phpt",
-        "destructuring_null_vs_omit.phpt",
-        "exprInList.phpt", // corpus: non-writable targets in list()
-        // [deprecated] Legacy octal digits (e.g. 0778) — parse error in PHP 8.
-        "legacy_octal_invalid_digits.phpt",
-        "invalidOctal_1.phpt", // corpus
-        "invalidOctal_2.phpt", // corpus
-        "float.phpt",          // corpus: contains invalid numeric literal
-        // [parse-leniency] Spread after named args.
-        "named_args_mixed_with_spread.phpt",
-        // [parse-leniency] Mixing [] and list() destructuring.
-        "nested_list_destructuring.phpt",
-        // [semantic] `new` in initializer positions PHP restricts.
-        "new_in_complex_initializers.phpt",
-        "new_in_initializers.phpt",
-        "newInInitializer.phpt", // corpus
-        // [semantic] `self` in intersection return types.
-        "return_type_self_intersection.phpt",
-        // [parse-leniency] `static;` as statement.
-        "static_semicolon_as_stmt.phpt",
-        // [semantic] Duplicate default in switch.
-        "switch_multiple_defaults.phpt",
-        // [parse-leniency] Trailing commas in positions PHP forbids.
-        "recovery_18.phpt",
-        // [deprecated] Curly brace array/string access — removed in PHP 8.0.
-        "alternative_array_syntax_1.phpt",
-        "alternative_array_syntax_2.phpt",
-        // [deprecated] Assign new by reference ($a =& new Foo) — removed in PHP 7.0.
-        "assignNewByRef_1.phpt",
-        "assignNewByRef_2.phpt",
-        // [semantic] isset() on expression result.
-        "exprInIsset.phpt",
-        // [semantic] First-class callable with `new`.
-        "firstClassCallables.phpt",
-        // [semantic] Write context for temporary expressions.
-        "misc.phpt", // corpus/expr/uvs/misc.phpt
-        // [parse-leniency] (void) cast — not valid in PHP.
-        "voidCast.phpt",
-        // [semantic] declare() inside a conditional block — PHP rejects at compile time.
-        "declare_in_conditional.phpt",
-        // [semantic] break/continue outside loop.
-        "controlFlow.phpt",
-        // [semantic] Unicode escape with codepoint too large.
-        "unicodeEscape_3.phpt",
-        // [semantic] Namespace declaration constraints (nesting, mixing, ordering).
-        "alias.phpt",
-        "groupUse.phpt",
-        "mix_1.phpt",
-        "mix_2.phpt",
-        "nested.phpt",
-        "outsideStmtInvalid_1.phpt",
-        "outsideStmtInvalid_2.phpt",
-        "outsideStmtInvalid_3.phpt",
-        // [semantic] Variadic parameter with default value.
-        "variadicDefaultValue.phpt",
-        // [semantic] Class member constraints enforced by PHP at compile time.
-        "asymmetric_visibility_1.phpt", // must have type
-        "asymmetric_visibility_2.phpt", // multiple access modifiers
-        "enum_with_string.phpt",        // backed enum case without value
-        "propertyTypes.phpt",           // static readonly
-        "property_hooks_1.phpt",        // hook parameter type mismatch
-        "property_hooks_2.phpt",        // empty hook list
-        "property_hooks_3.phpt",        // get hook with parameter list
-        "property_modifiers.phpt",      // property redeclaration
-        "readonlyMethod.phpt",          // readonly on method
-        "staticMethod_1.phpt",          // static __construct
-        "staticMethod_2.phpt",          // static __destruct
-        "staticMethod_3.phpt",          // static __clone
-        "staticMethod_4.phpt",          // static __CONSTRUCT
-        "staticMethod_5.phpt",          // static __Destruct
-        "staticMethod_6.phpt",          // static __cLoNe
-    ];
 
     let mut paths = collect_phpt_files(&dir);
     paths.sort();
@@ -163,11 +64,6 @@ fn fixture_files_are_valid_php() {
     let mut failures: Vec<String> = Vec::new();
 
     for path in paths {
-        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-        if name == "error_recovery.phpt" || php_rejects.contains(&name) {
-            continue;
-        }
-
         let label = path
             .strip_prefix(&dir)
             .unwrap()
@@ -176,6 +72,9 @@ fn fixture_files_are_valid_php() {
         let src = std::fs::read_to_string(&path).unwrap();
         let (config, source) = common::parse_fixture(&src);
 
+        if config.php_rejects.is_some() {
+            continue;
+        }
         if let Some(min_php) = config.min_php {
             if !php_version_met(min_php) {
                 continue;

--- a/crates/php-parser/tests/php_syntax.rs
+++ b/crates/php-parser/tests/php_syntax.rs
@@ -106,3 +106,63 @@ fn fixture_files_are_valid_php() {
         );
     }
 }
+
+/// Asserts that every `php_rejects` fixture is actually rejected by `php -l` and that
+/// its `===php_error===` section matches the real stderr output.
+///
+/// Run `UPDATE_FIXTURES=1 cargo test` to populate or refresh `===php_error===` sections.
+#[cfg_attr(not(php_available), ignore)]
+#[test]
+fn php_rejects_fixtures_fail_lint() {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let update = std::env::var("UPDATE_FIXTURES").is_ok();
+
+    let mut paths = collect_phpt_files(&dir);
+    paths.sort();
+
+    let mut failures: Vec<String> = Vec::new();
+
+    for path in paths {
+        let label = path
+            .strip_prefix(&dir)
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        let src = std::fs::read_to_string(&path).unwrap();
+        let (config, source) = common::parse_fixture(&src);
+
+        if config.php_rejects.is_none() {
+            continue;
+        }
+
+        let out = php_lint(source);
+        if out.status.success() {
+            failures.push(format!("{label}: expected php -l to fail but it passed"));
+            continue;
+        }
+
+        let actual = String::from_utf8_lossy(&out.stderr).trim().to_string();
+
+        if update {
+            common::update_fixture_php_error(path.to_str().unwrap(), &actual);
+        } else if let Some(expected) = &config.php_error {
+            if actual != *expected {
+                failures.push(format!(
+                    "{label}:\n  expected: {expected}\n  actual:   {actual}"
+                ));
+            }
+        } else {
+            failures.push(format!(
+                "{label}: missing ===php_error=== section (run UPDATE_FIXTURES=1 to generate)"
+            ));
+        }
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "php_rejects check failed for {} fixture(s):\n\n{}",
+            failures.len(),
+            failures.join("\n\n")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `PHP_REJECTS` filename list in `php_syntax.rs` with a `php_rejects=<category>` key in each fixture's `===config===` section, making the intent local to the fixture file
- Adds a new test (`php_rejects_fixtures_fail_lint`) that asserts every `php_rejects` fixture is actually rejected by `php -l` and that its `===php_error===` section matches real PHP stderr output; supports `UPDATE_FIXTURES=1` to auto-populate those sections
- Simplifies further by dropping the `php_rejects` config key entirely — the presence of a `===php_error===` section is now the sole marker that PHP rejects the fixture, eliminating the redundant key from all 60+ fixture files and from `FixtureConfig`

## Test plan

- [ ] `cargo test` passes locally
- [ ] `cargo test` with `php_available` feature passes (runs `php -l` validation)
- [ ] `UPDATE_FIXTURES=1 cargo test` can regenerate `===php_error===` sections