### PR TITLE
feat(ast): add Ident type to carry spans on static method/member/arg names

### DIFF
--- a/crates/php-ast/src/ast.rs
+++ b/crates/php-ast/src/ast.rs
@@ -239,6 +239,16 @@ pub enum NameKind {
     Relative,
 }
 
+/// A simple identifier with its source span.
+///
+/// Used for method names, member names, and argument names where source
+/// position is needed (e.g. `Foo::bar()`, `Foo::CONST`, `f(name: val)`).
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct Ident<'src> {
+    pub name: &'src str,
+    pub span: Span,
+}
+
 /// PHP built-in type keyword — zero-cost alternative to `Name::Simple` for the
 /// 20 reserved type names. One byte instead of a `Cow<str>` + `Span` in the AST.
 #[repr(u8)]
@@ -361,7 +371,7 @@ impl<'arena, 'src> serde::Serialize for TypeHintKind<'arena, 'src> {
 
 #[derive(Debug, Serialize)]
 pub struct Arg<'arena, 'src> {
-    pub name: Option<Cow<'src, str>>,
+    pub name: Option<Ident<'src>>,
     pub value: Expr<'arena, 'src>,
     pub unpack: bool,
     pub by_ref: bool,
@@ -717,15 +727,15 @@ pub enum TraitAdaptationKind<'arena, 'src> {
     /// `A::foo insteadof B, C;`
     Precedence {
         trait_name: Name<'arena, 'src>,
-        method: &'src str,
+        method: Ident<'src>,
         insteadof: ArenaVec<'arena, Name<'arena, 'src>>,
     },
     /// `foo as bar;` or `A::foo as protected bar;` or `foo as protected;`
     Alias {
         trait_name: Option<Name<'arena, 'src>>,
-        method: Cow<'src, str>,
+        method: Ident<'src>,
         new_modifier: Option<Visibility>,
-        new_name: Option<&'src str>,
+        new_name: Option<Ident<'src>>,
     },
 }
 
@@ -1273,13 +1283,13 @@ pub struct MethodCallExpr<'arena, 'src> {
 #[derive(Debug, Serialize)]
 pub struct StaticAccessExpr<'arena, 'src> {
     pub class: &'arena Expr<'arena, 'src>,
-    pub member: Cow<'src, str>,
+    pub member: Ident<'src>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct StaticMethodCallExpr<'arena, 'src> {
     pub class: &'arena Expr<'arena, 'src>,
-    pub method: Cow<'src, str>,
+    pub method: Ident<'src>,
     pub args: ArenaVec<'arena, Arg<'arena, 'src>>,
 }
 
@@ -1357,7 +1367,7 @@ pub enum CallableCreateKind<'arena, 'src> {
     /// `Foo::bar(...)`
     StaticMethod {
         class: &'arena Expr<'arena, 'src>,
-        method: Cow<'src, str>,
+        method: Ident<'src>,
     },
 }
 

--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -405,7 +405,10 @@ pub fn parse_expr_bp<'arena, 'src>(
             if parser.check(TokenKind::Variable) {
                 // Static property: Class::$prop
                 let token = parser.advance();
-                let member = Cow::Borrowed(parser.variable_name(token));
+                let member = Ident {
+                    name: parser.variable_name(token),
+                    span: token.span,
+                };
                 let span = Span::new(lhs.span.start, token.span.end);
                 lhs = Expr {
                     kind: ExprKind::StaticPropertyAccess(StaticAccessExpr {
@@ -445,7 +448,10 @@ pub fn parse_expr_bp<'arena, 'src>(
                                 kind: ExprKind::CallableCreate(CallableCreateExpr {
                                     kind: CallableCreateKind::StaticMethod {
                                         class: parser.alloc(lhs),
-                                        method: Cow::Borrowed("{dynamic}"),
+                                        method: Ident {
+                                            name: "{dynamic}",
+                                            span: member.span,
+                                        },
                                     },
                                 }),
                                 span,
@@ -488,13 +494,16 @@ pub fn parse_expr_bp<'arena, 'src>(
                 lhs = Expr {
                     kind: ExprKind::ClassConstAccess(StaticAccessExpr {
                         class: parser.alloc(lhs),
-                        member: Cow::Borrowed("class"),
+                        member: Ident {
+                            name: "class",
+                            span: token.span,
+                        },
                     }),
                     span,
                 };
             } else {
                 // Static method call or class constant
-                let (member_name, _member_span) =
+                let (member_name, member_span) =
                     if let Some(result) = parser.eat_identifier_or_keyword() {
                         result
                     } else {
@@ -515,7 +524,10 @@ pub fn parse_expr_bp<'arena, 'src>(
                                 kind: ExprKind::CallableCreate(CallableCreateExpr {
                                     kind: CallableCreateKind::StaticMethod {
                                         class: parser.alloc(lhs),
-                                        method: Cow::Borrowed(member_name),
+                                        method: Ident {
+                                            name: member_name,
+                                            span: member_span,
+                                        },
                                     },
                                 }),
                                 span,
@@ -527,7 +539,10 @@ pub fn parse_expr_bp<'arena, 'src>(
                                 kind: ExprKind::StaticMethodCall(parser.alloc(
                                     StaticMethodCallExpr {
                                         class: parser.alloc(lhs),
-                                        method: Cow::Borrowed(member_name),
+                                        method: Ident {
+                                            name: member_name,
+                                            span: member_span,
+                                        },
                                         args,
                                     },
                                 )),
@@ -541,7 +556,10 @@ pub fn parse_expr_bp<'arena, 'src>(
                     lhs = Expr {
                         kind: ExprKind::ClassConstAccess(StaticAccessExpr {
                             class: parser.alloc(lhs),
-                            member: Cow::Borrowed(member_name),
+                            member: Ident {
+                                name: member_name,
+                                span: member_span,
+                            },
                         }),
                         span,
                     };
@@ -2399,9 +2417,11 @@ fn parse_arg<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Arg<'arena, 
             parser.require_version(PhpVersion::Php80, "named arguments", span);
             parser.advance(); // consume :
             let src = parser.source;
-            Some(Cow::Borrowed(
-                &src[name_token.span.start as usize..name_token.span.end as usize],
-            ))
+            let name_str = &src[name_token.span.start as usize..name_token.span.end as usize];
+            Some(Ident {
+                name: name_str,
+                span: name_token.span,
+            })
         } else {
             None
         }

--- a/crates/php-parser/src/stmt.rs
+++ b/crates/php-parser/src/stmt.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use php_ast::*;
 use php_lexer::TokenKind;
 
@@ -1741,8 +1739,8 @@ fn parse_trait_adaptations<'arena, 'src>(
 
         if parser.eat(TokenKind::DoubleColon).is_some() {
             // Qualified: TraitName::method
-            let method = if let Some((text, _)) = parser.eat_identifier_or_keyword() {
-                text
+            let method = if let Some((text, span)) = parser.eat_identifier_or_keyword() {
+                Ident { name: text, span }
             } else {
                 let span = parser.current_span();
                 parser.error(ParseError::Expected {
@@ -1750,7 +1748,10 @@ fn parse_trait_adaptations<'arena, 'src>(
                     found: parser.current_kind(),
                     span,
                 });
-                "<error>"
+                Ident {
+                    name: "<error>",
+                    span,
+                }
             };
 
             // Check for `insteadof` or `as`
@@ -1785,7 +1786,7 @@ fn parse_trait_adaptations<'arena, 'src>(
                 adaptations.push(TraitAdaptation {
                     kind: TraitAdaptationKind::Alias {
                         trait_name: Some(first_name),
-                        method: Cow::Borrowed(method),
+                        method,
                         new_modifier,
                         new_name,
                     },
@@ -1802,7 +1803,19 @@ fn parse_trait_adaptations<'arena, 'src>(
             }
         } else if parser.eat(TokenKind::As).is_some() {
             // Unqualified alias: method as [visibility] [newName];
-            let method = first_name.join_parts();
+            let method = match &first_name {
+                Name::Simple { value, span } => Ident {
+                    name: value,
+                    span: *span,
+                },
+                Name::Complex { span, .. } => {
+                    let src = parser.source;
+                    Ident {
+                        name: &src[span.start as usize..span.end as usize],
+                        span: *span,
+                    }
+                }
+            };
             let (new_modifier, new_name) = parse_alias_rhs(parser);
             parser.expect(TokenKind::Semicolon);
             let span = Span::new(start, parser.previous_end());
@@ -1832,7 +1845,7 @@ fn parse_trait_adaptations<'arena, 'src>(
 /// Parse the right-hand side of an `as` alias: `[visibility] [newName]`
 fn parse_alias_rhs<'arena, 'src>(
     parser: &'_ mut Parser<'arena, 'src>,
-) -> (Option<Visibility>, Option<&'src str>) {
+) -> (Option<Visibility>, Option<Ident<'src>>) {
     let new_modifier = match parser.current_kind() {
         TokenKind::Public => {
             parser.advance();
@@ -1851,8 +1864,8 @@ fn parse_alias_rhs<'arena, 'src>(
 
     // New name (optional if visibility was given)
     let new_name = if parser.check(TokenKind::Identifier) || parser.is_semi_reserved_keyword() {
-        let (text, _) = parser.eat_identifier_or_keyword().unwrap();
-        Some(text)
+        let (text, span) = parser.eat_identifier_or_keyword().unwrap();
+        Some(Ident { name: text, span })
     } else {
         None
     };

--- a/crates/php-parser/tests/fixtures/attribute_with_new_expression_arg.phpt
+++ b/crates/php-parser/tests/fixtures/attribute_with_new_expression_arg.phpt
@@ -40,7 +40,13 @@
                         },
                         "args": [
                           {
-                            "name": "debug",
+                            "name": {
+                              "name": "debug",
+                              "span": {
+                                "start": 24,
+                                "end": 29
+                              }
+                            },
                             "value": {
                               "kind": {
                                 "Bool": false

--- a/crates/php-parser/tests/fixtures/attributes.phpt
+++ b/crates/php-parser/tests/fixtures/attributes.phpt
@@ -250,7 +250,13 @@ enum Color {
                   }
                 },
                 {
-                  "name": "methods",
+                  "name": {
+                    "name": "methods",
+                    "span": {
+                      "start": 156,
+                      "end": 163
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Array": [

--- a/crates/php-parser/tests/fixtures/categories/attributes/attr_complex_args.phpt
+++ b/crates/php-parser/tests/fixtures/categories/attributes/attr_complex_args.phpt
@@ -43,7 +43,13 @@
                   }
                 },
                 {
-                  "name": "methods",
+                  "name": {
+                    "name": "methods",
+                    "span": {
+                      "start": 22,
+                      "end": 29
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Array": [

--- a/crates/php-parser/tests/fixtures/categories/attributes/multiple_named_args_in_attr.phpt
+++ b/crates/php-parser/tests/fixtures/categories/attributes/multiple_named_args_in_attr.phpt
@@ -30,7 +30,13 @@
               },
               "args": [
                 {
-                  "name": "min",
+                  "name": {
+                    "name": "min",
+                    "span": {
+                      "start": 21,
+                      "end": 24
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1
@@ -48,7 +54,13 @@
                   }
                 },
                 {
-                  "name": "max",
+                  "name": {
+                    "name": "max",
+                    "span": {
+                      "start": 29,
+                      "end": 32
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 100

--- a/crates/php-parser/tests/fixtures/categories/attributes/named_arg_in_attr.phpt
+++ b/crates/php-parser/tests/fixtures/categories/attributes/named_arg_in_attr.phpt
@@ -25,7 +25,13 @@
               },
               "args": [
                 {
-                  "name": "path",
+                  "name": {
+                    "name": "path",
+                    "span": {
+                      "start": 14,
+                      "end": 18
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "/api"
@@ -43,7 +49,13 @@
                   }
                 },
                 {
-                  "name": "methods",
+                  "name": {
+                    "name": "methods",
+                    "span": {
+                      "start": 28,
+                      "end": 35
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Array": [

--- a/crates/php-parser/tests/fixtures/categories/attributes/positional_and_named_args_in_attr.phpt
+++ b/crates/php-parser/tests/fixtures/categories/attributes/positional_and_named_args_in_attr.phpt
@@ -47,7 +47,13 @@
                   }
                 },
                 {
-                  "name": "key",
+                  "name": {
+                    "name": "key",
+                    "span": {
+                      "start": 27,
+                      "end": 30
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "value"
@@ -65,7 +71,13 @@
                   }
                 },
                 {
-                  "name": "flag",
+                  "name": {
+                    "name": "flag",
+                    "span": {
+                      "start": 41,
+                      "end": 45
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Bool": true

--- a/crates/php-parser/tests/fixtures/categories/clone/clone_named_arg.phpt
+++ b/crates/php-parser/tests/fixtures/categories/clone/clone_named_arg.phpt
@@ -21,7 +21,13 @@ min_php=8.5
               },
               "args": [
                 {
-                  "name": "object",
+                  "name": {
+                    "name": "object",
+                    "span": {
+                      "start": 12,
+                      "end": 18
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/clone/clone_named_args_two.phpt
+++ b/crates/php-parser/tests/fixtures/categories/clone/clone_named_args_two.phpt
@@ -21,7 +21,13 @@ min_php=8.5
               },
               "args": [
                 {
-                  "name": "object",
+                  "name": {
+                    "name": "object",
+                    "span": {
+                      "start": 12,
+                      "end": 18
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"
@@ -39,7 +45,13 @@ min_php=8.5
                   }
                 },
                 {
-                  "name": "withProperties",
+                  "name": {
+                    "name": "withProperties",
+                    "span": {
+                      "start": 24,
+                      "end": 38
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Array": [

--- a/crates/php-parser/tests/fixtures/categories/dynamic_access/dynamic_static.phpt
+++ b/crates/php-parser/tests/fixtures/categories/dynamic_access/dynamic_static.phpt
@@ -17,7 +17,13 @@
                   "end": 12
                 }
               },
-              "member": "prop"
+              "member": {
+                "name": "prop",
+                "span": {
+                  "start": 14,
+                  "end": 19
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/categories/dynamic_access/dynamic_static_method.phpt
+++ b/crates/php-parser/tests/fixtures/categories/dynamic_access/dynamic_static_method.phpt
@@ -20,7 +20,13 @@
                         "end": 12
                       }
                     },
-                    "member": "method"
+                    "member": {
+                      "name": "method",
+                      "span": {
+                        "start": 14,
+                        "end": 21
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/categories/dynamic_access/variable_class_static.phpt
+++ b/crates/php-parser/tests/fixtures/categories/dynamic_access/variable_class_static.phpt
@@ -17,7 +17,13 @@
                   "end": 12
                 }
               },
-              "member": "CONST_NAME"
+              "member": {
+                "name": "CONST_NAME",
+                "span": {
+                  "start": 14,
+                  "end": 24
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/categories/enum/enum_from_and_tryfrom.phpt
+++ b/crates/php-parser/tests/fixtures/categories/enum/enum_from_and_tryfrom.phpt
@@ -17,7 +17,13 @@
                   "end": 12
                 }
               },
-              "method": "from",
+              "method": {
+                "name": "from",
+                "span": {
+                  "start": 14,
+                  "end": 18
+                }
+              },
               "args": [
                 {
                   "name": null,
@@ -65,7 +71,13 @@
                   "end": 29
                 }
               },
-              "method": "tryFrom",
+              "method": {
+                "name": "tryFrom",
+                "span": {
+                  "start": 31,
+                  "end": 38
+                }
+              },
               "args": [
                 {
                   "name": null,

--- a/crates/php-parser/tests/fixtures/categories/enum/enum_static_method.phpt
+++ b/crates/php-parser/tests/fixtures/categories/enum/enum_static_method.phpt
@@ -68,7 +68,13 @@ min_php=8.1
                                   "end": 81
                                 }
                               },
-                              "member": "Red"
+                              "member": {
+                                "name": "Red",
+                                "span": {
+                                  "start": 83,
+                                  "end": 86
+                                }
+                              }
                             }
                           },
                           "span": {

--- a/crates/php-parser/tests/fixtures/categories/enum_in_match/backed_enum_in_match.phpt
+++ b/crates/php-parser/tests/fixtures/categories/enum_in_match/backed_enum_in_match.phpt
@@ -114,7 +114,13 @@ min_php=8.1
                                     "end": 89
                                   }
                                 },
-                                "member": "Red"
+                                "member": {
+                                  "name": "Red",
+                                  "span": {
+                                    "start": 91,
+                                    "end": 94
+                                  }
+                                }
                               }
                             },
                             "span": {
@@ -151,7 +157,13 @@ min_php=8.1
                                     "end": 106
                                   }
                                 },
-                                "member": "Blue"
+                                "member": {
+                                  "name": "Blue",
+                                  "span": {
+                                    "start": 108,
+                                    "end": 112
+                                  }
+                                }
                               }
                             },
                             "span": {

--- a/crates/php-parser/tests/fixtures/categories/enum_in_match/enum_case_as_match_arm.phpt
+++ b/crates/php-parser/tests/fixtures/categories/enum_in_match/enum_case_as_match_arm.phpt
@@ -89,7 +89,13 @@ min_php=8.1
                                     "end": 73
                                   }
                                 },
-                                "member": "Active"
+                                "member": {
+                                  "name": "Active",
+                                  "span": {
+                                    "start": 75,
+                                    "end": 81
+                                  }
+                                }
                               }
                             },
                             "span": {
@@ -126,7 +132,13 @@ min_php=8.1
                                     "end": 97
                                   }
                                 },
-                                "member": "Inactive"
+                                "member": {
+                                  "name": "Inactive",
+                                  "span": {
+                                    "start": 99,
+                                    "end": 107
+                                  }
+                                }
                               }
                             },
                             "span": {

--- a/crates/php-parser/tests/fixtures/categories/enum_in_match/multiple_enum_arms.phpt
+++ b/crates/php-parser/tests/fixtures/categories/enum_in_match/multiple_enum_arms.phpt
@@ -47,7 +47,13 @@ min_php=8.1
                                     "end": 34
                                   }
                                 },
-                                "member": "Active"
+                                "member": {
+                                  "name": "Active",
+                                  "span": {
+                                    "start": 36,
+                                    "end": 42
+                                  }
+                                }
                               }
                             },
                             "span": {
@@ -67,7 +73,13 @@ min_php=8.1
                                     "end": 50
                                   }
                                 },
-                                "member": "Pending"
+                                "member": {
+                                  "name": "Pending",
+                                  "span": {
+                                    "start": 52,
+                                    "end": 59
+                                  }
+                                }
                               }
                             },
                             "span": {
@@ -104,7 +116,13 @@ min_php=8.1
                                     "end": 77
                                   }
                                 },
-                                "member": "Inactive"
+                                "member": {
+                                  "name": "Inactive",
+                                  "span": {
+                                    "start": 79,
+                                    "end": 87
+                                  }
+                                }
                               }
                             },
                             "span": {

--- a/crates/php-parser/tests/fixtures/categories/expression_chains/static_call_chain.phpt
+++ b/crates/php-parser/tests/fixtures/categories/expression_chains/static_call_chain.phpt
@@ -20,7 +20,13 @@
                         "end": 9
                       }
                     },
-                    "method": "create",
+                    "method": {
+                      "name": "create",
+                      "span": {
+                        "start": 11,
+                        "end": 17
+                      }
+                    },
                     "args": []
                   }
                 },

--- a/crates/php-parser/tests/fixtures/categories/fiber/fiber_create_and_start.phpt
+++ b/crates/php-parser/tests/fixtures/categories/fiber/fiber_create_and_start.phpt
@@ -75,7 +75,13 @@ min_php=8.1
                                               "end": 49
                                             }
                                           },
-                                          "method": "suspend",
+                                          "method": {
+                                            "name": "suspend",
+                                            "span": {
+                                              "start": 51,
+                                              "end": 58
+                                            }
+                                          },
                                           "args": [
                                             {
                                               "name": null,

--- a/crates/php-parser/tests/fixtures/categories/fiber/fiber_suspend_static.phpt
+++ b/crates/php-parser/tests/fixtures/categories/fiber/fiber_suspend_static.phpt
@@ -32,7 +32,13 @@ min_php=8.1
                         "end": 18
                       }
                     },
-                    "method": "suspend",
+                    "method": {
+                      "name": "suspend",
+                      "span": {
+                        "start": 20,
+                        "end": 27
+                      }
+                    },
                     "args": [
                       {
                         "name": null,

--- a/crates/php-parser/tests/fixtures/categories/heredoc/named_arg_with_heredoc_closing_marker_followed_by.phpt
+++ b/crates/php-parser/tests/fixtures/categories/heredoc/named_arg_with_heredoc_closing_marker_followed_by.phpt
@@ -21,7 +21,13 @@ EOT);
               },
               "args": [
                 {
-                  "name": "bar",
+                  "name": {
+                    "name": "bar",
+                    "span": {
+                      "start": 10,
+                      "end": 13
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Heredoc": {

--- a/crates/php-parser/tests/fixtures/categories/heredoc/named_arg_with_heredoc_value.phpt
+++ b/crates/php-parser/tests/fixtures/categories/heredoc/named_arg_with_heredoc_value.phpt
@@ -22,7 +22,13 @@ EOT
               },
               "args": [
                 {
-                  "name": "bar",
+                  "name": {
+                    "name": "bar",
+                    "span": {
+                      "start": 10,
+                      "end": 13
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Heredoc": {

--- a/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_false.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_false.phpt
@@ -19,7 +19,13 @@
               },
               "args": [
                 {
-                  "name": "false",
+                  "name": {
+                    "name": "false",
+                    "span": {
+                      "start": 10,
+                      "end": 15
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_fn.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_fn.phpt
@@ -19,7 +19,13 @@
               },
               "args": [
                 {
-                  "name": "fn",
+                  "name": {
+                    "name": "fn",
+                    "span": {
+                      "start": 10,
+                      "end": 12
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_for.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_for.phpt
@@ -19,7 +19,13 @@
               },
               "args": [
                 {
-                  "name": "for",
+                  "name": {
+                    "name": "for",
+                    "span": {
+                      "start": 10,
+                      "end": 13
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_list.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_list.phpt
@@ -19,7 +19,13 @@
               },
               "args": [
                 {
-                  "name": "list",
+                  "name": {
+                    "name": "list",
+                    "span": {
+                      "start": 10,
+                      "end": 14
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_null.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_null.phpt
@@ -19,7 +19,13 @@
               },
               "args": [
                 {
-                  "name": "null",
+                  "name": {
+                    "name": "null",
+                    "span": {
+                      "start": 10,
+                      "end": 14
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_true.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_true.phpt
@@ -19,7 +19,13 @@
               },
               "args": [
                 {
-                  "name": "true",
+                  "name": {
+                    "name": "true",
+                    "span": {
+                      "start": 10,
+                      "end": 14
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_while.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_while.phpt
@@ -19,7 +19,13 @@
               },
               "args": [
                 {
-                  "name": "while",
+                  "name": {
+                    "name": "while",
+                    "span": {
+                      "start": 10,
+                      "end": 15
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/named_args/mixed_named_args.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/mixed_named_args.phpt
@@ -55,7 +55,13 @@
                   }
                 },
                 {
-                  "name": "name",
+                  "name": {
+                    "name": "name",
+                    "span": {
+                      "start": 16,
+                      "end": 20
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "test"
@@ -73,7 +79,13 @@
                   }
                 },
                 {
-                  "name": "other",
+                  "name": {
+                    "name": "other",
+                    "span": {
+                      "start": 30,
+                      "end": 35
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Bool": true

--- a/crates/php-parser/tests/fixtures/categories/named_args/named_in_method.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/named_in_method.phpt
@@ -28,7 +28,13 @@
               },
               "args": [
                 {
-                  "name": "key",
+                  "name": {
+                    "name": "key",
+                    "span": {
+                      "start": 19,
+                      "end": 22
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "val"

--- a/crates/php-parser/tests/fixtures/categories/named_args/named_in_new.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/named_in_new.phpt
@@ -19,7 +19,13 @@
               },
               "args": [
                 {
-                  "name": "x",
+                  "name": {
+                    "name": "x",
+                    "span": {
+                      "start": 14,
+                      "end": 15
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1
@@ -37,7 +43,13 @@
                   }
                 },
                 {
-                  "name": "y",
+                  "name": {
+                    "name": "y",
+                    "span": {
+                      "start": 20,
+                      "end": 21
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 2

--- a/crates/php-parser/tests/fixtures/categories/named_args/named_with_spread.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/named_with_spread.phpt
@@ -37,7 +37,13 @@
                   }
                 },
                 {
-                  "name": "name",
+                  "name": {
+                    "name": "name",
+                    "span": {
+                      "start": 21,
+                      "end": 25
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "test"

--- a/crates/php-parser/tests/fixtures/categories/scope_resolution/class_const_on_name.phpt
+++ b/crates/php-parser/tests/fixtures/categories/scope_resolution/class_const_on_name.phpt
@@ -18,7 +18,13 @@
                     "end": 14
                   }
                 },
-                "member": "class"
+                "member": {
+                  "name": "class",
+                  "span": {
+                    "start": 16,
+                    "end": 21
+                  }
+                }
               }
             },
             "span": {

--- a/crates/php-parser/tests/fixtures/categories/scope_resolution/parent_const.phpt
+++ b/crates/php-parser/tests/fixtures/categories/scope_resolution/parent_const.phpt
@@ -50,7 +50,13 @@
                                   "end": 65
                                 }
                               },
-                              "member": "VERSION"
+                              "member": {
+                                "name": "VERSION",
+                                "span": {
+                                  "start": 67,
+                                  "end": 74
+                                }
+                              }
                             }
                           },
                           "span": {

--- a/crates/php-parser/tests/fixtures/categories/scope_resolution/parent_method.phpt
+++ b/crates/php-parser/tests/fixtures/categories/scope_resolution/parent_method.phpt
@@ -50,7 +50,13 @@
                                   "end": 58
                                 }
                               },
-                              "method": "f",
+                              "method": {
+                                "name": "f",
+                                "span": {
+                                  "start": 60,
+                                  "end": 61
+                                }
+                              },
                               "args": []
                             }
                           },

--- a/crates/php-parser/tests/fixtures/categories/scope_resolution/self_const.phpt
+++ b/crates/php-parser/tests/fixtures/categories/scope_resolution/self_const.phpt
@@ -63,7 +63,13 @@
                                   "end": 64
                                 }
                               },
-                              "member": "X"
+                              "member": {
+                                "name": "X",
+                                "span": {
+                                  "start": 66,
+                                  "end": 67
+                                }
+                              }
                             }
                           },
                           "span": {

--- a/crates/php-parser/tests/fixtures/categories/scope_resolution/self_static_prop.phpt
+++ b/crates/php-parser/tests/fixtures/categories/scope_resolution/self_static_prop.phpt
@@ -67,7 +67,13 @@
                                   "end": 73
                                 }
                               },
-                              "member": "x"
+                              "member": {
+                                "name": "x",
+                                "span": {
+                                  "start": 75,
+                                  "end": 77
+                                }
+                              }
                             }
                           },
                           "span": {

--- a/crates/php-parser/tests/fixtures/categories/scope_resolution/static_const.phpt
+++ b/crates/php-parser/tests/fixtures/categories/scope_resolution/static_const.phpt
@@ -41,7 +41,13 @@
                                   "end": 53
                                 }
                               },
-                              "member": "DEFAULT"
+                              "member": {
+                                "name": "DEFAULT",
+                                "span": {
+                                  "start": 55,
+                                  "end": 62
+                                }
+                              }
                             }
                           },
                           "span": {

--- a/crates/php-parser/tests/fixtures/categories/span_precision/method_call_span.phpt
+++ b/crates/php-parser/tests/fixtures/categories/span_precision/method_call_span.phpt
@@ -132,7 +132,13 @@ Foo::bar(1);
                   "end": 44
                 }
               },
-              "method": "bar",
+              "method": {
+                "name": "bar",
+                "span": {
+                  "start": 46,
+                  "end": 49
+                }
+              },
               "args": [
                 {
                   "name": null,

--- a/crates/php-parser/tests/fixtures/categories/trait_use/alias_qualified_method.phpt
+++ b/crates/php-parser/tests/fixtures/categories/trait_use/alias_qualified_method.phpt
@@ -44,9 +44,21 @@
                               "end": 25
                             }
                           },
-                          "method": "foo",
+                          "method": {
+                            "name": "foo",
+                            "span": {
+                              "start": 27,
+                              "end": 30
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "bar"
+                          "new_name": {
+                            "name": "bar",
+                            "span": {
+                              "start": 34,
+                              "end": 37
+                            }
+                          }
                         }
                       },
                       "span": {

--- a/crates/php-parser/tests/fixtures/categories/trait_use/alias_qualified_with_visibility.phpt
+++ b/crates/php-parser/tests/fixtures/categories/trait_use/alias_qualified_with_visibility.phpt
@@ -44,9 +44,21 @@
                               "end": 25
                             }
                           },
-                          "method": "foo",
+                          "method": {
+                            "name": "foo",
+                            "span": {
+                              "start": 27,
+                              "end": 30
+                            }
+                          },
                           "new_modifier": "Protected",
-                          "new_name": "baz"
+                          "new_name": {
+                            "name": "baz",
+                            "span": {
+                              "start": 44,
+                              "end": 47
+                            }
+                          }
                         }
                       },
                       "span": {

--- a/crates/php-parser/tests/fixtures/categories/trait_use/alias_visibility_only.phpt
+++ b/crates/php-parser/tests/fixtures/categories/trait_use/alias_visibility_only.phpt
@@ -35,7 +35,13 @@
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "foo",
+                          "method": {
+                            "name": "foo",
+                            "span": {
+                              "start": 24,
+                              "end": 27
+                            }
+                          },
                           "new_modifier": "Protected",
                           "new_name": null
                         }

--- a/crates/php-parser/tests/fixtures/categories/trait_use/insteadof_multi.phpt
+++ b/crates/php-parser/tests/fixtures/categories/trait_use/insteadof_multi.phpt
@@ -54,7 +54,13 @@
                               "end": 28
                             }
                           },
-                          "method": "m",
+                          "method": {
+                            "name": "m",
+                            "span": {
+                              "start": 30,
+                              "end": 31
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [

--- a/crates/php-parser/tests/fixtures/categories/trait_use/multiple_adaptations.phpt
+++ b/crates/php-parser/tests/fixtures/categories/trait_use/multiple_adaptations.phpt
@@ -54,7 +54,13 @@
                               "end": 28
                             }
                           },
-                          "method": "m",
+                          "method": {
+                            "name": "m",
+                            "span": {
+                              "start": 30,
+                              "end": 31
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [
@@ -87,9 +93,21 @@
                               "end": 46
                             }
                           },
-                          "method": "n",
+                          "method": {
+                            "name": "n",
+                            "span": {
+                              "start": 48,
+                              "end": 49
+                            }
+                          },
                           "new_modifier": "Public",
-                          "new_name": "nAlias"
+                          "new_name": {
+                            "name": "nAlias",
+                            "span": {
+                              "start": 60,
+                              "end": 66
+                            }
+                          }
                         }
                       },
                       "span": {

--- a/crates/php-parser/tests/fixtures/class_name_resolution.phpt
+++ b/crates/php-parser/tests/fixtures/class_name_resolution.phpt
@@ -17,7 +17,13 @@
                   "end": 9
                 }
               },
-              "member": "class"
+              "member": {
+                "name": "class",
+                "span": {
+                  "start": 11,
+                  "end": 16
+                }
+              }
             }
           },
           "span": {
@@ -45,7 +51,13 @@
                   "end": 22
                 }
               },
-              "member": "class"
+              "member": {
+                "name": "class",
+                "span": {
+                  "start": 24,
+                  "end": 29
+                }
+              }
             }
           },
           "span": {
@@ -73,7 +85,13 @@
                   "end": 37
                 }
               },
-              "member": "class"
+              "member": {
+                "name": "class",
+                "span": {
+                  "start": 39,
+                  "end": 44
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/class_static_and_const.phpt
+++ b/crates/php-parser/tests/fixtures/class_static_and_const.phpt
@@ -156,7 +156,13 @@ class Config {
                                         "end": 181
                                       }
                                     },
-                                    "member": "count"
+                                    "member": {
+                                      "name": "count",
+                                      "span": {
+                                        "start": 183,
+                                        "end": 189
+                                      }
+                                    }
                                   }
                                 },
                                 "span": {

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_16.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_16.phpt
@@ -21,7 +21,13 @@ expected ';' after expression
                   "end": 9
                 }
               },
-              "member": "<error>"
+              "member": {
+                "name": "<error>",
+                "span": {
+                  "start": 11,
+                  "end": 11
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_18.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_18.phpt
@@ -223,7 +223,13 @@ for ($a, ; $b, ; $c, );
                               "end": 127
                             }
                           },
-                          "method": "b",
+                          "method": {
+                            "name": "b",
+                            "span": {
+                              "start": 129,
+                              "end": 130
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_19.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_19.phpt
@@ -36,7 +36,13 @@ expected identifier, found ')'
                             "end": 14
                           }
                         },
-                        "member": "<error>"
+                        "member": {
+                          "name": "<error>",
+                          "span": {
+                            "start": 16,
+                            "end": 17
+                          }
+                        }
                       }
                     },
                     "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_1.phpt
@@ -226,7 +226,13 @@ new $a->b{'c'}();
                         "end": 54
                       }
                     },
-                    "member": "b"
+                    "member": {
+                      "name": "b",
+                      "span": {
+                        "start": 56,
+                        "end": 58
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -309,7 +315,13 @@ new $a->b{'c'}();
                         "end": 72
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "name": "B",
+                      "span": {
+                        "start": 74,
+                        "end": 75
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_1_php83.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_1_php83.phpt
@@ -226,7 +226,13 @@ new $a->b{'c'}();
                         "end": 54
                       }
                     },
-                    "member": "b"
+                    "member": {
+                      "name": "b",
+                      "span": {
+                        "start": 56,
+                        "end": 58
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -309,7 +315,13 @@ new $a->b{'c'}();
                         "end": 72
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "name": "B",
+                      "span": {
+                        "start": 74,
+                        "end": 75
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_2.phpt
@@ -226,7 +226,13 @@ new $a->b{'c'}();
                         "end": 54
                       }
                     },
-                    "member": "b"
+                    "member": {
+                      "name": "b",
+                      "span": {
+                        "start": 56,
+                        "end": 58
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -309,7 +315,13 @@ new $a->b{'c'}();
                         "end": 72
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "name": "B",
+                      "span": {
+                        "start": 74,
+                        "end": 75
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_2_php83.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_2_php83.phpt
@@ -226,7 +226,13 @@ new $a->b{'c'}();
                         "end": 54
                       }
                     },
-                    "member": "b"
+                    "member": {
+                      "name": "b",
+                      "span": {
+                        "start": 56,
+                        "end": 58
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -309,7 +315,13 @@ new $a->b{'c'}();
                         "end": 72
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "name": "B",
+                      "span": {
+                        "start": 74,
+                        "end": 75
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/exit.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/exit.phpt
@@ -152,7 +152,13 @@ DIE($a, $b);
               },
               "args": [
                 {
-                  "name": "status",
+                  "name": {
+                    "name": "status",
+                    "span": {
+                      "start": 66,
+                      "end": 72
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 42

--- a/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/constFetch.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/constFetch.phpt
@@ -40,7 +40,13 @@ $a::class;
                   "end": 11
                 }
               },
-              "member": "B"
+              "member": {
+                "name": "B",
+                "span": {
+                  "start": 13,
+                  "end": 14
+                }
+              }
             }
           },
           "span": {
@@ -68,7 +74,13 @@ $a::class;
                   "end": 17
                 }
               },
-              "member": "class"
+              "member": {
+                "name": "class",
+                "span": {
+                  "start": 19,
+                  "end": 24
+                }
+              }
             }
           },
           "span": {
@@ -96,7 +108,13 @@ $a::class;
                   "end": 28
                 }
               },
-              "member": "B"
+              "member": {
+                "name": "B",
+                "span": {
+                  "start": 30,
+                  "end": 31
+                }
+              }
             }
           },
           "span": {
@@ -124,7 +142,13 @@ $a::class;
                   "end": 35
                 }
               },
-              "member": "class"
+              "member": {
+                "name": "class",
+                "span": {
+                  "start": 37,
+                  "end": 42
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/constantDeref.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/constantDeref.phpt
@@ -607,7 +607,13 @@ $foo::BAR[2][1][0];
                         "end": 125
                       }
                     },
-                    "member": "BAR"
+                    "member": {
+                      "name": "BAR",
+                      "span": {
+                        "start": 127,
+                        "end": 130
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -660,7 +666,13 @@ $foo::BAR[2][1][0];
                                     "end": 139
                                   }
                                 },
-                                "member": "BAR"
+                                "member": {
+                                  "name": "BAR",
+                                  "span": {
+                                    "start": 141,
+                                    "end": 144
+                                  }
+                                }
                               }
                             },
                             "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/namedArgs.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/namedArgs.phpt
@@ -21,7 +21,13 @@ bar(class: 0);
               },
               "args": [
                 {
-                  "name": "a",
+                  "name": {
+                    "name": "a",
+                    "span": {
+                      "start": 10,
+                      "end": 11
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "b"
@@ -39,7 +45,13 @@ bar(class: 0);
                   }
                 },
                 {
-                  "name": "c",
+                  "name": {
+                    "name": "c",
+                    "span": {
+                      "start": 17,
+                      "end": 18
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "d"
@@ -86,7 +98,13 @@ bar(class: 0);
               },
               "args": [
                 {
-                  "name": "class",
+                  "name": {
+                    "name": "class",
+                    "span": {
+                      "start": 29,
+                      "end": 34
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 0

--- a/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/staticCall.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/staticCall.phpt
@@ -33,7 +33,13 @@ $a['b']::c();
                   "end": 34
                 }
               },
-              "method": "b",
+              "method": {
+                "name": "b",
+                "span": {
+                  "start": 36,
+                  "end": 37
+                }
+              },
               "args": []
             }
           },
@@ -112,7 +118,13 @@ $a['b']::c();
                         "end": 54
                       }
                     },
-                    "member": "b"
+                    "member": {
+                      "name": "b",
+                      "span": {
+                        "start": 56,
+                        "end": 58
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -154,7 +166,13 @@ $a['b']::c();
                               "end": 63
                             }
                           },
-                          "member": "b"
+                          "member": {
+                            "name": "b",
+                            "span": {
+                              "start": 65,
+                              "end": 67
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -215,7 +233,13 @@ $a['b']::c();
                                     "end": 77
                                   }
                                 },
-                                "member": "b"
+                                "member": {
+                                  "name": "b",
+                                  "span": {
+                                    "start": 79,
+                                    "end": 81
+                                  }
+                                }
                               }
                             },
                             "span": {
@@ -286,7 +310,13 @@ $a['b']::c();
                         "end": 120
                       }
                     },
-                    "method": "b",
+                    "method": {
+                      "name": "b",
+                      "span": {
+                        "start": 122,
+                        "end": 123
+                      }
+                    },
                     "args": []
                   }
                 },
@@ -331,7 +361,13 @@ $a['b']::c();
                   "end": 164
                 }
               },
-              "method": "b",
+              "method": {
+                "name": "b",
+                "span": {
+                  "start": 166,
+                  "end": 167
+                }
+              },
               "args": []
             }
           },
@@ -360,7 +396,13 @@ $a['b']::c();
                   "end": 173
                 }
               },
-              "method": "b",
+              "method": {
+                "name": "b",
+                "span": {
+                  "start": 175,
+                  "end": 176
+                }
+              },
               "args": []
             }
           },
@@ -397,7 +439,13 @@ $a['b']::c();
                   "end": 185
                 }
               },
-              "method": "b",
+              "method": {
+                "name": "b",
+                "span": {
+                  "start": 188,
+                  "end": 189
+                }
+              },
               "args": []
             }
           },
@@ -445,7 +493,13 @@ $a['b']::c();
                   "end": 200
                 }
               },
-              "method": "c",
+              "method": {
+                "name": "c",
+                "span": {
+                  "start": 202,
+                  "end": 203
+                }
+              },
               "args": []
             }
           },

--- a/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/staticPropertyFetch.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/staticPropertyFetch.phpt
@@ -27,7 +27,13 @@ A::$b['c'];
                   "end": 36
                 }
               },
-              "member": "b"
+              "member": {
+                "name": "b",
+                "span": {
+                  "start": 38,
+                  "end": 40
+                }
+              }
             }
           },
           "span": {
@@ -146,7 +152,13 @@ A::$b['c'];
                         "end": 79
                       }
                     },
-                    "member": "b"
+                    "member": {
+                      "name": "b",
+                      "span": {
+                        "start": 81,
+                        "end": 83
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/firstClassCallables.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/firstClassCallables.phpt
@@ -98,7 +98,13 @@ function foo() {}
                       "end": 34
                     }
                   },
-                  "method": "foo"
+                  "method": {
+                    "name": "foo",
+                    "span": {
+                      "start": 36,
+                      "end": 39
+                    }
+                  }
                 }
               }
             }

--- a/crates/php-parser/tests/fixtures/corpus/expr/match_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/match_3.phpt
@@ -49,7 +49,13 @@ $result = match ($operator) {
                                     "end": 55
                                   }
                                 },
-                                "member": "ADD"
+                                "member": {
+                                  "name": "ADD",
+                                  "span": {
+                                    "start": 57,
+                                    "end": 60
+                                  }
+                                }
                               }
                             },
                             "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/new.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/new.phpt
@@ -207,7 +207,13 @@ new $a->b['c']();
                         "end": 81
                       }
                     },
-                    "member": "b"
+                    "member": {
+                      "name": "b",
+                      "span": {
+                        "start": 83,
+                        "end": 85
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/newDeref.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/newDeref.phpt
@@ -141,7 +141,13 @@ new class {}();
                   "end": 44
                 }
               },
-              "member": "FOO"
+              "member": {
+                "name": "FOO",
+                "span": {
+                  "start": 46,
+                  "end": 49
+                }
+              }
             }
           },
           "span": {
@@ -180,7 +186,13 @@ new class {}();
                   "end": 58
                 }
               },
-              "method": "foo",
+              "method": {
+                "name": "foo",
+                "span": {
+                  "start": 60,
+                  "end": 63
+                }
+              },
               "args": []
             }
           },
@@ -220,7 +232,13 @@ new class {}();
                   "end": 74
                 }
               },
-              "member": "foo"
+              "member": {
+                "name": "foo",
+                "span": {
+                  "start": 76,
+                  "end": 80
+                }
+              }
             }
           },
           "span": {
@@ -473,7 +491,13 @@ new class {}();
                   "end": 158
                 }
               },
-              "member": "FOO"
+              "member": {
+                "name": "FOO",
+                "span": {
+                  "start": 160,
+                  "end": 163
+                }
+              }
             }
           },
           "span": {
@@ -523,7 +547,13 @@ new class {}();
                   "end": 177
                 }
               },
-              "method": "foo",
+              "method": {
+                "name": "foo",
+                "span": {
+                  "start": 179,
+                  "end": 182
+                }
+              },
               "args": []
             }
           },
@@ -574,7 +604,13 @@ new class {}();
                   "end": 198
                 }
               },
-              "member": "foo"
+              "member": {
+                "name": "foo",
+                "span": {
+                  "start": 200,
+                  "end": 204
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/trailingCommas.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/trailingCommas.phpt
@@ -163,7 +163,13 @@ isset($a, $b, );
                   "end": 46
                 }
               },
-              "method": "bar",
+              "method": {
+                "name": "bar",
+                "span": {
+                  "start": 48,
+                  "end": 51
+                }
+              },
               "args": [
                 {
                   "name": null,

--- a/crates/php-parser/tests/fixtures/corpus/expr/uvs/constDeref.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/uvs/constDeref.phpt
@@ -220,7 +220,13 @@ __FUNCIONT__->length();
                         "end": 51
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "name": "B",
+                      "span": {
+                        "start": 53,
+                        "end": 54
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -273,7 +279,13 @@ __FUNCIONT__->length();
                                     "end": 60
                                   }
                                 },
-                                "member": "B"
+                                "member": {
+                                  "name": "B",
+                                  "span": {
+                                    "start": 62,
+                                    "end": 63
+                                  }
+                                }
                               }
                             },
                             "span": {
@@ -352,7 +364,13 @@ __FUNCIONT__->length();
                         "end": 75
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "name": "B",
+                      "span": {
+                        "start": 77,
+                        "end": 78
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -399,7 +417,13 @@ __FUNCIONT__->length();
                         "end": 89
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "name": "B",
+                      "span": {
+                        "start": 91,
+                        "end": 92
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -447,7 +471,13 @@ __FUNCIONT__->length();
                         "end": 105
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "name": "B",
+                      "span": {
+                        "start": 107,
+                        "end": 108
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -455,7 +485,13 @@ __FUNCIONT__->length();
                   "end": 108
                 }
               },
-              "member": "C"
+              "member": {
+                "name": "C",
+                "span": {
+                  "start": 110,
+                  "end": 111
+                }
+              }
             }
           },
           "span": {
@@ -486,7 +522,13 @@ __FUNCIONT__->length();
                         "end": 114
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "name": "B",
+                      "span": {
+                        "start": 116,
+                        "end": 117
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -494,7 +536,13 @@ __FUNCIONT__->length();
                   "end": 117
                 }
               },
-              "member": "c"
+              "member": {
+                "name": "c",
+                "span": {
+                  "start": 119,
+                  "end": 121
+                }
+              }
             }
           },
           "span": {
@@ -525,7 +573,13 @@ __FUNCIONT__->length();
                         "end": 124
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "name": "B",
+                      "span": {
+                        "start": 126,
+                        "end": 127
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -533,7 +587,13 @@ __FUNCIONT__->length();
                   "end": 127
                 }
               },
-              "method": "c",
+              "method": {
+                "name": "c",
+                "span": {
+                  "start": 129,
+                  "end": 130
+                }
+              },
               "args": []
             }
           },

--- a/crates/php-parser/tests/fixtures/corpus/expr/uvs/new.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/uvs/new.phpt
@@ -156,7 +156,13 @@ new $weird[0]->foo::$className;
                   "end": 76
                 }
               },
-              "member": "className"
+              "member": {
+                "name": "className",
+                "span": {
+                  "start": 78,
+                  "end": 88
+                }
+              }
             }
           },
           "span": {
@@ -195,7 +201,13 @@ new $weird[0]->foo::$className;
                   "end": 99
                 }
               },
-              "member": "className"
+              "member": {
+                "name": "className",
+                "span": {
+                  "start": 101,
+                  "end": 111
+                }
+              }
             }
           },
           "span": {
@@ -272,7 +284,13 @@ new $weird[0]->foo::$className;
                   "end": 131
                 }
               },
-              "member": "className"
+              "member": {
+                "name": "className",
+                "span": {
+                  "start": 133,
+                  "end": 143
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/uvs/staticProperty.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/uvs/staticProperty.phpt
@@ -25,7 +25,13 @@ A::$A::$b;
                   "end": 7
                 }
               },
-              "member": "b"
+              "member": {
+                "name": "b",
+                "span": {
+                  "start": 9,
+                  "end": 11
+                }
+              }
             }
           },
           "span": {
@@ -53,7 +59,13 @@ A::$A::$b;
                   "end": 15
                 }
               },
-              "member": "b"
+              "member": {
+                "name": "b",
+                "span": {
+                  "start": 17,
+                  "end": 19
+                }
+              }
             }
           },
           "span": {
@@ -81,7 +93,13 @@ A::$A::$b;
                   "end": 24
                 }
               },
-              "member": "b"
+              "member": {
+                "name": "b",
+                "span": {
+                  "start": 26,
+                  "end": 28
+                }
+              }
             }
           },
           "span": {
@@ -137,7 +155,13 @@ A::$A::$b;
                   "end": 40
                 }
               },
-              "member": "b"
+              "member": {
+                "name": "b",
+                "span": {
+                  "start": 42,
+                  "end": 44
+                }
+              }
             }
           },
           "span": {
@@ -184,7 +208,13 @@ A::$A::$b;
                   "end": 52
                 }
               },
-              "member": "b"
+              "member": {
+                "name": "b",
+                "span": {
+                  "start": 54,
+                  "end": 56
+                }
+              }
             }
           },
           "span": {
@@ -322,7 +352,13 @@ A::$A::$b;
                         "end": 78
                       }
                     },
-                    "member": "A"
+                    "member": {
+                      "name": "A",
+                      "span": {
+                        "start": 80,
+                        "end": 82
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -330,7 +366,13 @@ A::$A::$b;
                   "end": 82
                 }
               },
-              "member": "b"
+              "member": {
+                "name": "b",
+                "span": {
+                  "start": 84,
+                  "end": 86
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/corpus/semiReserved.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/semiReserved.phpt
@@ -546,7 +546,13 @@ class Foo {
                   "end": 441
                 }
               },
-              "method": "list",
+              "method": {
+                "name": "list",
+                "span": {
+                  "start": 443,
+                  "end": 447
+                }
+              },
               "args": []
             }
           },
@@ -575,7 +581,13 @@ class Foo {
                   "end": 455
                 }
               },
-              "method": "protected",
+              "method": {
+                "name": "protected",
+                "span": {
+                  "start": 457,
+                  "end": 466
+                }
+              },
               "args": []
             }
           },
@@ -676,7 +688,13 @@ class Foo {
                   "end": 500
                 }
               },
-              "member": "TRAIT"
+              "member": {
+                "name": "TRAIT",
+                "span": {
+                  "start": 502,
+                  "end": 507
+                }
+              }
             }
           },
           "span": {
@@ -704,7 +722,13 @@ class Foo {
                   "end": 513
                 }
               },
-              "member": "FINAL"
+              "member": {
+                "name": "FINAL",
+                "span": {
+                  "start": 515,
+                  "end": 520
+                }
+              }
             }
           },
           "span": {
@@ -769,7 +793,13 @@ class Foo {
                               "end": 574
                             }
                           },
-                          "method": "catch",
+                          "method": {
+                            "name": "catch",
+                            "span": {
+                              "start": 576,
+                              "end": 581
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [
@@ -802,9 +832,21 @@ class Foo {
                               "end": 624
                             }
                           },
-                          "method": "list",
+                          "method": {
+                            "name": "list",
+                            "span": {
+                              "start": 626,
+                              "end": 630
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "foreach"
+                          "new_name": {
+                            "name": "foreach",
+                            "span": {
+                              "start": 634,
+                              "end": 641
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -825,9 +867,21 @@ class Foo {
                               "end": 657
                             }
                           },
-                          "method": "throw",
+                          "method": {
+                            "name": "throw",
+                            "span": {
+                              "start": 659,
+                              "end": 664
+                            }
+                          },
                           "new_modifier": "Protected",
-                          "new_name": "public"
+                          "new_name": {
+                            "name": "public",
+                            "span": {
+                              "start": 678,
+                              "end": 684
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -848,7 +902,13 @@ class Foo {
                               "end": 700
                             }
                           },
-                          "method": "self",
+                          "method": {
+                            "name": "self",
+                            "span": {
+                              "start": 702,
+                              "end": 706
+                            }
+                          },
                           "new_modifier": "Protected",
                           "new_name": null
                         }
@@ -862,9 +922,21 @@ class Foo {
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "exit",
+                          "method": {
+                            "name": "exit",
+                            "span": {
+                              "start": 729,
+                              "end": 733
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "die"
+                          "new_name": {
+                            "name": "die",
+                            "span": {
+                              "start": 737,
+                              "end": 740
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -885,9 +957,21 @@ class Foo {
                               "end": 757
                             }
                           },
-                          "method": "exit",
+                          "method": {
+                            "name": "exit",
+                            "span": {
+                              "start": 759,
+                              "end": 763
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "bye"
+                          "new_name": {
+                            "name": "bye",
+                            "span": {
+                              "start": 767,
+                              "end": 770
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -908,9 +992,21 @@ class Foo {
                               "end": 796
                             }
                           },
-                          "method": "exit",
+                          "method": {
+                            "name": "exit",
+                            "span": {
+                              "start": 798,
+                              "end": 802
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "byebye"
+                          "new_name": {
+                            "name": "byebye",
+                            "span": {
+                              "start": 806,
+                              "end": 812
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -931,7 +1027,13 @@ class Foo {
                               "end": 828
                             }
                           },
-                          "method": "catch",
+                          "method": {
+                            "name": "catch",
+                            "span": {
+                              "start": 899,
+                              "end": 904
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/attributes.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/attributes.phpt
@@ -124,7 +124,13 @@ $b = #[A13] static fn() => 0;
               },
               "args": [
                 {
-                  "name": "x",
+                  "name": {
+                    "name": "x",
+                    "span": {
+                      "start": 46,
+                      "end": 47
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/shortEchoAsIdentifier.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/shortEchoAsIdentifier.phpt
@@ -49,9 +49,21 @@ expected '::' or 'as', found ';'
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "x",
+                          "method": {
+                            "name": "x",
+                            "span": {
+                              "start": 36,
+                              "end": 37
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "y"
+                          "new_name": {
+                            "name": "y",
+                            "span": {
+                              "start": 41,
+                              "end": 42
+                            }
+                          }
                         }
                       },
                       "span": {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/trait.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/trait.phpt
@@ -111,9 +111,21 @@ class B {
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "a",
+                          "method": {
+                            "name": "a",
+                            "span": {
+                              "start": 88,
+                              "end": 89
+                            }
+                          },
                           "new_modifier": "Protected",
-                          "new_name": "b"
+                          "new_name": {
+                            "name": "b",
+                            "span": {
+                              "start": 103,
+                              "end": 104
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -125,9 +137,21 @@ class B {
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "c",
+                          "method": {
+                            "name": "c",
+                            "span": {
+                              "start": 114,
+                              "end": 115
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "d"
+                          "new_name": {
+                            "name": "d",
+                            "span": {
+                              "start": 119,
+                              "end": 120
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -139,7 +163,13 @@ class B {
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "e",
+                          "method": {
+                            "name": "e",
+                            "span": {
+                              "start": 130,
+                              "end": 131
+                            }
+                          },
                           "new_modifier": "Private",
                           "new_name": null
                         }
@@ -206,7 +236,13 @@ class B {
                               "end": 177
                             }
                           },
-                          "method": "a",
+                          "method": {
+                            "name": "a",
+                            "span": {
+                              "start": 179,
+                              "end": 180
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [
@@ -249,9 +285,21 @@ class B {
                               "end": 206
                             }
                           },
-                          "method": "b",
+                          "method": {
+                            "name": "b",
+                            "span": {
+                              "start": 208,
+                              "end": 209
+                            }
+                          },
                           "new_modifier": "Protected",
-                          "new_name": "c"
+                          "new_name": {
+                            "name": "c",
+                            "span": {
+                              "start": 223,
+                              "end": 224
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -272,9 +320,21 @@ class B {
                               "end": 235
                             }
                           },
-                          "method": "d",
+                          "method": {
+                            "name": "d",
+                            "span": {
+                              "start": 237,
+                              "end": 238
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "e"
+                          "new_name": {
+                            "name": "e",
+                            "span": {
+                              "start": 242,
+                              "end": 243
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -295,7 +355,13 @@ class B {
                               "end": 254
                             }
                           },
-                          "method": "f",
+                          "method": {
+                            "name": "f",
+                            "span": {
+                              "start": 256,
+                              "end": 257
+                            }
+                          },
                           "new_modifier": "Private",
                           "new_name": null
                         }

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/clone_function.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/clone_function.phpt
@@ -442,7 +442,13 @@ cannot use positional argument after named argument
               },
               "args": [
                 {
-                  "name": "object",
+                  "name": {
+                    "name": "object",
+                    "span": {
+                      "start": 235,
+                      "end": 241
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"
@@ -460,7 +466,13 @@ cannot use positional argument after named argument
                   }
                 },
                 {
-                  "name": "withProperties",
+                  "name": {
+                    "name": "withProperties",
+                    "span": {
+                      "start": 247,
+                      "end": 261
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Array": [
@@ -576,7 +588,13 @@ cannot use positional argument after named argument
                   }
                 },
                 {
-                  "name": "withProperties",
+                  "name": {
+                    "name": "withProperties",
+                    "span": {
+                      "start": 308,
+                      "end": 322
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Array": [
@@ -674,7 +692,13 @@ cannot use positional argument after named argument
               },
               "args": [
                 {
-                  "name": "object",
+                  "name": {
+                    "name": "object",
+                    "span": {
+                      "start": 365,
+                      "end": 371
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"
@@ -721,7 +745,13 @@ cannot use positional argument after named argument
               },
               "args": [
                 {
-                  "name": "object",
+                  "name": {
+                    "name": "object",
+                    "span": {
+                      "start": 384,
+                      "end": 390
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/defaultValues.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/defaultValues.phpt
@@ -81,7 +81,13 @@ function a(
                         "end": 60
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "name": "B",
+                      "span": {
+                        "start": 62,
+                        "end": 63
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/enum_multiple_interfaces_const_method.phpt
+++ b/crates/php-parser/tests/fixtures/enum_multiple_interfaces_const_method.phpt
@@ -115,7 +115,13 @@ enum Status: string implements Loggable, Serializable {
                             "end": 147
                           }
                         },
-                        "member": "Active"
+                        "member": {
+                          "name": "Active",
+                          "span": {
+                            "start": 149,
+                            "end": 155
+                          }
+                        }
                       }
                     },
                     "span": {
@@ -261,7 +267,13 @@ enum Status: string implements Loggable, Serializable {
                                         "end": 300
                                       }
                                     },
-                                    "member": "Active"
+                                    "member": {
+                                      "name": "Active",
+                                      "span": {
+                                        "start": 302,
+                                        "end": 308
+                                      }
+                                    }
                                   }
                                 },
                                 "span": {

--- a/crates/php-parser/tests/fixtures/enum_with_methods.phpt
+++ b/crates/php-parser/tests/fixtures/enum_with_methods.phpt
@@ -211,7 +211,13 @@ enum Suit: string implements HasColor {
                                               "end": 247
                                             }
                                           },
-                                          "member": "Hearts"
+                                          "member": {
+                                            "name": "Hearts",
+                                            "span": {
+                                              "start": 249,
+                                              "end": 255
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {
@@ -231,7 +237,13 @@ enum Suit: string implements HasColor {
                                               "end": 261
                                             }
                                           },
-                                          "member": "Diamonds"
+                                          "member": {
+                                            "name": "Diamonds",
+                                            "span": {
+                                              "start": 263,
+                                              "end": 271
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {
@@ -268,7 +280,13 @@ enum Suit: string implements HasColor {
                                               "end": 298
                                             }
                                           },
-                                          "member": "Clubs"
+                                          "member": {
+                                            "name": "Clubs",
+                                            "span": {
+                                              "start": 300,
+                                              "end": 305
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {
@@ -288,7 +306,13 @@ enum Suit: string implements HasColor {
                                               "end": 311
                                             }
                                           },
-                                          "member": "Spades"
+                                          "member": {
+                                            "name": "Spades",
+                                            "span": {
+                                              "start": 313,
+                                              "end": 319
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {

--- a/crates/php-parser/tests/fixtures/errors/enum_error_then_valid_function.phpt
+++ b/crates/php-parser/tests/fixtures/errors/enum_error_then_valid_function.phpt
@@ -60,7 +60,13 @@ expected expression
                           "end": 75
                         }
                       },
-                      "member": "Active"
+                      "member": {
+                        "name": "Active",
+                        "span": {
+                          "start": 77,
+                          "end": 83
+                        }
+                      }
                     }
                   },
                   "span": {

--- a/crates/php-parser/tests/fixtures/errors/named_arg_positional_after_named.phpt
+++ b/crates/php-parser/tests/fixtures/errors/named_arg_positional_after_named.phpt
@@ -21,7 +21,13 @@ cannot use positional argument after named argument
               },
               "args": [
                 {
-                  "name": "a",
+                  "name": {
+                    "name": "a",
+                    "span": {
+                      "start": 11,
+                      "end": 12
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1

--- a/crates/php-parser/tests/fixtures/errors/named_arg_spread_after_named.phpt
+++ b/crates/php-parser/tests/fixtures/errors/named_arg_spread_after_named.phpt
@@ -21,7 +21,13 @@ cannot use positional argument after named argument
               },
               "args": [
                 {
-                  "name": "a",
+                  "name": {
+                    "name": "a",
+                    "span": {
+                      "start": 11,
+                      "end": 12
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1

--- a/crates/php-parser/tests/fixtures/errors/trait_unclosed_brace.phpt
+++ b/crates/php-parser/tests/fixtures/errors/trait_unclosed_brace.phpt
@@ -50,9 +50,21 @@ expected '}', found end of file
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "m",
+                          "method": {
+                            "name": "m",
+                            "span": {
+                              "start": 35,
+                              "end": 36
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "x"
+                          "new_name": {
+                            "name": "x",
+                            "span": {
+                              "start": 40,
+                              "end": 41
+                            }
+                          }
                         }
                       },
                       "span": {

--- a/crates/php-parser/tests/fixtures/first_class_callable.phpt
+++ b/crates/php-parser/tests/fixtures/first_class_callable.phpt
@@ -144,7 +144,13 @@ $fn = Foo::bar(...);
                             "end": 59
                           }
                         },
-                        "method": "bar"
+                        "method": {
+                          "name": "bar",
+                          "span": {
+                            "start": 61,
+                            "end": 64
+                          }
+                        }
                       }
                     }
                   }

--- a/crates/php-parser/tests/fixtures/first_class_callable_variants.phpt
+++ b/crates/php-parser/tests/fixtures/first_class_callable_variants.phpt
@@ -145,7 +145,13 @@ $e = $obj->$dynamic(...);
                             "end": 56
                           }
                         },
-                        "method": "bar"
+                        "method": {
+                          "name": "bar",
+                          "span": {
+                            "start": 58,
+                            "end": 61
+                          }
+                        }
                       }
                     }
                   }

--- a/crates/php-parser/tests/fixtures/fully_qualified_names.phpt
+++ b/crates/php-parser/tests/fixtures/fully_qualified_names.phpt
@@ -87,7 +87,13 @@ $x = \strlen('hello');
                   "end": 56
                 }
               },
-              "method": "log",
+              "method": {
+                "name": "log",
+                "span": {
+                  "start": 58,
+                  "end": 61
+                }
+              },
               "args": [
                 {
                   "name": null,

--- a/crates/php-parser/tests/fixtures/isset_complex.phpt
+++ b/crates/php-parser/tests/fixtures/isset_complex.phpt
@@ -76,7 +76,13 @@
                         "end": 35
                       }
                     },
-                    "member": "static"
+                    "member": {
+                      "name": "static",
+                      "span": {
+                        "start": 37,
+                        "end": 44
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/mixed_named_positional_args.phpt
+++ b/crates/php-parser/tests/fixtures/mixed_named_positional_args.phpt
@@ -55,7 +55,13 @@
                   }
                 },
                 {
-                  "name": "name",
+                  "name": {
+                    "name": "name",
+                    "span": {
+                      "start": 20,
+                      "end": 24
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "val"
@@ -73,7 +79,13 @@
                   }
                 },
                 {
-                  "name": "count",
+                  "name": {
+                    "name": "count",
+                    "span": {
+                      "start": 32,
+                      "end": 37
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 5

--- a/crates/php-parser/tests/fixtures/named_args_duplicate.phpt
+++ b/crates/php-parser/tests/fixtures/named_args_duplicate.phpt
@@ -19,7 +19,13 @@
               },
               "args": [
                 {
-                  "name": "a",
+                  "name": {
+                    "name": "a",
+                    "span": {
+                      "start": 11,
+                      "end": 12
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1
@@ -37,7 +43,13 @@
                   }
                 },
                 {
-                  "name": "a",
+                  "name": {
+                    "name": "a",
+                    "span": {
+                      "start": 17,
+                      "end": 18
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 2

--- a/crates/php-parser/tests/fixtures/named_args_edge_cases.phpt
+++ b/crates/php-parser/tests/fixtures/named_args_edge_cases.phpt
@@ -23,7 +23,13 @@ array_map(callback: fn($x) => $x * 2, array: $arr);
               },
               "args": [
                 {
-                  "name": "a",
+                  "name": {
+                    "name": "a",
+                    "span": {
+                      "start": 10,
+                      "end": 11
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1
@@ -41,7 +47,13 @@ array_map(callback: fn($x) => $x * 2, array: $arr);
                   }
                 },
                 {
-                  "name": "b",
+                  "name": {
+                    "name": "b",
+                    "span": {
+                      "start": 16,
+                      "end": 17
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 2
@@ -59,7 +71,13 @@ array_map(callback: fn($x) => $x * 2, array: $arr);
                   }
                 },
                 {
-                  "name": "c",
+                  "name": {
+                    "name": "c",
+                    "span": {
+                      "start": 22,
+                      "end": 23
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 3
@@ -124,7 +142,13 @@ array_map(callback: fn($x) => $x * 2, array: $arr);
                   }
                 },
                 {
-                  "name": "extra",
+                  "name": {
+                    "name": "extra",
+                    "span": {
+                      "start": 43,
+                      "end": 48
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Bool": true
@@ -207,7 +231,13 @@ array_map(callback: fn($x) => $x * 2, array: $arr);
                   }
                 },
                 {
-                  "name": "name",
+                  "name": {
+                    "name": "name",
+                    "span": {
+                      "start": 67,
+                      "end": 71
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "test"
@@ -254,7 +284,13 @@ array_map(callback: fn($x) => $x * 2, array: $arr);
               },
               "args": [
                 {
-                  "name": "callback",
+                  "name": {
+                    "name": "callback",
+                    "span": {
+                      "start": 92,
+                      "end": 100
+                    }
+                  },
                   "value": {
                     "kind": {
                       "ArrowFunction": {
@@ -324,7 +360,13 @@ array_map(callback: fn($x) => $x * 2, array: $arr);
                   }
                 },
                 {
-                  "name": "array",
+                  "name": {
+                    "name": "array",
+                    "span": {
+                      "start": 120,
+                      "end": 125
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "arr"

--- a/crates/php-parser/tests/fixtures/named_args_keywords.phpt
+++ b/crates/php-parser/tests/fixtures/named_args_keywords.phpt
@@ -21,7 +21,13 @@ foo(class: 'MyClass', static: true, match: 'yes');
               },
               "args": [
                 {
-                  "name": "array",
+                  "name": {
+                    "name": "array",
+                    "span": {
+                      "start": 18,
+                      "end": 23
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "arr"
@@ -39,7 +45,13 @@ foo(class: 'MyClass', static: true, match: 'yes');
                   }
                 },
                 {
-                  "name": "offset",
+                  "name": {
+                    "name": "offset",
+                    "span": {
+                      "start": 31,
+                      "end": 37
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1
@@ -57,7 +69,13 @@ foo(class: 'MyClass', static: true, match: 'yes');
                   }
                 },
                 {
-                  "name": "length",
+                  "name": {
+                    "name": "length",
+                    "span": {
+                      "start": 42,
+                      "end": 48
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 2
@@ -104,7 +122,13 @@ foo(class: 'MyClass', static: true, match: 'yes');
               },
               "args": [
                 {
-                  "name": "class",
+                  "name": {
+                    "name": "class",
+                    "span": {
+                      "start": 58,
+                      "end": 63
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "MyClass"
@@ -122,7 +146,13 @@ foo(class: 'MyClass', static: true, match: 'yes');
                   }
                 },
                 {
-                  "name": "static",
+                  "name": {
+                    "name": "static",
+                    "span": {
+                      "start": 76,
+                      "end": 82
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Bool": true
@@ -140,7 +170,13 @@ foo(class: 'MyClass', static: true, match: 'yes');
                   }
                 },
                 {
-                  "name": "match",
+                  "name": {
+                    "name": "match",
+                    "span": {
+                      "start": 90,
+                      "end": 95
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "yes"

--- a/crates/php-parser/tests/fixtures/named_args_mixed_with_spread.phpt
+++ b/crates/php-parser/tests/fixtures/named_args_mixed_with_spread.phpt
@@ -21,7 +21,13 @@ cannot use positional argument after named argument
               },
               "args": [
                 {
-                  "name": "a",
+                  "name": {
+                    "name": "a",
+                    "span": {
+                      "start": 11,
+                      "end": 12
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1

--- a/crates/php-parser/tests/fixtures/named_arguments.phpt
+++ b/crates/php-parser/tests/fixtures/named_arguments.phpt
@@ -19,7 +19,13 @@
               },
               "args": [
                 {
-                  "name": "string",
+                  "name": {
+                    "name": "string",
+                    "span": {
+                      "start": 23,
+                      "end": 29
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "str"
@@ -37,7 +43,13 @@
                   }
                 },
                 {
-                  "name": "flags",
+                  "name": {
+                    "name": "flags",
+                    "span": {
+                      "start": 37,
+                      "end": 42
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Identifier": "ENT_QUOTES"
@@ -55,7 +67,13 @@
                   }
                 },
                 {
-                  "name": "encoding",
+                  "name": {
+                    "name": "encoding",
+                    "span": {
+                      "start": 56,
+                      "end": 64
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "UTF-8"

--- a/crates/php-parser/tests/fixtures/new_in_complex_initializers.phpt
+++ b/crates/php-parser/tests/fixtures/new_in_complex_initializers.phpt
@@ -140,7 +140,13 @@ class Config {
                     },
                     "args": [
                       {
-                        "name": "name",
+                        "name": {
+                          "name": "name",
+                          "span": {
+                            "start": 86,
+                            "end": 90
+                          }
+                        },
                         "value": {
                           "kind": {
                             "String": "x"
@@ -220,7 +226,13 @@ class Config {
                         },
                         "args": [
                           {
-                            "name": "debug",
+                            "name": {
+                              "name": "debug",
+                              "span": {
+                                "start": 151,
+                                "end": 156
+                              }
+                            },
                             "value": {
                               "kind": {
                                 "Bool": false

--- a/crates/php-parser/tests/fixtures/realistic_controller.phpt
+++ b/crates/php-parser/tests/fixtures/realistic_controller.phpt
@@ -410,7 +410,13 @@ class UserController extends BaseController implements JsonResponder
                                                       "end": 384
                                                     }
                                                   },
-                                                  "method": "find",
+                                                  "method": {
+                                                    "name": "find",
+                                                    "span": {
+                                                      "start": 386,
+                                                      "end": 390
+                                                    }
+                                                  },
                                                   "args": [
                                                     {
                                                       "name": null,
@@ -1045,7 +1051,13 @@ class UserController extends BaseController implements JsonResponder
                                         "end": 1027
                                       }
                                     },
-                                    "method": "all",
+                                    "method": {
+                                      "name": "all",
+                                      "span": {
+                                        "start": 1029,
+                                        "end": 1032
+                                      }
+                                    },
                                     "args": []
                                   }
                                 },

--- a/crates/php-parser/tests/fixtures/realistic_enum_service.phpt
+++ b/crates/php-parser/tests/fixtures/realistic_enum_service.phpt
@@ -229,7 +229,13 @@ class TaskService
                                               "end": 224
                                             }
                                           },
-                                          "member": "Low"
+                                          "member": {
+                                            "name": "Low",
+                                            "span": {
+                                              "start": 226,
+                                              "end": 229
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {
@@ -266,7 +272,13 @@ class TaskService
                                               "end": 269
                                             }
                                           },
-                                          "member": "Medium"
+                                          "member": {
+                                            "name": "Medium",
+                                            "span": {
+                                              "start": 271,
+                                              "end": 277
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {
@@ -303,7 +315,13 @@ class TaskService
                                               "end": 320
                                             }
                                           },
-                                          "member": "High"
+                                          "member": {
+                                            "name": "High",
+                                            "span": {
+                                              "start": 322,
+                                              "end": 326
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {
@@ -340,7 +358,13 @@ class TaskService
                                               "end": 367
                                             }
                                           },
-                                          "member": "Critical"
+                                          "member": {
+                                            "name": "Critical",
+                                            "span": {
+                                              "start": 369,
+                                              "end": 377
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {
@@ -487,7 +511,13 @@ class TaskService
                                   "end": 533
                                 }
                               },
-                              "member": "Critical"
+                              "member": {
+                                "name": "Critical",
+                                "span": {
+                                  "start": 535,
+                                  "end": 543
+                                }
+                              }
                             }
                           },
                           "span": {
@@ -687,7 +717,13 @@ class TaskService
                                         "end": 706
                                       }
                                     },
-                                    "member": "counter"
+                                    "member": {
+                                      "name": "counter",
+                                      "span": {
+                                        "start": 708,
+                                        "end": 716
+                                      }
+                                    }
                                   }
                                 },
                                 "span": {
@@ -736,7 +772,13 @@ class TaskService
                                         "end": 738
                                       }
                                     },
-                                    "member": "counter"
+                                    "member": {
+                                      "name": "counter",
+                                      "span": {
+                                        "start": 740,
+                                        "end": 748
+                                      }
+                                    }
                                   }
                                 },
                                 "span": {
@@ -1156,7 +1198,13 @@ class TaskService
                                                       "end": 1044
                                                     }
                                                   },
-                                                  "member": "Critical"
+                                                  "member": {
+                                                    "name": "Critical",
+                                                    "span": {
+                                                      "start": 1046,
+                                                      "end": 1054
+                                                    }
+                                                  }
                                                 }
                                               },
                                               "span": {
@@ -1197,7 +1245,13 @@ class TaskService
                                                       "end": 1080
                                                     }
                                                   },
-                                                  "member": "High"
+                                                  "member": {
+                                                    "name": "High",
+                                                    "span": {
+                                                      "start": 1082,
+                                                      "end": 1086
+                                                    }
+                                                  }
                                                 }
                                               },
                                               "span": {

--- a/crates/php-parser/tests/fixtures/realistic_middleware.phpt
+++ b/crates/php-parser/tests/fixtures/realistic_middleware.phpt
@@ -733,7 +733,13 @@ class RateLimitMiddleware implements MiddlewareInterface
                                     "end": 642
                                   }
                                 },
-                                "member": "excludedPaths"
+                                "member": {
+                                  "name": "excludedPaths",
+                                  "span": {
+                                    "start": 644,
+                                    "end": 658
+                                  }
+                                }
                               }
                             },
                             "span": {
@@ -2005,7 +2011,13 @@ class RateLimitMiddleware implements MiddlewareInterface
                                         "end": 1643
                                       }
                                     },
-                                    "member": "excludedPaths"
+                                    "member": {
+                                      "name": "excludedPaths",
+                                      "span": {
+                                        "start": 1645,
+                                        "end": 1659
+                                      }
+                                    }
                                   }
                                 },
                                 "span": {
@@ -2031,7 +2043,13 @@ class RateLimitMiddleware implements MiddlewareInterface
                                                 "end": 1670
                                               }
                                             },
-                                            "member": "excludedPaths"
+                                            "member": {
+                                              "name": "excludedPaths",
+                                              "span": {
+                                                "start": 1672,
+                                                "end": 1686
+                                              }
+                                            }
                                           }
                                         },
                                         "span": {
@@ -2483,7 +2501,13 @@ class RateLimitMiddleware implements MiddlewareInterface
                                               "end": 2052
                                             }
                                           },
-                                          "member": "MAX_REQUESTS"
+                                          "member": {
+                                            "name": "MAX_REQUESTS",
+                                            "span": {
+                                              "start": 2054,
+                                              "end": 2066
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {

--- a/crates/php-parser/tests/fixtures/realistic_repository.phpt
+++ b/crates/php-parser/tests/fixtures/realistic_repository.phpt
@@ -1284,7 +1284,13 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                               },
                               "args": [
                                 {
-                                  "name": "id",
+                                  "name": {
+                                    "name": "id",
+                                    "span": {
+                                      "start": 1138,
+                                      "end": 1140
+                                    }
+                                  },
                                   "value": {
                                     "kind": {
                                       "Cast": [
@@ -1332,7 +1338,13 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                                   }
                                 },
                                 {
-                                  "name": "name",
+                                  "name": {
+                                    "name": "name",
+                                    "span": {
+                                      "start": 1171,
+                                      "end": 1175
+                                    }
+                                  },
                                   "value": {
                                     "kind": {
                                       "ArrayAccess": {
@@ -1369,7 +1381,13 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                                   }
                                 },
                                 {
-                                  "name": "email",
+                                  "name": {
+                                    "name": "email",
+                                    "span": {
+                                      "start": 1203,
+                                      "end": 1208
+                                    }
+                                  },
                                   "value": {
                                     "kind": {
                                       "NullCoalesce": {
@@ -1533,7 +1551,13 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                                         "end": 1310
                                       }
                                     },
-                                    "member": "queryCount"
+                                    "member": {
+                                      "name": "queryCount",
+                                      "span": {
+                                        "start": 1312,
+                                        "end": 1323
+                                      }
+                                    }
                                   }
                                 },
                                 "span": {
@@ -1835,7 +1859,13 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                                         "end": 1525
                                       }
                                     },
-                                    "member": "queryCount"
+                                    "member": {
+                                      "name": "queryCount",
+                                      "span": {
+                                        "start": 1527,
+                                        "end": 1538
+                                      }
+                                    }
                                   }
                                 },
                                 "span": {
@@ -3430,7 +3460,13 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                                   "end": 2694
                                 }
                               },
-                              "member": "queryCount"
+                              "member": {
+                                "name": "queryCount",
+                                "span": {
+                                  "start": 2696,
+                                  "end": 2707
+                                }
+                              }
                             }
                           },
                           "span": {

--- a/crates/php-parser/tests/fixtures/spread_then_named_arg.phpt
+++ b/crates/php-parser/tests/fixtures/spread_then_named_arg.phpt
@@ -37,7 +37,13 @@
                   }
                 },
                 {
-                  "name": "last",
+                  "name": {
+                    "name": "last",
+                    "span": {
+                      "start": 21,
+                      "end": 25
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "end"

--- a/crates/php-parser/tests/fixtures/static_access.phpt
+++ b/crates/php-parser/tests/fixtures/static_access.phpt
@@ -23,7 +23,13 @@ static::factory();
                   "end": 9
                 }
               },
-              "member": "BAR"
+              "member": {
+                "name": "BAR",
+                "span": {
+                  "start": 11,
+                  "end": 14
+                }
+              }
             }
           },
           "span": {
@@ -51,7 +57,13 @@ static::factory();
                   "end": 19
                 }
               },
-              "member": "instance"
+              "member": {
+                "name": "instance",
+                "span": {
+                  "start": 21,
+                  "end": 30
+                }
+              }
             }
           },
           "span": {
@@ -79,7 +91,13 @@ static::factory();
                   "end": 35
                 }
               },
-              "method": "create",
+              "method": {
+                "name": "create",
+                "span": {
+                  "start": 37,
+                  "end": 43
+                }
+              },
               "args": []
             }
           },
@@ -108,7 +126,13 @@ static::factory();
                   "end": 51
                 }
               },
-              "member": "x"
+              "member": {
+                "name": "x",
+                "span": {
+                  "start": 53,
+                  "end": 55
+                }
+              }
             }
           },
           "span": {
@@ -136,7 +160,13 @@ static::factory();
                   "end": 63
                 }
               },
-              "method": "__construct",
+              "method": {
+                "name": "__construct",
+                "span": {
+                  "start": 65,
+                  "end": 76
+                }
+              },
               "args": []
             }
           },
@@ -165,7 +195,13 @@ static::factory();
                   "end": 86
                 }
               },
-              "method": "factory",
+              "method": {
+                "name": "factory",
+                "span": {
+                  "start": 88,
+                  "end": 95
+                }
+              },
               "args": []
             }
           },

--- a/crates/php-parser/tests/fixtures/static_double_colon_as_stmt.phpt
+++ b/crates/php-parser/tests/fixtures/static_double_colon_as_stmt.phpt
@@ -20,7 +20,13 @@ static::class;
                   "end": 12
                 }
               },
-              "member": "prop"
+              "member": {
+                "name": "prop",
+                "span": {
+                  "start": 14,
+                  "end": 19
+                }
+              }
             }
           },
           "span": {
@@ -48,7 +54,13 @@ static::class;
                   "end": 27
                 }
               },
-              "method": "method",
+              "method": {
+                "name": "method",
+                "span": {
+                  "start": 29,
+                  "end": 35
+                }
+              },
               "args": []
             }
           },
@@ -77,7 +89,13 @@ static::class;
                   "end": 45
                 }
               },
-              "member": "class"
+              "member": {
+                "name": "class",
+                "span": {
+                  "start": 47,
+                  "end": 52
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/static_method_callable_and_access.phpt
+++ b/crates/php-parser/tests/fixtures/static_method_callable_and_access.phpt
@@ -38,7 +38,13 @@ $f = self::$prop;
                             "end": 14
                           }
                         },
-                        "method": "bar"
+                        "method": {
+                          "name": "bar",
+                          "span": {
+                            "start": 16,
+                            "end": 19
+                          }
+                        }
                       }
                     }
                   }
@@ -88,7 +94,13 @@ $f = self::$prop;
                         "end": 34
                       }
                     },
-                    "member": "prop"
+                    "member": {
+                      "name": "prop",
+                      "span": {
+                        "start": 36,
+                        "end": 41
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -136,7 +148,13 @@ $f = self::$prop;
                         "end": 51
                       }
                     },
-                    "member": "CONST"
+                    "member": {
+                      "name": "CONST",
+                      "span": {
+                        "start": 53,
+                        "end": 58
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -184,7 +202,13 @@ $f = self::$prop;
                         "end": 71
                       }
                     },
-                    "method": "method",
+                    "method": {
+                      "name": "method",
+                      "span": {
+                        "start": 73,
+                        "end": 79
+                      }
+                    },
                     "args": []
                   }
                 },
@@ -233,7 +257,13 @@ $f = self::$prop;
                         "end": 94
                       }
                     },
-                    "method": "method",
+                    "method": {
+                      "name": "method",
+                      "span": {
+                        "start": 96,
+                        "end": 102
+                      }
+                    },
                     "args": []
                   }
                 },
@@ -282,7 +312,13 @@ $f = self::$prop;
                         "end": 115
                       }
                     },
-                    "member": "prop"
+                    "member": {
+                      "name": "prop",
+                      "span": {
+                        "start": 117,
+                        "end": 122
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/trait_conflict_resolution.phpt
+++ b/crates/php-parser/tests/fixtures/trait_conflict_resolution.phpt
@@ -64,7 +64,13 @@ class MyClass {
                               "end": 46
                             }
                           },
-                          "method": "foo",
+                          "method": {
+                            "name": "foo",
+                            "span": {
+                              "start": 48,
+                              "end": 51
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [
@@ -97,9 +103,21 @@ class MyClass {
                               "end": 74
                             }
                           },
-                          "method": "foo",
+                          "method": {
+                            "name": "foo",
+                            "span": {
+                              "start": 76,
+                              "end": 79
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "baz"
+                          "new_name": {
+                            "name": "baz",
+                            "span": {
+                              "start": 83,
+                              "end": 86
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -111,9 +129,21 @@ class MyClass {
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "foo",
+                          "method": {
+                            "name": "foo",
+                            "span": {
+                              "start": 96,
+                              "end": 99
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "bar"
+                          "new_name": {
+                            "name": "bar",
+                            "span": {
+                              "start": 103,
+                              "end": 106
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -125,7 +155,13 @@ class MyClass {
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "foo",
+                          "method": {
+                            "name": "foo",
+                            "span": {
+                              "start": 116,
+                              "end": 119
+                            }
+                          },
                           "new_modifier": "Protected",
                           "new_name": null
                         }
@@ -148,9 +184,21 @@ class MyClass {
                               "end": 143
                             }
                           },
-                          "method": "hello",
+                          "method": {
+                            "name": "hello",
+                            "span": {
+                              "start": 145,
+                              "end": 150
+                            }
+                          },
                           "new_modifier": "Private",
-                          "new_name": "hi"
+                          "new_name": {
+                            "name": "hi",
+                            "span": {
+                              "start": 162,
+                              "end": 164
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -171,7 +219,13 @@ class MyClass {
                               "end": 175
                             }
                           },
-                          "method": "big",
+                          "method": {
+                            "name": "big",
+                            "span": {
+                              "start": 177,
+                              "end": 180
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [

--- a/crates/php-parser/tests/fixtures/trait_multiple_alias_and_precedence.phpt
+++ b/crates/php-parser/tests/fixtures/trait_multiple_alias_and_precedence.phpt
@@ -151,7 +151,13 @@ class C {
                               "end": 139
                             }
                           },
-                          "method": "foo",
+                          "method": {
+                            "name": "foo",
+                            "span": {
+                              "start": 141,
+                              "end": 144
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [
@@ -184,9 +190,21 @@ class C {
                               "end": 167
                             }
                           },
-                          "method": "foo",
+                          "method": {
+                            "name": "foo",
+                            "span": {
+                              "start": 169,
+                              "end": 172
+                            }
+                          },
                           "new_modifier": "Private",
-                          "new_name": "afoo"
+                          "new_name": {
+                            "name": "afoo",
+                            "span": {
+                              "start": 184,
+                              "end": 188
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -207,9 +225,21 @@ class C {
                               "end": 199
                             }
                           },
-                          "method": "bar",
+                          "method": {
+                            "name": "bar",
+                            "span": {
+                              "start": 201,
+                              "end": 204
+                            }
+                          },
                           "new_modifier": "Public",
-                          "new_name": "bbar"
+                          "new_name": {
+                            "name": "bbar",
+                            "span": {
+                              "start": 215,
+                              "end": 219
+                            }
+                          }
                         }
                       },
                       "span": {

--- a/crates/php-parser/tests/fixtures/trait_multiple_insteadof.phpt
+++ b/crates/php-parser/tests/fixtures/trait_multiple_insteadof.phpt
@@ -175,7 +175,13 @@ class C {
                               "end": 155
                             }
                           },
-                          "method": "m",
+                          "method": {
+                            "name": "m",
+                            "span": {
+                              "start": 157,
+                              "end": 158
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [
@@ -218,7 +224,13 @@ class C {
                               "end": 187
                             }
                           },
-                          "method": "m",
+                          "method": {
+                            "name": "m",
+                            "span": {
+                              "start": 189,
+                              "end": 190
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [

--- a/crates/php-printer/src/printer.rs
+++ b/crates/php-printer/src/printer.rs
@@ -667,12 +667,12 @@ impl Printer {
             ExprKind::StaticPropertyAccess(access) => {
                 self.print_expr(access.class, PREC_PRIMARY);
                 self.w("::$");
-                self.w(&access.member);
+                self.w(access.member.name);
             }
             ExprKind::ClassConstAccess(access) => {
                 self.print_expr(access.class, PREC_PRIMARY);
                 self.w("::");
-                self.w(&access.member);
+                self.w(access.member.name);
             }
             ExprKind::ClassConstAccessDynamic { class, member } => {
                 self.print_expr(class, PREC_PRIMARY);
@@ -688,7 +688,7 @@ impl Printer {
             ExprKind::StaticMethodCall(call) => {
                 self.print_expr(call.class, PREC_PRIMARY);
                 self.w("::");
-                self.w(&call.method);
+                self.w(call.method.name);
                 self.w("(");
                 self.print_args(&call.args);
                 self.w(")");
@@ -744,7 +744,7 @@ impl Printer {
                 CallableCreateKind::StaticMethod { class, method } => {
                     self.print_expr(class, PREC_PRIMARY);
                     self.w("::");
-                    self.w(method);
+                    self.w(method.name);
                     self.w("(...)");
                 }
             },
@@ -1019,7 +1019,7 @@ impl Printer {
                     } => {
                         self.print_name(trait_name);
                         self.w("::");
-                        self.w(method);
+                        self.w(method.name);
                         self.w(" insteadof ");
                         for (i, name) in insteadof.iter().enumerate() {
                             if i > 0 {
@@ -1038,7 +1038,7 @@ impl Printer {
                             self.print_name(tn);
                             self.w("::");
                         }
-                        self.w(method);
+                        self.w(method.name);
                         self.w(" as");
                         if let Some(vis) = new_modifier {
                             self.w(" ");
@@ -1046,7 +1046,7 @@ impl Printer {
                         }
                         if let Some(name) = new_name {
                             self.w(" ");
-                            self.w(name);
+                            self.w(name.name);
                         }
                     }
                 }
@@ -1365,7 +1365,7 @@ impl Printer {
                 self.w(", ");
             }
             if let Some(name) = &arg.name {
-                self.w(name);
+                self.w(name.name);
                 self.w(": ");
             }
             if arg.unpack {


### PR DESCRIPTION
## Summary

- Static identifiers in the AST (`Foo::bar()`, `Foo::CONST`, `Foo::$prop`, `Foo::bar(...)`, trait `insteadof`/`as` method names, named argument labels) were stored as bare `Cow<str>` or `&str` with no source span — unlike their dynamic counterparts which use `&'arena Expr` and get spans for free
- Adds `Ident<'src> { name: &'src str, span: Span }` to `php-ast` and applies it to all six affected sites
- The parser already computed these spans and discarded them (`_member_span`); this change captures them
- 100+ `.phpt` fixtures regenerated to include the new `span` fields in serialized AST output

## Affected fields

| Type | Field | Old | New |
|---|---|---|---|
| `StaticMethodCallExpr` | `method` | `Cow<'src, str>` | `Ident<'src>` |
| `StaticAccessExpr` | `member` | `Cow<'src, str>` | `Ident<'src>` |
| `CallableCreateKind::StaticMethod` | `method` | `Cow<'src, str>` | `Ident<'src>` |
| `TraitAdaptationKind::Precedence` | `method` | `&'src str` | `Ident<'src>` |
| `TraitAdaptationKind::Alias` | `method`, `new_name` | `Cow`/`&'src str` | `Ident<'src>` |
| `Arg` | `name` | `Option<Cow<'src, str>>` | `Option<Ident<'src>>` |

## Test plan

- [x] `cargo check` — clean, no warnings
- [x] `UPDATE_FIXTURES=1 cargo test` — all tests pass, fixtures regenerated
- [x] Verified span values in `static_method_callable_and_access.phpt`, `trait_conflict_resolution.phpt`, `named_arguments.phpt`, `class_static_and_const.phpt`