### PR TITLE
feat(ast): add spans to static method/member/arg identifiers

### DIFF
--- a/crates/php-ast/src/ast.rs
+++ b/crates/php-ast/src/ast.rs
@@ -361,7 +361,7 @@ impl<'arena, 'src> serde::Serialize for TypeHintKind<'arena, 'src> {
 
 #[derive(Debug, Serialize)]
 pub struct Arg<'arena, 'src> {
-    pub name: Option<Cow<'src, str>>,
+    pub name: Option<Name<'arena, 'src>>,
     pub value: Expr<'arena, 'src>,
     pub unpack: bool,
     pub by_ref: bool,
@@ -717,15 +717,15 @@ pub enum TraitAdaptationKind<'arena, 'src> {
     /// `A::foo insteadof B, C;`
     Precedence {
         trait_name: Name<'arena, 'src>,
-        method: &'src str,
+        method: Name<'arena, 'src>,
         insteadof: ArenaVec<'arena, Name<'arena, 'src>>,
     },
     /// `foo as bar;` or `A::foo as protected bar;` or `foo as protected;`
     Alias {
         trait_name: Option<Name<'arena, 'src>>,
-        method: Cow<'src, str>,
+        method: Name<'arena, 'src>,
         new_modifier: Option<Visibility>,
-        new_name: Option<&'src str>,
+        new_name: Option<Name<'arena, 'src>>,
     },
 }
 
@@ -1273,13 +1273,13 @@ pub struct MethodCallExpr<'arena, 'src> {
 #[derive(Debug, Serialize)]
 pub struct StaticAccessExpr<'arena, 'src> {
     pub class: &'arena Expr<'arena, 'src>,
-    pub member: Cow<'src, str>,
+    pub member: &'arena Expr<'arena, 'src>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct StaticMethodCallExpr<'arena, 'src> {
     pub class: &'arena Expr<'arena, 'src>,
-    pub method: Cow<'src, str>,
+    pub method: &'arena Expr<'arena, 'src>,
     pub args: ArenaVec<'arena, Arg<'arena, 'src>>,
 }
 
@@ -1357,7 +1357,7 @@ pub enum CallableCreateKind<'arena, 'src> {
     /// `Foo::bar(...)`
     StaticMethod {
         class: &'arena Expr<'arena, 'src>,
-        method: Cow<'src, str>,
+        method: &'arena Expr<'arena, 'src>,
     },
 }
 

--- a/crates/php-ast/src/visitor.rs
+++ b/crates/php-ast/src/visitor.rs
@@ -375,6 +375,7 @@ pub fn walk_expr<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
         }
         ExprKind::StaticPropertyAccess(access) | ExprKind::ClassConstAccess(access) => {
             visitor.visit_expr(access.class)?;
+            visitor.visit_expr(access.member)?;
         }
         ExprKind::ClassConstAccessDynamic { class, member }
         | ExprKind::StaticPropertyAccessDynamic { class, member } => {
@@ -383,6 +384,7 @@ pub fn walk_expr<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
         }
         ExprKind::StaticMethodCall(call) => {
             visitor.visit_expr(call.class)?;
+            visitor.visit_expr(call.method)?;
             for arg in call.args.iter() {
                 visitor.visit_arg(arg)?;
             }
@@ -452,8 +454,9 @@ pub fn walk_expr<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
                 visitor.visit_expr(object)?;
                 visitor.visit_expr(method)?;
             }
-            CallableCreateKind::StaticMethod { class, .. } => {
+            CallableCreateKind::StaticMethod { class, method } => {
                 visitor.visit_expr(class)?;
+                visitor.visit_expr(method)?;
             }
         },
         ExprKind::Int(_)

--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -405,7 +405,10 @@ pub fn parse_expr_bp<'arena, 'src>(
             if parser.check(TokenKind::Variable) {
                 // Static property: Class::$prop
                 let token = parser.advance();
-                let member = Cow::Borrowed(parser.variable_name(token));
+                let member = parser.alloc(Expr {
+                    kind: ExprKind::Identifier(NameStr::Src(parser.variable_name(token))),
+                    span: token.span,
+                });
                 let span = Span::new(lhs.span.start, token.span.end);
                 lhs = Expr {
                     kind: ExprKind::StaticPropertyAccess(StaticAccessExpr {
@@ -445,7 +448,7 @@ pub fn parse_expr_bp<'arena, 'src>(
                                 kind: ExprKind::CallableCreate(CallableCreateExpr {
                                     kind: CallableCreateKind::StaticMethod {
                                         class: parser.alloc(lhs),
-                                        method: Cow::Borrowed("{dynamic}"),
+                                        method: parser.alloc(member),
                                     },
                                 }),
                                 span,
@@ -488,13 +491,16 @@ pub fn parse_expr_bp<'arena, 'src>(
                 lhs = Expr {
                     kind: ExprKind::ClassConstAccess(StaticAccessExpr {
                         class: parser.alloc(lhs),
-                        member: Cow::Borrowed("class"),
+                        member: parser.alloc(Expr {
+                            kind: ExprKind::Identifier(NameStr::Src("class")),
+                            span: token.span,
+                        }),
                     }),
                     span,
                 };
             } else {
                 // Static method call or class constant
-                let (member_name, _member_span) =
+                let (member_name, member_span) =
                     if let Some(result) = parser.eat_identifier_or_keyword() {
                         result
                     } else {
@@ -506,6 +512,10 @@ pub fn parse_expr_bp<'arena, 'src>(
                         });
                         ("<error>", span)
                     };
+                let member = parser.alloc(Expr {
+                    kind: ExprKind::Identifier(NameStr::Src(member_name)),
+                    span: member_span,
+                });
 
                 if parser.check(TokenKind::LeftParen) {
                     match parse_arg_list_or_callable(parser) {
@@ -515,7 +525,7 @@ pub fn parse_expr_bp<'arena, 'src>(
                                 kind: ExprKind::CallableCreate(CallableCreateExpr {
                                     kind: CallableCreateKind::StaticMethod {
                                         class: parser.alloc(lhs),
-                                        method: Cow::Borrowed(member_name),
+                                        method: member,
                                     },
                                 }),
                                 span,
@@ -527,7 +537,7 @@ pub fn parse_expr_bp<'arena, 'src>(
                                 kind: ExprKind::StaticMethodCall(parser.alloc(
                                     StaticMethodCallExpr {
                                         class: parser.alloc(lhs),
-                                        method: Cow::Borrowed(member_name),
+                                        method: member,
                                         args,
                                     },
                                 )),
@@ -541,7 +551,7 @@ pub fn parse_expr_bp<'arena, 'src>(
                     lhs = Expr {
                         kind: ExprKind::ClassConstAccess(StaticAccessExpr {
                             class: parser.alloc(lhs),
-                            member: Cow::Borrowed(member_name),
+                            member,
                         }),
                         span,
                     };
@@ -2399,9 +2409,10 @@ fn parse_arg<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Arg<'arena, 
             parser.require_version(PhpVersion::Php80, "named arguments", span);
             parser.advance(); // consume :
             let src = parser.source;
-            Some(Cow::Borrowed(
-                &src[name_token.span.start as usize..name_token.span.end as usize],
-            ))
+            Some(Name::Simple {
+                value: &src[name_token.span.start as usize..name_token.span.end as usize],
+                span: name_token.span,
+            })
         } else {
             None
         }

--- a/crates/php-parser/src/stmt.rs
+++ b/crates/php-parser/src/stmt.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use php_ast::*;
 use php_lexer::TokenKind;
 
@@ -1741,8 +1739,8 @@ fn parse_trait_adaptations<'arena, 'src>(
 
         if parser.eat(TokenKind::DoubleColon).is_some() {
             // Qualified: TraitName::method
-            let method = if let Some((text, _)) = parser.eat_identifier_or_keyword() {
-                text
+            let method = if let Some((text, span)) = parser.eat_identifier_or_keyword() {
+                Name::Simple { value: text, span }
             } else {
                 let span = parser.current_span();
                 parser.error(ParseError::Expected {
@@ -1750,7 +1748,10 @@ fn parse_trait_adaptations<'arena, 'src>(
                     found: parser.current_kind(),
                     span,
                 });
-                "<error>"
+                Name::Simple {
+                    value: "<error>",
+                    span,
+                }
             };
 
             // Check for `insteadof` or `as`
@@ -1785,7 +1786,7 @@ fn parse_trait_adaptations<'arena, 'src>(
                 adaptations.push(TraitAdaptation {
                     kind: TraitAdaptationKind::Alias {
                         trait_name: Some(first_name),
-                        method: Cow::Borrowed(method),
+                        method,
                         new_modifier,
                         new_name,
                     },
@@ -1801,15 +1802,15 @@ fn parse_trait_adaptations<'arena, 'src>(
                 parser.advance();
             }
         } else if parser.eat(TokenKind::As).is_some() {
-            // Unqualified alias: method as [visibility] [newName];
-            let method = first_name.join_parts();
+            // Unqualified alias: `method as [visibility] [newName];`
+            // first_name already is the method Name — use it directly.
             let (new_modifier, new_name) = parse_alias_rhs(parser);
             parser.expect(TokenKind::Semicolon);
             let span = Span::new(start, parser.previous_end());
             adaptations.push(TraitAdaptation {
                 kind: TraitAdaptationKind::Alias {
                     trait_name: None,
-                    method,
+                    method: first_name,
                     new_modifier,
                     new_name,
                 },
@@ -1832,7 +1833,7 @@ fn parse_trait_adaptations<'arena, 'src>(
 /// Parse the right-hand side of an `as` alias: `[visibility] [newName]`
 fn parse_alias_rhs<'arena, 'src>(
     parser: &'_ mut Parser<'arena, 'src>,
-) -> (Option<Visibility>, Option<&'src str>) {
+) -> (Option<Visibility>, Option<Name<'arena, 'src>>) {
     let new_modifier = match parser.current_kind() {
         TokenKind::Public => {
             parser.advance();
@@ -1851,8 +1852,8 @@ fn parse_alias_rhs<'arena, 'src>(
 
     // New name (optional if visibility was given)
     let new_name = if parser.check(TokenKind::Identifier) || parser.is_semi_reserved_keyword() {
-        let (text, _) = parser.eat_identifier_or_keyword().unwrap();
-        Some(text)
+        let (text, span) = parser.eat_identifier_or_keyword().unwrap();
+        Some(Name::Simple { value: text, span })
     } else {
         None
     };

--- a/crates/php-parser/tests/fixtures/attribute_with_new_expression_arg.phpt
+++ b/crates/php-parser/tests/fixtures/attribute_with_new_expression_arg.phpt
@@ -40,7 +40,16 @@
                         },
                         "args": [
                           {
-                            "name": "debug",
+                            "name": {
+                              "parts": [
+                                "debug"
+                              ],
+                              "kind": "Unqualified",
+                              "span": {
+                                "start": 24,
+                                "end": 29
+                              }
+                            },
                             "value": {
                               "kind": {
                                 "Bool": false

--- a/crates/php-parser/tests/fixtures/attributes.phpt
+++ b/crates/php-parser/tests/fixtures/attributes.phpt
@@ -250,7 +250,16 @@ enum Color {
                   }
                 },
                 {
-                  "name": "methods",
+                  "name": {
+                    "parts": [
+                      "methods"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 156,
+                      "end": 163
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Array": [

--- a/crates/php-parser/tests/fixtures/categories/attributes/attr_complex_args.phpt
+++ b/crates/php-parser/tests/fixtures/categories/attributes/attr_complex_args.phpt
@@ -43,7 +43,16 @@
                   }
                 },
                 {
-                  "name": "methods",
+                  "name": {
+                    "parts": [
+                      "methods"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 22,
+                      "end": 29
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Array": [

--- a/crates/php-parser/tests/fixtures/categories/attributes/multiple_named_args_in_attr.phpt
+++ b/crates/php-parser/tests/fixtures/categories/attributes/multiple_named_args_in_attr.phpt
@@ -30,7 +30,16 @@
               },
               "args": [
                 {
-                  "name": "min",
+                  "name": {
+                    "parts": [
+                      "min"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 21,
+                      "end": 24
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1
@@ -48,7 +57,16 @@
                   }
                 },
                 {
-                  "name": "max",
+                  "name": {
+                    "parts": [
+                      "max"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 29,
+                      "end": 32
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 100

--- a/crates/php-parser/tests/fixtures/categories/attributes/named_arg_in_attr.phpt
+++ b/crates/php-parser/tests/fixtures/categories/attributes/named_arg_in_attr.phpt
@@ -25,7 +25,16 @@
               },
               "args": [
                 {
-                  "name": "path",
+                  "name": {
+                    "parts": [
+                      "path"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 14,
+                      "end": 18
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "/api"
@@ -43,7 +52,16 @@
                   }
                 },
                 {
-                  "name": "methods",
+                  "name": {
+                    "parts": [
+                      "methods"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 28,
+                      "end": 35
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Array": [

--- a/crates/php-parser/tests/fixtures/categories/attributes/positional_and_named_args_in_attr.phpt
+++ b/crates/php-parser/tests/fixtures/categories/attributes/positional_and_named_args_in_attr.phpt
@@ -47,7 +47,16 @@
                   }
                 },
                 {
-                  "name": "key",
+                  "name": {
+                    "parts": [
+                      "key"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 27,
+                      "end": 30
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "value"
@@ -65,7 +74,16 @@
                   }
                 },
                 {
-                  "name": "flag",
+                  "name": {
+                    "parts": [
+                      "flag"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 41,
+                      "end": 45
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Bool": true

--- a/crates/php-parser/tests/fixtures/categories/clone/clone_named_arg.phpt
+++ b/crates/php-parser/tests/fixtures/categories/clone/clone_named_arg.phpt
@@ -21,7 +21,16 @@ min_php=8.5
               },
               "args": [
                 {
-                  "name": "object",
+                  "name": {
+                    "parts": [
+                      "object"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 12,
+                      "end": 18
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/clone/clone_named_args_two.phpt
+++ b/crates/php-parser/tests/fixtures/categories/clone/clone_named_args_two.phpt
@@ -21,7 +21,16 @@ min_php=8.5
               },
               "args": [
                 {
-                  "name": "object",
+                  "name": {
+                    "parts": [
+                      "object"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 12,
+                      "end": 18
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"
@@ -39,7 +48,16 @@ min_php=8.5
                   }
                 },
                 {
-                  "name": "withProperties",
+                  "name": {
+                    "parts": [
+                      "withProperties"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 24,
+                      "end": 38
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Array": [

--- a/crates/php-parser/tests/fixtures/categories/dynamic_access/dynamic_static.phpt
+++ b/crates/php-parser/tests/fixtures/categories/dynamic_access/dynamic_static.phpt
@@ -17,7 +17,15 @@
                   "end": 12
                 }
               },
-              "member": "prop"
+              "member": {
+                "kind": {
+                  "Identifier": "prop"
+                },
+                "span": {
+                  "start": 14,
+                  "end": 19
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/categories/dynamic_access/dynamic_static_method.phpt
+++ b/crates/php-parser/tests/fixtures/categories/dynamic_access/dynamic_static_method.phpt
@@ -20,7 +20,15 @@
                         "end": 12
                       }
                     },
-                    "member": "method"
+                    "member": {
+                      "kind": {
+                        "Identifier": "method"
+                      },
+                      "span": {
+                        "start": 14,
+                        "end": 21
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/categories/dynamic_access/variable_class_static.phpt
+++ b/crates/php-parser/tests/fixtures/categories/dynamic_access/variable_class_static.phpt
@@ -17,7 +17,15 @@
                   "end": 12
                 }
               },
-              "member": "CONST_NAME"
+              "member": {
+                "kind": {
+                  "Identifier": "CONST_NAME"
+                },
+                "span": {
+                  "start": 14,
+                  "end": 24
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/categories/enum/enum_from_and_tryfrom.phpt
+++ b/crates/php-parser/tests/fixtures/categories/enum/enum_from_and_tryfrom.phpt
@@ -17,7 +17,15 @@
                   "end": 12
                 }
               },
-              "method": "from",
+              "method": {
+                "kind": {
+                  "Identifier": "from"
+                },
+                "span": {
+                  "start": 14,
+                  "end": 18
+                }
+              },
               "args": [
                 {
                   "name": null,
@@ -65,7 +73,15 @@
                   "end": 29
                 }
               },
-              "method": "tryFrom",
+              "method": {
+                "kind": {
+                  "Identifier": "tryFrom"
+                },
+                "span": {
+                  "start": 31,
+                  "end": 38
+                }
+              },
               "args": [
                 {
                   "name": null,

--- a/crates/php-parser/tests/fixtures/categories/enum/enum_static_method.phpt
+++ b/crates/php-parser/tests/fixtures/categories/enum/enum_static_method.phpt
@@ -68,7 +68,15 @@ min_php=8.1
                                   "end": 81
                                 }
                               },
-                              "member": "Red"
+                              "member": {
+                                "kind": {
+                                  "Identifier": "Red"
+                                },
+                                "span": {
+                                  "start": 83,
+                                  "end": 86
+                                }
+                              }
                             }
                           },
                           "span": {

--- a/crates/php-parser/tests/fixtures/categories/enum_in_match/backed_enum_in_match.phpt
+++ b/crates/php-parser/tests/fixtures/categories/enum_in_match/backed_enum_in_match.phpt
@@ -114,7 +114,15 @@ min_php=8.1
                                     "end": 89
                                   }
                                 },
-                                "member": "Red"
+                                "member": {
+                                  "kind": {
+                                    "Identifier": "Red"
+                                  },
+                                  "span": {
+                                    "start": 91,
+                                    "end": 94
+                                  }
+                                }
                               }
                             },
                             "span": {
@@ -151,7 +159,15 @@ min_php=8.1
                                     "end": 106
                                   }
                                 },
-                                "member": "Blue"
+                                "member": {
+                                  "kind": {
+                                    "Identifier": "Blue"
+                                  },
+                                  "span": {
+                                    "start": 108,
+                                    "end": 112
+                                  }
+                                }
                               }
                             },
                             "span": {

--- a/crates/php-parser/tests/fixtures/categories/enum_in_match/enum_case_as_match_arm.phpt
+++ b/crates/php-parser/tests/fixtures/categories/enum_in_match/enum_case_as_match_arm.phpt
@@ -89,7 +89,15 @@ min_php=8.1
                                     "end": 73
                                   }
                                 },
-                                "member": "Active"
+                                "member": {
+                                  "kind": {
+                                    "Identifier": "Active"
+                                  },
+                                  "span": {
+                                    "start": 75,
+                                    "end": 81
+                                  }
+                                }
                               }
                             },
                             "span": {
@@ -126,7 +134,15 @@ min_php=8.1
                                     "end": 97
                                   }
                                 },
-                                "member": "Inactive"
+                                "member": {
+                                  "kind": {
+                                    "Identifier": "Inactive"
+                                  },
+                                  "span": {
+                                    "start": 99,
+                                    "end": 107
+                                  }
+                                }
                               }
                             },
                             "span": {

--- a/crates/php-parser/tests/fixtures/categories/enum_in_match/multiple_enum_arms.phpt
+++ b/crates/php-parser/tests/fixtures/categories/enum_in_match/multiple_enum_arms.phpt
@@ -47,7 +47,15 @@ min_php=8.1
                                     "end": 34
                                   }
                                 },
-                                "member": "Active"
+                                "member": {
+                                  "kind": {
+                                    "Identifier": "Active"
+                                  },
+                                  "span": {
+                                    "start": 36,
+                                    "end": 42
+                                  }
+                                }
                               }
                             },
                             "span": {
@@ -67,7 +75,15 @@ min_php=8.1
                                     "end": 50
                                   }
                                 },
-                                "member": "Pending"
+                                "member": {
+                                  "kind": {
+                                    "Identifier": "Pending"
+                                  },
+                                  "span": {
+                                    "start": 52,
+                                    "end": 59
+                                  }
+                                }
                               }
                             },
                             "span": {
@@ -104,7 +120,15 @@ min_php=8.1
                                     "end": 77
                                   }
                                 },
-                                "member": "Inactive"
+                                "member": {
+                                  "kind": {
+                                    "Identifier": "Inactive"
+                                  },
+                                  "span": {
+                                    "start": 79,
+                                    "end": 87
+                                  }
+                                }
                               }
                             },
                             "span": {

--- a/crates/php-parser/tests/fixtures/categories/expression_chains/static_call_chain.phpt
+++ b/crates/php-parser/tests/fixtures/categories/expression_chains/static_call_chain.phpt
@@ -20,7 +20,15 @@
                         "end": 9
                       }
                     },
-                    "method": "create",
+                    "method": {
+                      "kind": {
+                        "Identifier": "create"
+                      },
+                      "span": {
+                        "start": 11,
+                        "end": 17
+                      }
+                    },
                     "args": []
                   }
                 },

--- a/crates/php-parser/tests/fixtures/categories/fiber/fiber_create_and_start.phpt
+++ b/crates/php-parser/tests/fixtures/categories/fiber/fiber_create_and_start.phpt
@@ -75,7 +75,15 @@ min_php=8.1
                                               "end": 49
                                             }
                                           },
-                                          "method": "suspend",
+                                          "method": {
+                                            "kind": {
+                                              "Identifier": "suspend"
+                                            },
+                                            "span": {
+                                              "start": 51,
+                                              "end": 58
+                                            }
+                                          },
                                           "args": [
                                             {
                                               "name": null,

--- a/crates/php-parser/tests/fixtures/categories/fiber/fiber_suspend_static.phpt
+++ b/crates/php-parser/tests/fixtures/categories/fiber/fiber_suspend_static.phpt
@@ -32,7 +32,15 @@ min_php=8.1
                         "end": 18
                       }
                     },
-                    "method": "suspend",
+                    "method": {
+                      "kind": {
+                        "Identifier": "suspend"
+                      },
+                      "span": {
+                        "start": 20,
+                        "end": 27
+                      }
+                    },
                     "args": [
                       {
                         "name": null,

--- a/crates/php-parser/tests/fixtures/categories/heredoc/named_arg_with_heredoc_closing_marker_followed_by.phpt
+++ b/crates/php-parser/tests/fixtures/categories/heredoc/named_arg_with_heredoc_closing_marker_followed_by.phpt
@@ -21,7 +21,16 @@ EOT);
               },
               "args": [
                 {
-                  "name": "bar",
+                  "name": {
+                    "parts": [
+                      "bar"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 10,
+                      "end": 13
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Heredoc": {

--- a/crates/php-parser/tests/fixtures/categories/heredoc/named_arg_with_heredoc_value.phpt
+++ b/crates/php-parser/tests/fixtures/categories/heredoc/named_arg_with_heredoc_value.phpt
@@ -22,7 +22,16 @@ EOT
               },
               "args": [
                 {
-                  "name": "bar",
+                  "name": {
+                    "parts": [
+                      "bar"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 10,
+                      "end": 13
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Heredoc": {

--- a/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_false.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_false.phpt
@@ -19,7 +19,16 @@
               },
               "args": [
                 {
-                  "name": "false",
+                  "name": {
+                    "parts": [
+                      "false"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 10,
+                      "end": 15
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_fn.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_fn.phpt
@@ -19,7 +19,16 @@
               },
               "args": [
                 {
-                  "name": "fn",
+                  "name": {
+                    "parts": [
+                      "fn"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 10,
+                      "end": 12
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_for.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_for.phpt
@@ -19,7 +19,16 @@
               },
               "args": [
                 {
-                  "name": "for",
+                  "name": {
+                    "parts": [
+                      "for"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 10,
+                      "end": 13
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_list.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_list.phpt
@@ -19,7 +19,16 @@
               },
               "args": [
                 {
-                  "name": "list",
+                  "name": {
+                    "parts": [
+                      "list"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 10,
+                      "end": 14
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_null.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_null.phpt
@@ -19,7 +19,16 @@
               },
               "args": [
                 {
-                  "name": "null",
+                  "name": {
+                    "parts": [
+                      "null"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 10,
+                      "end": 14
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_true.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_true.phpt
@@ -19,7 +19,16 @@
               },
               "args": [
                 {
-                  "name": "true",
+                  "name": {
+                    "parts": [
+                      "true"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 10,
+                      "end": 14
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_while.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/keyword_name_while.phpt
@@ -19,7 +19,16 @@
               },
               "args": [
                 {
-                  "name": "while",
+                  "name": {
+                    "parts": [
+                      "while"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 10,
+                      "end": 15
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/categories/named_args/mixed_named_args.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/mixed_named_args.phpt
@@ -55,7 +55,16 @@
                   }
                 },
                 {
-                  "name": "name",
+                  "name": {
+                    "parts": [
+                      "name"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 16,
+                      "end": 20
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "test"
@@ -73,7 +82,16 @@
                   }
                 },
                 {
-                  "name": "other",
+                  "name": {
+                    "parts": [
+                      "other"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 30,
+                      "end": 35
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Bool": true

--- a/crates/php-parser/tests/fixtures/categories/named_args/named_in_method.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/named_in_method.phpt
@@ -28,7 +28,16 @@
               },
               "args": [
                 {
-                  "name": "key",
+                  "name": {
+                    "parts": [
+                      "key"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 19,
+                      "end": 22
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "val"

--- a/crates/php-parser/tests/fixtures/categories/named_args/named_in_new.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/named_in_new.phpt
@@ -19,7 +19,16 @@
               },
               "args": [
                 {
-                  "name": "x",
+                  "name": {
+                    "parts": [
+                      "x"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 14,
+                      "end": 15
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1
@@ -37,7 +46,16 @@
                   }
                 },
                 {
-                  "name": "y",
+                  "name": {
+                    "parts": [
+                      "y"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 20,
+                      "end": 21
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 2

--- a/crates/php-parser/tests/fixtures/categories/named_args/named_with_spread.phpt
+++ b/crates/php-parser/tests/fixtures/categories/named_args/named_with_spread.phpt
@@ -37,7 +37,16 @@
                   }
                 },
                 {
-                  "name": "name",
+                  "name": {
+                    "parts": [
+                      "name"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 21,
+                      "end": 25
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "test"

--- a/crates/php-parser/tests/fixtures/categories/scope_resolution/class_const_on_name.phpt
+++ b/crates/php-parser/tests/fixtures/categories/scope_resolution/class_const_on_name.phpt
@@ -18,7 +18,15 @@
                     "end": 14
                   }
                 },
-                "member": "class"
+                "member": {
+                  "kind": {
+                    "Identifier": "class"
+                  },
+                  "span": {
+                    "start": 16,
+                    "end": 21
+                  }
+                }
               }
             },
             "span": {

--- a/crates/php-parser/tests/fixtures/categories/scope_resolution/parent_const.phpt
+++ b/crates/php-parser/tests/fixtures/categories/scope_resolution/parent_const.phpt
@@ -50,7 +50,15 @@
                                   "end": 65
                                 }
                               },
-                              "member": "VERSION"
+                              "member": {
+                                "kind": {
+                                  "Identifier": "VERSION"
+                                },
+                                "span": {
+                                  "start": 67,
+                                  "end": 74
+                                }
+                              }
                             }
                           },
                           "span": {

--- a/crates/php-parser/tests/fixtures/categories/scope_resolution/parent_method.phpt
+++ b/crates/php-parser/tests/fixtures/categories/scope_resolution/parent_method.phpt
@@ -50,7 +50,15 @@
                                   "end": 58
                                 }
                               },
-                              "method": "f",
+                              "method": {
+                                "kind": {
+                                  "Identifier": "f"
+                                },
+                                "span": {
+                                  "start": 60,
+                                  "end": 61
+                                }
+                              },
                               "args": []
                             }
                           },

--- a/crates/php-parser/tests/fixtures/categories/scope_resolution/self_const.phpt
+++ b/crates/php-parser/tests/fixtures/categories/scope_resolution/self_const.phpt
@@ -63,7 +63,15 @@
                                   "end": 64
                                 }
                               },
-                              "member": "X"
+                              "member": {
+                                "kind": {
+                                  "Identifier": "X"
+                                },
+                                "span": {
+                                  "start": 66,
+                                  "end": 67
+                                }
+                              }
                             }
                           },
                           "span": {

--- a/crates/php-parser/tests/fixtures/categories/scope_resolution/self_static_prop.phpt
+++ b/crates/php-parser/tests/fixtures/categories/scope_resolution/self_static_prop.phpt
@@ -67,7 +67,15 @@
                                   "end": 73
                                 }
                               },
-                              "member": "x"
+                              "member": {
+                                "kind": {
+                                  "Identifier": "x"
+                                },
+                                "span": {
+                                  "start": 75,
+                                  "end": 77
+                                }
+                              }
                             }
                           },
                           "span": {

--- a/crates/php-parser/tests/fixtures/categories/scope_resolution/static_const.phpt
+++ b/crates/php-parser/tests/fixtures/categories/scope_resolution/static_const.phpt
@@ -41,7 +41,15 @@
                                   "end": 53
                                 }
                               },
-                              "member": "DEFAULT"
+                              "member": {
+                                "kind": {
+                                  "Identifier": "DEFAULT"
+                                },
+                                "span": {
+                                  "start": 55,
+                                  "end": 62
+                                }
+                              }
                             }
                           },
                           "span": {

--- a/crates/php-parser/tests/fixtures/categories/span_precision/method_call_span.phpt
+++ b/crates/php-parser/tests/fixtures/categories/span_precision/method_call_span.phpt
@@ -132,7 +132,15 @@ Foo::bar(1);
                   "end": 44
                 }
               },
-              "method": "bar",
+              "method": {
+                "kind": {
+                  "Identifier": "bar"
+                },
+                "span": {
+                  "start": 46,
+                  "end": 49
+                }
+              },
               "args": [
                 {
                   "name": null,

--- a/crates/php-parser/tests/fixtures/categories/trait_use/alias_qualified_method.phpt
+++ b/crates/php-parser/tests/fixtures/categories/trait_use/alias_qualified_method.phpt
@@ -44,9 +44,27 @@
                               "end": 25
                             }
                           },
-                          "method": "foo",
+                          "method": {
+                            "parts": [
+                              "foo"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 27,
+                              "end": 30
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "bar"
+                          "new_name": {
+                            "parts": [
+                              "bar"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 34,
+                              "end": 37
+                            }
+                          }
                         }
                       },
                       "span": {

--- a/crates/php-parser/tests/fixtures/categories/trait_use/alias_qualified_with_visibility.phpt
+++ b/crates/php-parser/tests/fixtures/categories/trait_use/alias_qualified_with_visibility.phpt
@@ -44,9 +44,27 @@
                               "end": 25
                             }
                           },
-                          "method": "foo",
+                          "method": {
+                            "parts": [
+                              "foo"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 27,
+                              "end": 30
+                            }
+                          },
                           "new_modifier": "Protected",
-                          "new_name": "baz"
+                          "new_name": {
+                            "parts": [
+                              "baz"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 44,
+                              "end": 47
+                            }
+                          }
                         }
                       },
                       "span": {

--- a/crates/php-parser/tests/fixtures/categories/trait_use/alias_visibility_only.phpt
+++ b/crates/php-parser/tests/fixtures/categories/trait_use/alias_visibility_only.phpt
@@ -35,7 +35,16 @@
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "foo",
+                          "method": {
+                            "parts": [
+                              "foo"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 24,
+                              "end": 27
+                            }
+                          },
                           "new_modifier": "Protected",
                           "new_name": null
                         }

--- a/crates/php-parser/tests/fixtures/categories/trait_use/insteadof_multi.phpt
+++ b/crates/php-parser/tests/fixtures/categories/trait_use/insteadof_multi.phpt
@@ -54,7 +54,16 @@
                               "end": 28
                             }
                           },
-                          "method": "m",
+                          "method": {
+                            "parts": [
+                              "m"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 30,
+                              "end": 31
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [

--- a/crates/php-parser/tests/fixtures/categories/trait_use/multiple_adaptations.phpt
+++ b/crates/php-parser/tests/fixtures/categories/trait_use/multiple_adaptations.phpt
@@ -54,7 +54,16 @@
                               "end": 28
                             }
                           },
-                          "method": "m",
+                          "method": {
+                            "parts": [
+                              "m"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 30,
+                              "end": 31
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [
@@ -87,9 +96,27 @@
                               "end": 46
                             }
                           },
-                          "method": "n",
+                          "method": {
+                            "parts": [
+                              "n"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 48,
+                              "end": 49
+                            }
+                          },
                           "new_modifier": "Public",
-                          "new_name": "nAlias"
+                          "new_name": {
+                            "parts": [
+                              "nAlias"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 60,
+                              "end": 66
+                            }
+                          }
                         }
                       },
                       "span": {

--- a/crates/php-parser/tests/fixtures/class_name_resolution.phpt
+++ b/crates/php-parser/tests/fixtures/class_name_resolution.phpt
@@ -17,7 +17,15 @@
                   "end": 9
                 }
               },
-              "member": "class"
+              "member": {
+                "kind": {
+                  "Identifier": "class"
+                },
+                "span": {
+                  "start": 11,
+                  "end": 16
+                }
+              }
             }
           },
           "span": {
@@ -45,7 +53,15 @@
                   "end": 22
                 }
               },
-              "member": "class"
+              "member": {
+                "kind": {
+                  "Identifier": "class"
+                },
+                "span": {
+                  "start": 24,
+                  "end": 29
+                }
+              }
             }
           },
           "span": {
@@ -73,7 +89,15 @@
                   "end": 37
                 }
               },
-              "member": "class"
+              "member": {
+                "kind": {
+                  "Identifier": "class"
+                },
+                "span": {
+                  "start": 39,
+                  "end": 44
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/class_static_and_const.phpt
+++ b/crates/php-parser/tests/fixtures/class_static_and_const.phpt
@@ -156,7 +156,15 @@ class Config {
                                         "end": 181
                                       }
                                     },
-                                    "member": "count"
+                                    "member": {
+                                      "kind": {
+                                        "Identifier": "count"
+                                      },
+                                      "span": {
+                                        "start": 183,
+                                        "end": 189
+                                      }
+                                    }
                                   }
                                 },
                                 "span": {

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_16.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_16.phpt
@@ -21,7 +21,15 @@ expected ';' after expression
                   "end": 9
                 }
               },
-              "member": "<error>"
+              "member": {
+                "kind": {
+                  "Identifier": "<error>"
+                },
+                "span": {
+                  "start": 11,
+                  "end": 11
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_18.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_18.phpt
@@ -223,7 +223,16 @@ for ($a, ; $b, ; $c, );
                               "end": 127
                             }
                           },
-                          "method": "b",
+                          "method": {
+                            "parts": [
+                              "b"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 129,
+                              "end": 130
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_19.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_19.phpt
@@ -36,7 +36,15 @@ expected identifier, found ')'
                             "end": 14
                           }
                         },
-                        "member": "<error>"
+                        "member": {
+                          "kind": {
+                            "Identifier": "<error>"
+                          },
+                          "span": {
+                            "start": 16,
+                            "end": 17
+                          }
+                        }
                       }
                     },
                     "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_1.phpt
@@ -226,7 +226,15 @@ new $a->b{'c'}();
                         "end": 54
                       }
                     },
-                    "member": "b"
+                    "member": {
+                      "kind": {
+                        "Identifier": "b"
+                      },
+                      "span": {
+                        "start": 56,
+                        "end": 58
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -309,7 +317,15 @@ new $a->b{'c'}();
                         "end": 72
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "kind": {
+                        "Identifier": "B"
+                      },
+                      "span": {
+                        "start": 74,
+                        "end": 75
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_1_php83.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_1_php83.phpt
@@ -226,7 +226,15 @@ new $a->b{'c'}();
                         "end": 54
                       }
                     },
-                    "member": "b"
+                    "member": {
+                      "kind": {
+                        "Identifier": "b"
+                      },
+                      "span": {
+                        "start": 56,
+                        "end": 58
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -309,7 +317,15 @@ new $a->b{'c'}();
                         "end": 72
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "kind": {
+                        "Identifier": "B"
+                      },
+                      "span": {
+                        "start": 74,
+                        "end": 75
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_2.phpt
@@ -226,7 +226,15 @@ new $a->b{'c'}();
                         "end": 54
                       }
                     },
-                    "member": "b"
+                    "member": {
+                      "kind": {
+                        "Identifier": "b"
+                      },
+                      "span": {
+                        "start": 56,
+                        "end": 58
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -309,7 +317,15 @@ new $a->b{'c'}();
                         "end": 72
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "kind": {
+                        "Identifier": "B"
+                      },
+                      "span": {
+                        "start": 74,
+                        "end": 75
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_2_php83.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/alternative_array_syntax_2_php83.phpt
@@ -226,7 +226,15 @@ new $a->b{'c'}();
                         "end": 54
                       }
                     },
-                    "member": "b"
+                    "member": {
+                      "kind": {
+                        "Identifier": "b"
+                      },
+                      "span": {
+                        "start": 56,
+                        "end": 58
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -309,7 +317,15 @@ new $a->b{'c'}();
                         "end": 72
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "kind": {
+                        "Identifier": "B"
+                      },
+                      "span": {
+                        "start": 74,
+                        "end": 75
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/exit.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/exit.phpt
@@ -152,7 +152,16 @@ DIE($a, $b);
               },
               "args": [
                 {
-                  "name": "status",
+                  "name": {
+                    "parts": [
+                      "status"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 66,
+                      "end": 72
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 42

--- a/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/constFetch.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/constFetch.phpt
@@ -40,7 +40,15 @@ $a::class;
                   "end": 11
                 }
               },
-              "member": "B"
+              "member": {
+                "kind": {
+                  "Identifier": "B"
+                },
+                "span": {
+                  "start": 13,
+                  "end": 14
+                }
+              }
             }
           },
           "span": {
@@ -68,7 +76,15 @@ $a::class;
                   "end": 17
                 }
               },
-              "member": "class"
+              "member": {
+                "kind": {
+                  "Identifier": "class"
+                },
+                "span": {
+                  "start": 19,
+                  "end": 24
+                }
+              }
             }
           },
           "span": {
@@ -96,7 +112,15 @@ $a::class;
                   "end": 28
                 }
               },
-              "member": "B"
+              "member": {
+                "kind": {
+                  "Identifier": "B"
+                },
+                "span": {
+                  "start": 30,
+                  "end": 31
+                }
+              }
             }
           },
           "span": {
@@ -124,7 +148,15 @@ $a::class;
                   "end": 35
                 }
               },
-              "member": "class"
+              "member": {
+                "kind": {
+                  "Identifier": "class"
+                },
+                "span": {
+                  "start": 37,
+                  "end": 42
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/constantDeref.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/constantDeref.phpt
@@ -607,7 +607,15 @@ $foo::BAR[2][1][0];
                         "end": 125
                       }
                     },
-                    "member": "BAR"
+                    "member": {
+                      "kind": {
+                        "Identifier": "BAR"
+                      },
+                      "span": {
+                        "start": 127,
+                        "end": 130
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -660,7 +668,15 @@ $foo::BAR[2][1][0];
                                     "end": 139
                                   }
                                 },
-                                "member": "BAR"
+                                "member": {
+                                  "kind": {
+                                    "Identifier": "BAR"
+                                  },
+                                  "span": {
+                                    "start": 141,
+                                    "end": 144
+                                  }
+                                }
                               }
                             },
                             "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/namedArgs.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/namedArgs.phpt
@@ -21,7 +21,16 @@ bar(class: 0);
               },
               "args": [
                 {
-                  "name": "a",
+                  "name": {
+                    "parts": [
+                      "a"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 10,
+                      "end": 11
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "b"
@@ -39,7 +48,16 @@ bar(class: 0);
                   }
                 },
                 {
-                  "name": "c",
+                  "name": {
+                    "parts": [
+                      "c"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 17,
+                      "end": 18
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "d"
@@ -86,7 +104,16 @@ bar(class: 0);
               },
               "args": [
                 {
-                  "name": "class",
+                  "name": {
+                    "parts": [
+                      "class"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 29,
+                      "end": 34
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 0

--- a/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/staticCall.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/staticCall.phpt
@@ -33,7 +33,15 @@ $a['b']::c();
                   "end": 34
                 }
               },
-              "method": "b",
+              "method": {
+                "kind": {
+                  "Identifier": "b"
+                },
+                "span": {
+                  "start": 36,
+                  "end": 37
+                }
+              },
               "args": []
             }
           },
@@ -112,7 +120,15 @@ $a['b']::c();
                         "end": 54
                       }
                     },
-                    "member": "b"
+                    "member": {
+                      "kind": {
+                        "Identifier": "b"
+                      },
+                      "span": {
+                        "start": 56,
+                        "end": 58
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -154,7 +170,15 @@ $a['b']::c();
                               "end": 63
                             }
                           },
-                          "member": "b"
+                          "member": {
+                            "kind": {
+                              "Identifier": "b"
+                            },
+                            "span": {
+                              "start": 65,
+                              "end": 67
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -215,7 +239,15 @@ $a['b']::c();
                                     "end": 77
                                   }
                                 },
-                                "member": "b"
+                                "member": {
+                                  "kind": {
+                                    "Identifier": "b"
+                                  },
+                                  "span": {
+                                    "start": 79,
+                                    "end": 81
+                                  }
+                                }
                               }
                             },
                             "span": {
@@ -286,7 +318,15 @@ $a['b']::c();
                         "end": 120
                       }
                     },
-                    "method": "b",
+                    "method": {
+                      "kind": {
+                        "Identifier": "b"
+                      },
+                      "span": {
+                        "start": 122,
+                        "end": 123
+                      }
+                    },
                     "args": []
                   }
                 },
@@ -331,7 +371,15 @@ $a['b']::c();
                   "end": 164
                 }
               },
-              "method": "b",
+              "method": {
+                "kind": {
+                  "Identifier": "b"
+                },
+                "span": {
+                  "start": 166,
+                  "end": 167
+                }
+              },
               "args": []
             }
           },
@@ -360,7 +408,15 @@ $a['b']::c();
                   "end": 173
                 }
               },
-              "method": "b",
+              "method": {
+                "kind": {
+                  "Identifier": "b"
+                },
+                "span": {
+                  "start": 175,
+                  "end": 176
+                }
+              },
               "args": []
             }
           },
@@ -397,7 +453,15 @@ $a['b']::c();
                   "end": 185
                 }
               },
-              "method": "b",
+              "method": {
+                "kind": {
+                  "Identifier": "b"
+                },
+                "span": {
+                  "start": 188,
+                  "end": 189
+                }
+              },
               "args": []
             }
           },
@@ -445,7 +509,15 @@ $a['b']::c();
                   "end": 200
                 }
               },
-              "method": "c",
+              "method": {
+                "kind": {
+                  "Identifier": "c"
+                },
+                "span": {
+                  "start": 202,
+                  "end": 203
+                }
+              },
               "args": []
             }
           },

--- a/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/staticPropertyFetch.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/fetchAndCall/staticPropertyFetch.phpt
@@ -27,7 +27,15 @@ A::$b['c'];
                   "end": 36
                 }
               },
-              "member": "b"
+              "member": {
+                "kind": {
+                  "Identifier": "b"
+                },
+                "span": {
+                  "start": 38,
+                  "end": 40
+                }
+              }
             }
           },
           "span": {
@@ -146,7 +154,15 @@ A::$b['c'];
                         "end": 79
                       }
                     },
-                    "member": "b"
+                    "member": {
+                      "kind": {
+                        "Identifier": "b"
+                      },
+                      "span": {
+                        "start": 81,
+                        "end": 83
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/firstClassCallables.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/firstClassCallables.phpt
@@ -98,7 +98,15 @@ function foo() {}
                       "end": 34
                     }
                   },
-                  "method": "foo"
+                  "method": {
+                    "kind": {
+                      "Identifier": "foo"
+                    },
+                    "span": {
+                      "start": 36,
+                      "end": 39
+                    }
+                  }
                 }
               }
             }

--- a/crates/php-parser/tests/fixtures/corpus/expr/match_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/match_3.phpt
@@ -49,7 +49,15 @@ $result = match ($operator) {
                                     "end": 55
                                   }
                                 },
-                                "member": "ADD"
+                                "member": {
+                                  "kind": {
+                                    "Identifier": "ADD"
+                                  },
+                                  "span": {
+                                    "start": 57,
+                                    "end": 60
+                                  }
+                                }
                               }
                             },
                             "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/new.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/new.phpt
@@ -207,7 +207,15 @@ new $a->b['c']();
                         "end": 81
                       }
                     },
-                    "member": "b"
+                    "member": {
+                      "kind": {
+                        "Identifier": "b"
+                      },
+                      "span": {
+                        "start": 83,
+                        "end": 85
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/newDeref.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/newDeref.phpt
@@ -141,7 +141,15 @@ new class {}();
                   "end": 44
                 }
               },
-              "member": "FOO"
+              "member": {
+                "kind": {
+                  "Identifier": "FOO"
+                },
+                "span": {
+                  "start": 46,
+                  "end": 49
+                }
+              }
             }
           },
           "span": {
@@ -180,7 +188,15 @@ new class {}();
                   "end": 58
                 }
               },
-              "method": "foo",
+              "method": {
+                "kind": {
+                  "Identifier": "foo"
+                },
+                "span": {
+                  "start": 60,
+                  "end": 63
+                }
+              },
               "args": []
             }
           },
@@ -220,7 +236,15 @@ new class {}();
                   "end": 74
                 }
               },
-              "member": "foo"
+              "member": {
+                "kind": {
+                  "Identifier": "foo"
+                },
+                "span": {
+                  "start": 76,
+                  "end": 80
+                }
+              }
             }
           },
           "span": {
@@ -473,7 +497,15 @@ new class {}();
                   "end": 158
                 }
               },
-              "member": "FOO"
+              "member": {
+                "kind": {
+                  "Identifier": "FOO"
+                },
+                "span": {
+                  "start": 160,
+                  "end": 163
+                }
+              }
             }
           },
           "span": {
@@ -523,7 +555,15 @@ new class {}();
                   "end": 177
                 }
               },
-              "method": "foo",
+              "method": {
+                "kind": {
+                  "Identifier": "foo"
+                },
+                "span": {
+                  "start": 179,
+                  "end": 182
+                }
+              },
               "args": []
             }
           },
@@ -574,7 +614,15 @@ new class {}();
                   "end": 198
                 }
               },
-              "member": "foo"
+              "member": {
+                "kind": {
+                  "Identifier": "foo"
+                },
+                "span": {
+                  "start": 200,
+                  "end": 204
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/trailingCommas.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/trailingCommas.phpt
@@ -163,7 +163,15 @@ isset($a, $b, );
                   "end": 46
                 }
               },
-              "method": "bar",
+              "method": {
+                "kind": {
+                  "Identifier": "bar"
+                },
+                "span": {
+                  "start": 48,
+                  "end": 51
+                }
+              },
               "args": [
                 {
                   "name": null,

--- a/crates/php-parser/tests/fixtures/corpus/expr/uvs/constDeref.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/uvs/constDeref.phpt
@@ -220,7 +220,15 @@ __FUNCIONT__->length();
                         "end": 51
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "kind": {
+                        "Identifier": "B"
+                      },
+                      "span": {
+                        "start": 53,
+                        "end": 54
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -273,7 +281,15 @@ __FUNCIONT__->length();
                                     "end": 60
                                   }
                                 },
-                                "member": "B"
+                                "member": {
+                                  "kind": {
+                                    "Identifier": "B"
+                                  },
+                                  "span": {
+                                    "start": 62,
+                                    "end": 63
+                                  }
+                                }
                               }
                             },
                             "span": {
@@ -352,7 +368,15 @@ __FUNCIONT__->length();
                         "end": 75
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "kind": {
+                        "Identifier": "B"
+                      },
+                      "span": {
+                        "start": 77,
+                        "end": 78
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -399,7 +423,15 @@ __FUNCIONT__->length();
                         "end": 89
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "kind": {
+                        "Identifier": "B"
+                      },
+                      "span": {
+                        "start": 91,
+                        "end": 92
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -447,7 +479,15 @@ __FUNCIONT__->length();
                         "end": 105
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "kind": {
+                        "Identifier": "B"
+                      },
+                      "span": {
+                        "start": 107,
+                        "end": 108
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -455,7 +495,15 @@ __FUNCIONT__->length();
                   "end": 108
                 }
               },
-              "member": "C"
+              "member": {
+                "kind": {
+                  "Identifier": "C"
+                },
+                "span": {
+                  "start": 110,
+                  "end": 111
+                }
+              }
             }
           },
           "span": {
@@ -486,7 +534,15 @@ __FUNCIONT__->length();
                         "end": 114
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "kind": {
+                        "Identifier": "B"
+                      },
+                      "span": {
+                        "start": 116,
+                        "end": 117
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -494,7 +550,15 @@ __FUNCIONT__->length();
                   "end": 117
                 }
               },
-              "member": "c"
+              "member": {
+                "kind": {
+                  "Identifier": "c"
+                },
+                "span": {
+                  "start": 119,
+                  "end": 121
+                }
+              }
             }
           },
           "span": {
@@ -525,7 +589,15 @@ __FUNCIONT__->length();
                         "end": 124
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "kind": {
+                        "Identifier": "B"
+                      },
+                      "span": {
+                        "start": 126,
+                        "end": 127
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -533,7 +605,15 @@ __FUNCIONT__->length();
                   "end": 127
                 }
               },
-              "method": "c",
+              "method": {
+                "kind": {
+                  "Identifier": "c"
+                },
+                "span": {
+                  "start": 129,
+                  "end": 130
+                }
+              },
               "args": []
             }
           },

--- a/crates/php-parser/tests/fixtures/corpus/expr/uvs/new.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/uvs/new.phpt
@@ -156,7 +156,15 @@ new $weird[0]->foo::$className;
                   "end": 76
                 }
               },
-              "member": "className"
+              "member": {
+                "kind": {
+                  "Identifier": "className"
+                },
+                "span": {
+                  "start": 78,
+                  "end": 88
+                }
+              }
             }
           },
           "span": {
@@ -195,7 +203,15 @@ new $weird[0]->foo::$className;
                   "end": 99
                 }
               },
-              "member": "className"
+              "member": {
+                "kind": {
+                  "Identifier": "className"
+                },
+                "span": {
+                  "start": 101,
+                  "end": 111
+                }
+              }
             }
           },
           "span": {
@@ -272,7 +288,15 @@ new $weird[0]->foo::$className;
                   "end": 131
                 }
               },
-              "member": "className"
+              "member": {
+                "kind": {
+                  "Identifier": "className"
+                },
+                "span": {
+                  "start": 133,
+                  "end": 143
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/corpus/expr/uvs/staticProperty.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/uvs/staticProperty.phpt
@@ -25,7 +25,15 @@ A::$A::$b;
                   "end": 7
                 }
               },
-              "member": "b"
+              "member": {
+                "kind": {
+                  "Identifier": "b"
+                },
+                "span": {
+                  "start": 9,
+                  "end": 11
+                }
+              }
             }
           },
           "span": {
@@ -53,7 +61,15 @@ A::$A::$b;
                   "end": 15
                 }
               },
-              "member": "b"
+              "member": {
+                "kind": {
+                  "Identifier": "b"
+                },
+                "span": {
+                  "start": 17,
+                  "end": 19
+                }
+              }
             }
           },
           "span": {
@@ -81,7 +97,15 @@ A::$A::$b;
                   "end": 24
                 }
               },
-              "member": "b"
+              "member": {
+                "kind": {
+                  "Identifier": "b"
+                },
+                "span": {
+                  "start": 26,
+                  "end": 28
+                }
+              }
             }
           },
           "span": {
@@ -137,7 +161,15 @@ A::$A::$b;
                   "end": 40
                 }
               },
-              "member": "b"
+              "member": {
+                "kind": {
+                  "Identifier": "b"
+                },
+                "span": {
+                  "start": 42,
+                  "end": 44
+                }
+              }
             }
           },
           "span": {
@@ -184,7 +216,15 @@ A::$A::$b;
                   "end": 52
                 }
               },
-              "member": "b"
+              "member": {
+                "kind": {
+                  "Identifier": "b"
+                },
+                "span": {
+                  "start": 54,
+                  "end": 56
+                }
+              }
             }
           },
           "span": {
@@ -322,7 +362,15 @@ A::$A::$b;
                         "end": 78
                       }
                     },
-                    "member": "A"
+                    "member": {
+                      "kind": {
+                        "Identifier": "A"
+                      },
+                      "span": {
+                        "start": 80,
+                        "end": 82
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -330,7 +378,15 @@ A::$A::$b;
                   "end": 82
                 }
               },
-              "member": "b"
+              "member": {
+                "kind": {
+                  "Identifier": "b"
+                },
+                "span": {
+                  "start": 84,
+                  "end": 86
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/corpus/semiReserved.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/semiReserved.phpt
@@ -546,7 +546,15 @@ class Foo {
                   "end": 441
                 }
               },
-              "method": "list",
+              "method": {
+                "kind": {
+                  "Identifier": "list"
+                },
+                "span": {
+                  "start": 443,
+                  "end": 447
+                }
+              },
               "args": []
             }
           },
@@ -575,7 +583,15 @@ class Foo {
                   "end": 455
                 }
               },
-              "method": "protected",
+              "method": {
+                "kind": {
+                  "Identifier": "protected"
+                },
+                "span": {
+                  "start": 457,
+                  "end": 466
+                }
+              },
               "args": []
             }
           },
@@ -676,7 +692,15 @@ class Foo {
                   "end": 500
                 }
               },
-              "member": "TRAIT"
+              "member": {
+                "kind": {
+                  "Identifier": "TRAIT"
+                },
+                "span": {
+                  "start": 502,
+                  "end": 507
+                }
+              }
             }
           },
           "span": {
@@ -704,7 +728,15 @@ class Foo {
                   "end": 513
                 }
               },
-              "member": "FINAL"
+              "member": {
+                "kind": {
+                  "Identifier": "FINAL"
+                },
+                "span": {
+                  "start": 515,
+                  "end": 520
+                }
+              }
             }
           },
           "span": {
@@ -769,7 +801,16 @@ class Foo {
                               "end": 574
                             }
                           },
-                          "method": "catch",
+                          "method": {
+                            "parts": [
+                              "catch"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 576,
+                              "end": 581
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [
@@ -802,9 +843,27 @@ class Foo {
                               "end": 624
                             }
                           },
-                          "method": "list",
+                          "method": {
+                            "parts": [
+                              "list"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 626,
+                              "end": 630
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "foreach"
+                          "new_name": {
+                            "parts": [
+                              "foreach"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 634,
+                              "end": 641
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -825,9 +884,27 @@ class Foo {
                               "end": 657
                             }
                           },
-                          "method": "throw",
+                          "method": {
+                            "parts": [
+                              "throw"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 659,
+                              "end": 664
+                            }
+                          },
                           "new_modifier": "Protected",
-                          "new_name": "public"
+                          "new_name": {
+                            "parts": [
+                              "public"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 678,
+                              "end": 684
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -848,7 +925,16 @@ class Foo {
                               "end": 700
                             }
                           },
-                          "method": "self",
+                          "method": {
+                            "parts": [
+                              "self"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 702,
+                              "end": 706
+                            }
+                          },
                           "new_modifier": "Protected",
                           "new_name": null
                         }
@@ -862,9 +948,27 @@ class Foo {
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "exit",
+                          "method": {
+                            "parts": [
+                              "exit"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 729,
+                              "end": 733
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "die"
+                          "new_name": {
+                            "parts": [
+                              "die"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 737,
+                              "end": 740
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -885,9 +989,27 @@ class Foo {
                               "end": 757
                             }
                           },
-                          "method": "exit",
+                          "method": {
+                            "parts": [
+                              "exit"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 759,
+                              "end": 763
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "bye"
+                          "new_name": {
+                            "parts": [
+                              "bye"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 767,
+                              "end": 770
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -908,9 +1030,27 @@ class Foo {
                               "end": 796
                             }
                           },
-                          "method": "exit",
+                          "method": {
+                            "parts": [
+                              "exit"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 798,
+                              "end": 802
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "byebye"
+                          "new_name": {
+                            "parts": [
+                              "byebye"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 806,
+                              "end": 812
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -931,7 +1071,16 @@ class Foo {
                               "end": 828
                             }
                           },
-                          "method": "catch",
+                          "method": {
+                            "parts": [
+                              "catch"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 899,
+                              "end": 904
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [

--- a/crates/php-parser/tests/fixtures/corpus/stmt/attributes.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/attributes.phpt
@@ -124,7 +124,16 @@ $b = #[A13] static fn() => 0;
               },
               "args": [
                 {
-                  "name": "x",
+                  "name": {
+                    "parts": [
+                      "x"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 46,
+                      "end": 47
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/shortEchoAsIdentifier.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/shortEchoAsIdentifier.phpt
@@ -49,9 +49,27 @@ expected '::' or 'as', found ';'
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "x",
+                          "method": {
+                            "parts": [
+                              "x"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 36,
+                              "end": 37
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "y"
+                          "new_name": {
+                            "parts": [
+                              "y"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 41,
+                              "end": 42
+                            }
+                          }
                         }
                       },
                       "span": {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/trait.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/trait.phpt
@@ -111,9 +111,27 @@ class B {
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "a",
+                          "method": {
+                            "parts": [
+                              "a"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 88,
+                              "end": 89
+                            }
+                          },
                           "new_modifier": "Protected",
-                          "new_name": "b"
+                          "new_name": {
+                            "parts": [
+                              "b"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 103,
+                              "end": 104
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -125,9 +143,27 @@ class B {
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "c",
+                          "method": {
+                            "parts": [
+                              "c"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 114,
+                              "end": 115
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "d"
+                          "new_name": {
+                            "parts": [
+                              "d"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 119,
+                              "end": 120
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -139,7 +175,16 @@ class B {
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "e",
+                          "method": {
+                            "parts": [
+                              "e"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 130,
+                              "end": 131
+                            }
+                          },
                           "new_modifier": "Private",
                           "new_name": null
                         }
@@ -206,7 +251,16 @@ class B {
                               "end": 177
                             }
                           },
-                          "method": "a",
+                          "method": {
+                            "parts": [
+                              "a"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 179,
+                              "end": 180
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [
@@ -249,9 +303,27 @@ class B {
                               "end": 206
                             }
                           },
-                          "method": "b",
+                          "method": {
+                            "parts": [
+                              "b"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 208,
+                              "end": 209
+                            }
+                          },
                           "new_modifier": "Protected",
-                          "new_name": "c"
+                          "new_name": {
+                            "parts": [
+                              "c"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 223,
+                              "end": 224
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -272,9 +344,27 @@ class B {
                               "end": 235
                             }
                           },
-                          "method": "d",
+                          "method": {
+                            "parts": [
+                              "d"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 237,
+                              "end": 238
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "e"
+                          "new_name": {
+                            "parts": [
+                              "e"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 242,
+                              "end": 243
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -295,7 +385,16 @@ class B {
                               "end": 254
                             }
                           },
-                          "method": "f",
+                          "method": {
+                            "parts": [
+                              "f"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 256,
+                              "end": 257
+                            }
+                          },
                           "new_modifier": "Private",
                           "new_name": null
                         }

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/clone_function.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/clone_function.phpt
@@ -442,7 +442,16 @@ cannot use positional argument after named argument
               },
               "args": [
                 {
-                  "name": "object",
+                  "name": {
+                    "parts": [
+                      "object"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 235,
+                      "end": 241
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"
@@ -460,7 +469,16 @@ cannot use positional argument after named argument
                   }
                 },
                 {
-                  "name": "withProperties",
+                  "name": {
+                    "parts": [
+                      "withProperties"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 247,
+                      "end": 261
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Array": [
@@ -576,7 +594,16 @@ cannot use positional argument after named argument
                   }
                 },
                 {
-                  "name": "withProperties",
+                  "name": {
+                    "parts": [
+                      "withProperties"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 308,
+                      "end": 322
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Array": [
@@ -674,7 +701,16 @@ cannot use positional argument after named argument
               },
               "args": [
                 {
-                  "name": "object",
+                  "name": {
+                    "parts": [
+                      "object"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 365,
+                      "end": 371
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"
@@ -721,7 +757,16 @@ cannot use positional argument after named argument
               },
               "args": [
                 {
-                  "name": "object",
+                  "name": {
+                    "parts": [
+                      "object"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 384,
+                      "end": 390
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "x"

--- a/crates/php-parser/tests/fixtures/corpus/stmt/function/defaultValues.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/function/defaultValues.phpt
@@ -81,7 +81,15 @@ function a(
                         "end": 60
                       }
                     },
-                    "member": "B"
+                    "member": {
+                      "kind": {
+                        "Identifier": "B"
+                      },
+                      "span": {
+                        "start": 62,
+                        "end": 63
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/enum_multiple_interfaces_const_method.phpt
+++ b/crates/php-parser/tests/fixtures/enum_multiple_interfaces_const_method.phpt
@@ -115,7 +115,15 @@ enum Status: string implements Loggable, Serializable {
                             "end": 147
                           }
                         },
-                        "member": "Active"
+                        "member": {
+                          "kind": {
+                            "Identifier": "Active"
+                          },
+                          "span": {
+                            "start": 149,
+                            "end": 155
+                          }
+                        }
                       }
                     },
                     "span": {
@@ -261,7 +269,15 @@ enum Status: string implements Loggable, Serializable {
                                         "end": 300
                                       }
                                     },
-                                    "member": "Active"
+                                    "member": {
+                                      "kind": {
+                                        "Identifier": "Active"
+                                      },
+                                      "span": {
+                                        "start": 302,
+                                        "end": 308
+                                      }
+                                    }
                                   }
                                 },
                                 "span": {

--- a/crates/php-parser/tests/fixtures/enum_with_methods.phpt
+++ b/crates/php-parser/tests/fixtures/enum_with_methods.phpt
@@ -211,7 +211,15 @@ enum Suit: string implements HasColor {
                                               "end": 247
                                             }
                                           },
-                                          "member": "Hearts"
+                                          "member": {
+                                            "kind": {
+                                              "Identifier": "Hearts"
+                                            },
+                                            "span": {
+                                              "start": 249,
+                                              "end": 255
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {
@@ -231,7 +239,15 @@ enum Suit: string implements HasColor {
                                               "end": 261
                                             }
                                           },
-                                          "member": "Diamonds"
+                                          "member": {
+                                            "kind": {
+                                              "Identifier": "Diamonds"
+                                            },
+                                            "span": {
+                                              "start": 263,
+                                              "end": 271
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {
@@ -268,7 +284,15 @@ enum Suit: string implements HasColor {
                                               "end": 298
                                             }
                                           },
-                                          "member": "Clubs"
+                                          "member": {
+                                            "kind": {
+                                              "Identifier": "Clubs"
+                                            },
+                                            "span": {
+                                              "start": 300,
+                                              "end": 305
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {
@@ -288,7 +312,15 @@ enum Suit: string implements HasColor {
                                               "end": 311
                                             }
                                           },
-                                          "member": "Spades"
+                                          "member": {
+                                            "kind": {
+                                              "Identifier": "Spades"
+                                            },
+                                            "span": {
+                                              "start": 313,
+                                              "end": 319
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {

--- a/crates/php-parser/tests/fixtures/errors/enum_error_then_valid_function.phpt
+++ b/crates/php-parser/tests/fixtures/errors/enum_error_then_valid_function.phpt
@@ -60,7 +60,15 @@ expected expression
                           "end": 75
                         }
                       },
-                      "member": "Active"
+                      "member": {
+                        "kind": {
+                          "Identifier": "Active"
+                        },
+                        "span": {
+                          "start": 77,
+                          "end": 83
+                        }
+                      }
                     }
                   },
                   "span": {

--- a/crates/php-parser/tests/fixtures/errors/named_arg_positional_after_named.phpt
+++ b/crates/php-parser/tests/fixtures/errors/named_arg_positional_after_named.phpt
@@ -21,7 +21,16 @@ cannot use positional argument after named argument
               },
               "args": [
                 {
-                  "name": "a",
+                  "name": {
+                    "parts": [
+                      "a"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 11,
+                      "end": 12
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1

--- a/crates/php-parser/tests/fixtures/errors/named_arg_spread_after_named.phpt
+++ b/crates/php-parser/tests/fixtures/errors/named_arg_spread_after_named.phpt
@@ -21,7 +21,16 @@ cannot use positional argument after named argument
               },
               "args": [
                 {
-                  "name": "a",
+                  "name": {
+                    "parts": [
+                      "a"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 11,
+                      "end": 12
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1

--- a/crates/php-parser/tests/fixtures/errors/trait_unclosed_brace.phpt
+++ b/crates/php-parser/tests/fixtures/errors/trait_unclosed_brace.phpt
@@ -50,9 +50,27 @@ expected '}', found end of file
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "m",
+                          "method": {
+                            "parts": [
+                              "m"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 35,
+                              "end": 36
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "x"
+                          "new_name": {
+                            "parts": [
+                              "x"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 40,
+                              "end": 41
+                            }
+                          }
                         }
                       },
                       "span": {

--- a/crates/php-parser/tests/fixtures/first_class_callable.phpt
+++ b/crates/php-parser/tests/fixtures/first_class_callable.phpt
@@ -144,7 +144,15 @@ $fn = Foo::bar(...);
                             "end": 59
                           }
                         },
-                        "method": "bar"
+                        "method": {
+                          "kind": {
+                            "Identifier": "bar"
+                          },
+                          "span": {
+                            "start": 61,
+                            "end": 64
+                          }
+                        }
                       }
                     }
                   }

--- a/crates/php-parser/tests/fixtures/first_class_callable_variants.phpt
+++ b/crates/php-parser/tests/fixtures/first_class_callable_variants.phpt
@@ -145,7 +145,15 @@ $e = $obj->$dynamic(...);
                             "end": 56
                           }
                         },
-                        "method": "bar"
+                        "method": {
+                          "kind": {
+                            "Identifier": "bar"
+                          },
+                          "span": {
+                            "start": 58,
+                            "end": 61
+                          }
+                        }
                       }
                     }
                   }

--- a/crates/php-parser/tests/fixtures/fully_qualified_names.phpt
+++ b/crates/php-parser/tests/fixtures/fully_qualified_names.phpt
@@ -87,7 +87,15 @@ $x = \strlen('hello');
                   "end": 56
                 }
               },
-              "method": "log",
+              "method": {
+                "kind": {
+                  "Identifier": "log"
+                },
+                "span": {
+                  "start": 58,
+                  "end": 61
+                }
+              },
               "args": [
                 {
                   "name": null,

--- a/crates/php-parser/tests/fixtures/isset_complex.phpt
+++ b/crates/php-parser/tests/fixtures/isset_complex.phpt
@@ -76,7 +76,15 @@
                         "end": 35
                       }
                     },
-                    "member": "static"
+                    "member": {
+                      "kind": {
+                        "Identifier": "static"
+                      },
+                      "span": {
+                        "start": 37,
+                        "end": 44
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/mixed_named_positional_args.phpt
+++ b/crates/php-parser/tests/fixtures/mixed_named_positional_args.phpt
@@ -55,7 +55,16 @@
                   }
                 },
                 {
-                  "name": "name",
+                  "name": {
+                    "parts": [
+                      "name"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 20,
+                      "end": 24
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "val"
@@ -73,7 +82,16 @@
                   }
                 },
                 {
-                  "name": "count",
+                  "name": {
+                    "parts": [
+                      "count"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 32,
+                      "end": 37
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 5

--- a/crates/php-parser/tests/fixtures/named_args_duplicate.phpt
+++ b/crates/php-parser/tests/fixtures/named_args_duplicate.phpt
@@ -19,7 +19,16 @@
               },
               "args": [
                 {
-                  "name": "a",
+                  "name": {
+                    "parts": [
+                      "a"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 11,
+                      "end": 12
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1
@@ -37,7 +46,16 @@
                   }
                 },
                 {
-                  "name": "a",
+                  "name": {
+                    "parts": [
+                      "a"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 17,
+                      "end": 18
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 2

--- a/crates/php-parser/tests/fixtures/named_args_edge_cases.phpt
+++ b/crates/php-parser/tests/fixtures/named_args_edge_cases.phpt
@@ -23,7 +23,16 @@ array_map(callback: fn($x) => $x * 2, array: $arr);
               },
               "args": [
                 {
-                  "name": "a",
+                  "name": {
+                    "parts": [
+                      "a"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 10,
+                      "end": 11
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1
@@ -41,7 +50,16 @@ array_map(callback: fn($x) => $x * 2, array: $arr);
                   }
                 },
                 {
-                  "name": "b",
+                  "name": {
+                    "parts": [
+                      "b"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 16,
+                      "end": 17
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 2
@@ -59,7 +77,16 @@ array_map(callback: fn($x) => $x * 2, array: $arr);
                   }
                 },
                 {
-                  "name": "c",
+                  "name": {
+                    "parts": [
+                      "c"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 22,
+                      "end": 23
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 3
@@ -124,7 +151,16 @@ array_map(callback: fn($x) => $x * 2, array: $arr);
                   }
                 },
                 {
-                  "name": "extra",
+                  "name": {
+                    "parts": [
+                      "extra"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 43,
+                      "end": 48
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Bool": true
@@ -207,7 +243,16 @@ array_map(callback: fn($x) => $x * 2, array: $arr);
                   }
                 },
                 {
-                  "name": "name",
+                  "name": {
+                    "parts": [
+                      "name"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 67,
+                      "end": 71
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "test"
@@ -254,7 +299,16 @@ array_map(callback: fn($x) => $x * 2, array: $arr);
               },
               "args": [
                 {
-                  "name": "callback",
+                  "name": {
+                    "parts": [
+                      "callback"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 92,
+                      "end": 100
+                    }
+                  },
                   "value": {
                     "kind": {
                       "ArrowFunction": {
@@ -324,7 +378,16 @@ array_map(callback: fn($x) => $x * 2, array: $arr);
                   }
                 },
                 {
-                  "name": "array",
+                  "name": {
+                    "parts": [
+                      "array"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 120,
+                      "end": 125
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "arr"

--- a/crates/php-parser/tests/fixtures/named_args_keywords.phpt
+++ b/crates/php-parser/tests/fixtures/named_args_keywords.phpt
@@ -21,7 +21,16 @@ foo(class: 'MyClass', static: true, match: 'yes');
               },
               "args": [
                 {
-                  "name": "array",
+                  "name": {
+                    "parts": [
+                      "array"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 18,
+                      "end": 23
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "arr"
@@ -39,7 +48,16 @@ foo(class: 'MyClass', static: true, match: 'yes');
                   }
                 },
                 {
-                  "name": "offset",
+                  "name": {
+                    "parts": [
+                      "offset"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 31,
+                      "end": 37
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1
@@ -57,7 +75,16 @@ foo(class: 'MyClass', static: true, match: 'yes');
                   }
                 },
                 {
-                  "name": "length",
+                  "name": {
+                    "parts": [
+                      "length"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 42,
+                      "end": 48
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 2
@@ -104,7 +131,16 @@ foo(class: 'MyClass', static: true, match: 'yes');
               },
               "args": [
                 {
-                  "name": "class",
+                  "name": {
+                    "parts": [
+                      "class"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 58,
+                      "end": 63
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "MyClass"
@@ -122,7 +158,16 @@ foo(class: 'MyClass', static: true, match: 'yes');
                   }
                 },
                 {
-                  "name": "static",
+                  "name": {
+                    "parts": [
+                      "static"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 76,
+                      "end": 82
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Bool": true
@@ -140,7 +185,16 @@ foo(class: 'MyClass', static: true, match: 'yes');
                   }
                 },
                 {
-                  "name": "match",
+                  "name": {
+                    "parts": [
+                      "match"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 90,
+                      "end": 95
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "yes"

--- a/crates/php-parser/tests/fixtures/named_args_mixed_with_spread.phpt
+++ b/crates/php-parser/tests/fixtures/named_args_mixed_with_spread.phpt
@@ -21,7 +21,16 @@ cannot use positional argument after named argument
               },
               "args": [
                 {
-                  "name": "a",
+                  "name": {
+                    "parts": [
+                      "a"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 11,
+                      "end": 12
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Int": 1

--- a/crates/php-parser/tests/fixtures/named_arguments.phpt
+++ b/crates/php-parser/tests/fixtures/named_arguments.phpt
@@ -19,7 +19,16 @@
               },
               "args": [
                 {
-                  "name": "string",
+                  "name": {
+                    "parts": [
+                      "string"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 23,
+                      "end": 29
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Variable": "str"
@@ -37,7 +46,16 @@
                   }
                 },
                 {
-                  "name": "flags",
+                  "name": {
+                    "parts": [
+                      "flags"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 37,
+                      "end": 42
+                    }
+                  },
                   "value": {
                     "kind": {
                       "Identifier": "ENT_QUOTES"
@@ -55,7 +73,16 @@
                   }
                 },
                 {
-                  "name": "encoding",
+                  "name": {
+                    "parts": [
+                      "encoding"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 56,
+                      "end": 64
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "UTF-8"

--- a/crates/php-parser/tests/fixtures/new_in_complex_initializers.phpt
+++ b/crates/php-parser/tests/fixtures/new_in_complex_initializers.phpt
@@ -140,7 +140,16 @@ class Config {
                     },
                     "args": [
                       {
-                        "name": "name",
+                        "name": {
+                          "parts": [
+                            "name"
+                          ],
+                          "kind": "Unqualified",
+                          "span": {
+                            "start": 86,
+                            "end": 90
+                          }
+                        },
                         "value": {
                           "kind": {
                             "String": "x"
@@ -220,7 +229,16 @@ class Config {
                         },
                         "args": [
                           {
-                            "name": "debug",
+                            "name": {
+                              "parts": [
+                                "debug"
+                              ],
+                              "kind": "Unqualified",
+                              "span": {
+                                "start": 151,
+                                "end": 156
+                              }
+                            },
                             "value": {
                               "kind": {
                                 "Bool": false

--- a/crates/php-parser/tests/fixtures/realistic_controller.phpt
+++ b/crates/php-parser/tests/fixtures/realistic_controller.phpt
@@ -410,7 +410,15 @@ class UserController extends BaseController implements JsonResponder
                                                       "end": 384
                                                     }
                                                   },
-                                                  "method": "find",
+                                                  "method": {
+                                                    "kind": {
+                                                      "Identifier": "find"
+                                                    },
+                                                    "span": {
+                                                      "start": 386,
+                                                      "end": 390
+                                                    }
+                                                  },
                                                   "args": [
                                                     {
                                                       "name": null,
@@ -1045,7 +1053,15 @@ class UserController extends BaseController implements JsonResponder
                                         "end": 1027
                                       }
                                     },
-                                    "method": "all",
+                                    "method": {
+                                      "kind": {
+                                        "Identifier": "all"
+                                      },
+                                      "span": {
+                                        "start": 1029,
+                                        "end": 1032
+                                      }
+                                    },
                                     "args": []
                                   }
                                 },

--- a/crates/php-parser/tests/fixtures/realistic_enum_service.phpt
+++ b/crates/php-parser/tests/fixtures/realistic_enum_service.phpt
@@ -229,7 +229,15 @@ class TaskService
                                               "end": 224
                                             }
                                           },
-                                          "member": "Low"
+                                          "member": {
+                                            "kind": {
+                                              "Identifier": "Low"
+                                            },
+                                            "span": {
+                                              "start": 226,
+                                              "end": 229
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {
@@ -266,7 +274,15 @@ class TaskService
                                               "end": 269
                                             }
                                           },
-                                          "member": "Medium"
+                                          "member": {
+                                            "kind": {
+                                              "Identifier": "Medium"
+                                            },
+                                            "span": {
+                                              "start": 271,
+                                              "end": 277
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {
@@ -303,7 +319,15 @@ class TaskService
                                               "end": 320
                                             }
                                           },
-                                          "member": "High"
+                                          "member": {
+                                            "kind": {
+                                              "Identifier": "High"
+                                            },
+                                            "span": {
+                                              "start": 322,
+                                              "end": 326
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {
@@ -340,7 +364,15 @@ class TaskService
                                               "end": 367
                                             }
                                           },
-                                          "member": "Critical"
+                                          "member": {
+                                            "kind": {
+                                              "Identifier": "Critical"
+                                            },
+                                            "span": {
+                                              "start": 369,
+                                              "end": 377
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {
@@ -487,7 +519,15 @@ class TaskService
                                   "end": 533
                                 }
                               },
-                              "member": "Critical"
+                              "member": {
+                                "kind": {
+                                  "Identifier": "Critical"
+                                },
+                                "span": {
+                                  "start": 535,
+                                  "end": 543
+                                }
+                              }
                             }
                           },
                           "span": {
@@ -687,7 +727,15 @@ class TaskService
                                         "end": 706
                                       }
                                     },
-                                    "member": "counter"
+                                    "member": {
+                                      "kind": {
+                                        "Identifier": "counter"
+                                      },
+                                      "span": {
+                                        "start": 708,
+                                        "end": 716
+                                      }
+                                    }
                                   }
                                 },
                                 "span": {
@@ -736,7 +784,15 @@ class TaskService
                                         "end": 738
                                       }
                                     },
-                                    "member": "counter"
+                                    "member": {
+                                      "kind": {
+                                        "Identifier": "counter"
+                                      },
+                                      "span": {
+                                        "start": 740,
+                                        "end": 748
+                                      }
+                                    }
                                   }
                                 },
                                 "span": {
@@ -1156,7 +1212,15 @@ class TaskService
                                                       "end": 1044
                                                     }
                                                   },
-                                                  "member": "Critical"
+                                                  "member": {
+                                                    "kind": {
+                                                      "Identifier": "Critical"
+                                                    },
+                                                    "span": {
+                                                      "start": 1046,
+                                                      "end": 1054
+                                                    }
+                                                  }
                                                 }
                                               },
                                               "span": {
@@ -1197,7 +1261,15 @@ class TaskService
                                                       "end": 1080
                                                     }
                                                   },
-                                                  "member": "High"
+                                                  "member": {
+                                                    "kind": {
+                                                      "Identifier": "High"
+                                                    },
+                                                    "span": {
+                                                      "start": 1082,
+                                                      "end": 1086
+                                                    }
+                                                  }
                                                 }
                                               },
                                               "span": {

--- a/crates/php-parser/tests/fixtures/realistic_middleware.phpt
+++ b/crates/php-parser/tests/fixtures/realistic_middleware.phpt
@@ -733,7 +733,15 @@ class RateLimitMiddleware implements MiddlewareInterface
                                     "end": 642
                                   }
                                 },
-                                "member": "excludedPaths"
+                                "member": {
+                                  "kind": {
+                                    "Identifier": "excludedPaths"
+                                  },
+                                  "span": {
+                                    "start": 644,
+                                    "end": 658
+                                  }
+                                }
                               }
                             },
                             "span": {
@@ -2005,7 +2013,15 @@ class RateLimitMiddleware implements MiddlewareInterface
                                         "end": 1643
                                       }
                                     },
-                                    "member": "excludedPaths"
+                                    "member": {
+                                      "kind": {
+                                        "Identifier": "excludedPaths"
+                                      },
+                                      "span": {
+                                        "start": 1645,
+                                        "end": 1659
+                                      }
+                                    }
                                   }
                                 },
                                 "span": {
@@ -2031,7 +2047,15 @@ class RateLimitMiddleware implements MiddlewareInterface
                                                 "end": 1670
                                               }
                                             },
-                                            "member": "excludedPaths"
+                                            "member": {
+                                              "kind": {
+                                                "Identifier": "excludedPaths"
+                                              },
+                                              "span": {
+                                                "start": 1672,
+                                                "end": 1686
+                                              }
+                                            }
                                           }
                                         },
                                         "span": {
@@ -2483,7 +2507,15 @@ class RateLimitMiddleware implements MiddlewareInterface
                                               "end": 2052
                                             }
                                           },
-                                          "member": "MAX_REQUESTS"
+                                          "member": {
+                                            "kind": {
+                                              "Identifier": "MAX_REQUESTS"
+                                            },
+                                            "span": {
+                                              "start": 2054,
+                                              "end": 2066
+                                            }
+                                          }
                                         }
                                       },
                                       "span": {

--- a/crates/php-parser/tests/fixtures/realistic_repository.phpt
+++ b/crates/php-parser/tests/fixtures/realistic_repository.phpt
@@ -1284,7 +1284,16 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                               },
                               "args": [
                                 {
-                                  "name": "id",
+                                  "name": {
+                                    "parts": [
+                                      "id"
+                                    ],
+                                    "kind": "Unqualified",
+                                    "span": {
+                                      "start": 1138,
+                                      "end": 1140
+                                    }
+                                  },
                                   "value": {
                                     "kind": {
                                       "Cast": [
@@ -1332,7 +1341,16 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                                   }
                                 },
                                 {
-                                  "name": "name",
+                                  "name": {
+                                    "parts": [
+                                      "name"
+                                    ],
+                                    "kind": "Unqualified",
+                                    "span": {
+                                      "start": 1171,
+                                      "end": 1175
+                                    }
+                                  },
                                   "value": {
                                     "kind": {
                                       "ArrayAccess": {
@@ -1369,7 +1387,16 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                                   }
                                 },
                                 {
-                                  "name": "email",
+                                  "name": {
+                                    "parts": [
+                                      "email"
+                                    ],
+                                    "kind": "Unqualified",
+                                    "span": {
+                                      "start": 1203,
+                                      "end": 1208
+                                    }
+                                  },
                                   "value": {
                                     "kind": {
                                       "NullCoalesce": {
@@ -1533,7 +1560,15 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                                         "end": 1310
                                       }
                                     },
-                                    "member": "queryCount"
+                                    "member": {
+                                      "kind": {
+                                        "Identifier": "queryCount"
+                                      },
+                                      "span": {
+                                        "start": 1312,
+                                        "end": 1323
+                                      }
+                                    }
                                   }
                                 },
                                 "span": {
@@ -1835,7 +1870,15 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                                         "end": 1525
                                       }
                                     },
-                                    "member": "queryCount"
+                                    "member": {
+                                      "kind": {
+                                        "Identifier": "queryCount"
+                                      },
+                                      "span": {
+                                        "start": 1527,
+                                        "end": 1538
+                                      }
+                                    }
                                   }
                                 },
                                 "span": {
@@ -3430,7 +3473,15 @@ class UserRepository extends AbstractRepository implements RepositoryInterface
                                   "end": 2694
                                 }
                               },
-                              "member": "queryCount"
+                              "member": {
+                                "kind": {
+                                  "Identifier": "queryCount"
+                                },
+                                "span": {
+                                  "start": 2696,
+                                  "end": 2707
+                                }
+                              }
                             }
                           },
                           "span": {

--- a/crates/php-parser/tests/fixtures/spread_then_named_arg.phpt
+++ b/crates/php-parser/tests/fixtures/spread_then_named_arg.phpt
@@ -37,7 +37,16 @@
                   }
                 },
                 {
-                  "name": "last",
+                  "name": {
+                    "parts": [
+                      "last"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 21,
+                      "end": 25
+                    }
+                  },
                   "value": {
                     "kind": {
                       "String": "end"

--- a/crates/php-parser/tests/fixtures/static_access.phpt
+++ b/crates/php-parser/tests/fixtures/static_access.phpt
@@ -23,7 +23,15 @@ static::factory();
                   "end": 9
                 }
               },
-              "member": "BAR"
+              "member": {
+                "kind": {
+                  "Identifier": "BAR"
+                },
+                "span": {
+                  "start": 11,
+                  "end": 14
+                }
+              }
             }
           },
           "span": {
@@ -51,7 +59,15 @@ static::factory();
                   "end": 19
                 }
               },
-              "member": "instance"
+              "member": {
+                "kind": {
+                  "Identifier": "instance"
+                },
+                "span": {
+                  "start": 21,
+                  "end": 30
+                }
+              }
             }
           },
           "span": {
@@ -79,7 +95,15 @@ static::factory();
                   "end": 35
                 }
               },
-              "method": "create",
+              "method": {
+                "kind": {
+                  "Identifier": "create"
+                },
+                "span": {
+                  "start": 37,
+                  "end": 43
+                }
+              },
               "args": []
             }
           },
@@ -108,7 +132,15 @@ static::factory();
                   "end": 51
                 }
               },
-              "member": "x"
+              "member": {
+                "kind": {
+                  "Identifier": "x"
+                },
+                "span": {
+                  "start": 53,
+                  "end": 55
+                }
+              }
             }
           },
           "span": {
@@ -136,7 +168,15 @@ static::factory();
                   "end": 63
                 }
               },
-              "method": "__construct",
+              "method": {
+                "kind": {
+                  "Identifier": "__construct"
+                },
+                "span": {
+                  "start": 65,
+                  "end": 76
+                }
+              },
               "args": []
             }
           },
@@ -165,7 +205,15 @@ static::factory();
                   "end": 86
                 }
               },
-              "method": "factory",
+              "method": {
+                "kind": {
+                  "Identifier": "factory"
+                },
+                "span": {
+                  "start": 88,
+                  "end": 95
+                }
+              },
               "args": []
             }
           },

--- a/crates/php-parser/tests/fixtures/static_double_colon_as_stmt.phpt
+++ b/crates/php-parser/tests/fixtures/static_double_colon_as_stmt.phpt
@@ -20,7 +20,15 @@ static::class;
                   "end": 12
                 }
               },
-              "member": "prop"
+              "member": {
+                "kind": {
+                  "Identifier": "prop"
+                },
+                "span": {
+                  "start": 14,
+                  "end": 19
+                }
+              }
             }
           },
           "span": {
@@ -48,7 +56,15 @@ static::class;
                   "end": 27
                 }
               },
-              "method": "method",
+              "method": {
+                "kind": {
+                  "Identifier": "method"
+                },
+                "span": {
+                  "start": 29,
+                  "end": 35
+                }
+              },
               "args": []
             }
           },
@@ -77,7 +93,15 @@ static::class;
                   "end": 45
                 }
               },
-              "member": "class"
+              "member": {
+                "kind": {
+                  "Identifier": "class"
+                },
+                "span": {
+                  "start": 47,
+                  "end": 52
+                }
+              }
             }
           },
           "span": {

--- a/crates/php-parser/tests/fixtures/static_method_callable_and_access.phpt
+++ b/crates/php-parser/tests/fixtures/static_method_callable_and_access.phpt
@@ -38,7 +38,15 @@ $f = self::$prop;
                             "end": 14
                           }
                         },
-                        "method": "bar"
+                        "method": {
+                          "kind": {
+                            "Identifier": "bar"
+                          },
+                          "span": {
+                            "start": 16,
+                            "end": 19
+                          }
+                        }
                       }
                     }
                   }
@@ -88,7 +96,15 @@ $f = self::$prop;
                         "end": 34
                       }
                     },
-                    "member": "prop"
+                    "member": {
+                      "kind": {
+                        "Identifier": "prop"
+                      },
+                      "span": {
+                        "start": 36,
+                        "end": 41
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -136,7 +152,15 @@ $f = self::$prop;
                         "end": 51
                       }
                     },
-                    "member": "CONST"
+                    "member": {
+                      "kind": {
+                        "Identifier": "CONST"
+                      },
+                      "span": {
+                        "start": 53,
+                        "end": 58
+                      }
+                    }
                   }
                 },
                 "span": {
@@ -184,7 +208,15 @@ $f = self::$prop;
                         "end": 71
                       }
                     },
-                    "method": "method",
+                    "method": {
+                      "kind": {
+                        "Identifier": "method"
+                      },
+                      "span": {
+                        "start": 73,
+                        "end": 79
+                      }
+                    },
                     "args": []
                   }
                 },
@@ -233,7 +265,15 @@ $f = self::$prop;
                         "end": 94
                       }
                     },
-                    "method": "method",
+                    "method": {
+                      "kind": {
+                        "Identifier": "method"
+                      },
+                      "span": {
+                        "start": 96,
+                        "end": 102
+                      }
+                    },
                     "args": []
                   }
                 },
@@ -282,7 +322,15 @@ $f = self::$prop;
                         "end": 115
                       }
                     },
-                    "member": "prop"
+                    "member": {
+                      "kind": {
+                        "Identifier": "prop"
+                      },
+                      "span": {
+                        "start": 117,
+                        "end": 122
+                      }
+                    }
                   }
                 },
                 "span": {

--- a/crates/php-parser/tests/fixtures/trait_conflict_resolution.phpt
+++ b/crates/php-parser/tests/fixtures/trait_conflict_resolution.phpt
@@ -64,7 +64,16 @@ class MyClass {
                               "end": 46
                             }
                           },
-                          "method": "foo",
+                          "method": {
+                            "parts": [
+                              "foo"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 48,
+                              "end": 51
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [
@@ -97,9 +106,27 @@ class MyClass {
                               "end": 74
                             }
                           },
-                          "method": "foo",
+                          "method": {
+                            "parts": [
+                              "foo"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 76,
+                              "end": 79
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "baz"
+                          "new_name": {
+                            "parts": [
+                              "baz"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 83,
+                              "end": 86
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -111,9 +138,27 @@ class MyClass {
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "foo",
+                          "method": {
+                            "parts": [
+                              "foo"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 96,
+                              "end": 99
+                            }
+                          },
                           "new_modifier": null,
-                          "new_name": "bar"
+                          "new_name": {
+                            "parts": [
+                              "bar"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 103,
+                              "end": 106
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -125,7 +170,16 @@ class MyClass {
                       "kind": {
                         "Alias": {
                           "trait_name": null,
-                          "method": "foo",
+                          "method": {
+                            "parts": [
+                              "foo"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 116,
+                              "end": 119
+                            }
+                          },
                           "new_modifier": "Protected",
                           "new_name": null
                         }
@@ -148,9 +202,27 @@ class MyClass {
                               "end": 143
                             }
                           },
-                          "method": "hello",
+                          "method": {
+                            "parts": [
+                              "hello"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 145,
+                              "end": 150
+                            }
+                          },
                           "new_modifier": "Private",
-                          "new_name": "hi"
+                          "new_name": {
+                            "parts": [
+                              "hi"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 162,
+                              "end": 164
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -171,7 +243,16 @@ class MyClass {
                               "end": 175
                             }
                           },
-                          "method": "big",
+                          "method": {
+                            "parts": [
+                              "big"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 177,
+                              "end": 180
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [

--- a/crates/php-parser/tests/fixtures/trait_multiple_alias_and_precedence.phpt
+++ b/crates/php-parser/tests/fixtures/trait_multiple_alias_and_precedence.phpt
@@ -151,7 +151,16 @@ class C {
                               "end": 139
                             }
                           },
-                          "method": "foo",
+                          "method": {
+                            "parts": [
+                              "foo"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 141,
+                              "end": 144
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [
@@ -184,9 +193,27 @@ class C {
                               "end": 167
                             }
                           },
-                          "method": "foo",
+                          "method": {
+                            "parts": [
+                              "foo"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 169,
+                              "end": 172
+                            }
+                          },
                           "new_modifier": "Private",
-                          "new_name": "afoo"
+                          "new_name": {
+                            "parts": [
+                              "afoo"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 184,
+                              "end": 188
+                            }
+                          }
                         }
                       },
                       "span": {
@@ -207,9 +234,27 @@ class C {
                               "end": 199
                             }
                           },
-                          "method": "bar",
+                          "method": {
+                            "parts": [
+                              "bar"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 201,
+                              "end": 204
+                            }
+                          },
                           "new_modifier": "Public",
-                          "new_name": "bbar"
+                          "new_name": {
+                            "parts": [
+                              "bbar"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 215,
+                              "end": 219
+                            }
+                          }
                         }
                       },
                       "span": {

--- a/crates/php-parser/tests/fixtures/trait_multiple_insteadof.phpt
+++ b/crates/php-parser/tests/fixtures/trait_multiple_insteadof.phpt
@@ -175,7 +175,16 @@ class C {
                               "end": 155
                             }
                           },
-                          "method": "m",
+                          "method": {
+                            "parts": [
+                              "m"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 157,
+                              "end": 158
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [
@@ -218,7 +227,16 @@ class C {
                               "end": 187
                             }
                           },
-                          "method": "m",
+                          "method": {
+                            "parts": [
+                              "m"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 189,
+                              "end": 190
+                            }
+                          },
                           "insteadof": [
                             {
                               "parts": [

--- a/crates/php-printer/src/printer.rs
+++ b/crates/php-printer/src/printer.rs
@@ -667,12 +667,12 @@ impl Printer {
             ExprKind::StaticPropertyAccess(access) => {
                 self.print_expr(access.class, PREC_PRIMARY);
                 self.w("::$");
-                self.w(&access.member);
+                self.print_expr(access.member, PREC_PRIMARY);
             }
             ExprKind::ClassConstAccess(access) => {
                 self.print_expr(access.class, PREC_PRIMARY);
                 self.w("::");
-                self.w(&access.member);
+                self.print_expr(access.member, PREC_PRIMARY);
             }
             ExprKind::ClassConstAccessDynamic { class, member } => {
                 self.print_expr(class, PREC_PRIMARY);
@@ -688,7 +688,7 @@ impl Printer {
             ExprKind::StaticMethodCall(call) => {
                 self.print_expr(call.class, PREC_PRIMARY);
                 self.w("::");
-                self.w(&call.method);
+                self.print_expr(call.method, PREC_PRIMARY);
                 self.w("(");
                 self.print_args(&call.args);
                 self.w(")");
@@ -744,7 +744,7 @@ impl Printer {
                 CallableCreateKind::StaticMethod { class, method } => {
                     self.print_expr(class, PREC_PRIMARY);
                     self.w("::");
-                    self.w(method);
+                    self.print_expr(method, PREC_PRIMARY);
                     self.w("(...)");
                 }
             },
@@ -1019,7 +1019,7 @@ impl Printer {
                     } => {
                         self.print_name(trait_name);
                         self.w("::");
-                        self.w(method);
+                        self.print_name(method);
                         self.w(" insteadof ");
                         for (i, name) in insteadof.iter().enumerate() {
                             if i > 0 {
@@ -1038,7 +1038,7 @@ impl Printer {
                             self.print_name(tn);
                             self.w("::");
                         }
-                        self.w(method);
+                        self.print_name(method);
                         self.w(" as");
                         if let Some(vis) = new_modifier {
                             self.w(" ");
@@ -1046,7 +1046,7 @@ impl Printer {
                         }
                         if let Some(name) = new_name {
                             self.w(" ");
-                            self.w(name);
+                            self.print_name(name);
                         }
                     }
                 }
@@ -1365,7 +1365,7 @@ impl Printer {
                 self.w(", ");
             }
             if let Some(name) = &arg.name {
-                self.w(name);
+                self.print_name(name);
                 self.w(": ");
             }
             if arg.unpack {


### PR DESCRIPTION
## Summary

- Static identifiers (`Foo::bar()`, `Foo::CONST`, `Foo::$prop`, `Foo::bar(...)`, trait `insteadof`/`as` method names, named argument labels) stored names as bare `Cow<str>`/`&str` with no source span
- Fixes by using only existing types — no new types introduced:

| Field | Old | New |
|---|---|---|
| `StaticMethodCallExpr.method` | `Cow<'src, str>` | `&'arena Expr` |
| `StaticAccessExpr.member` | `Cow<'src, str>` | `&'arena Expr` |
| `CallableCreateKind::StaticMethod.method` | `Cow<'src, str>` | `&'arena Expr` |
| `TraitAdaptationKind::Precedence.method` | `&'src str` | `Name<'arena, 'src>` |
| `TraitAdaptationKind::Alias.method` | `Cow<'src, str>` | `Name<'arena, 'src>` |
| `TraitAdaptationKind::Alias.new_name` | `Option<&'src str>` | `Option<Name>` |
| `Arg.name` | `Option<Cow<'src, str>>` | `Option<Name>` |

The `&'arena Expr` choice mirrors `MethodCallExpr.method` and `PropertyAccessExpr.property` exactly. The `Name` choice mirrors `trait_name` in the same enum and `Attribute.name` for arg labels.

The parser already computed spans and discarded them (`_member_span`). The unqualified trait alias case becomes simpler: `first_name` was already a `Name` and is now used directly as `method` without conversion.

## Test plan

- [x] `cargo check` — clean, no warnings
- [x] `UPDATE_FIXTURES=1 cargo test` — all tests pass, fixtures regenerated