### PR TITLE
test(type_hints): add DNF type edge case fixtures

### DIFF
--- a/crates/php-parser/tests/fixtures/categories/type_hints/dnf_property_type.phpt
+++ b/crates/php-parser/tests/fixtures/categories/type_hints/dnf_property_type.phpt
@@ -1,0 +1,156 @@
+===config===
+min_php=8.2
+===source===
+<?php
+class Foo {
+    public (Iterator&Countable)|(ArrayAccess&Stringable) $prop;
+}
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "prop",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Union": [
+                        {
+                          "kind": {
+                            "Intersection": [
+                              {
+                                "kind": {
+                                  "Named": {
+                                    "parts": [
+                                      "Iterator"
+                                    ],
+                                    "kind": "Unqualified",
+                                    "span": {
+                                      "start": 30,
+                                      "end": 38
+                                    }
+                                  }
+                                },
+                                "span": {
+                                  "start": 30,
+                                  "end": 38
+                                }
+                              },
+                              {
+                                "kind": {
+                                  "Named": {
+                                    "parts": [
+                                      "Countable"
+                                    ],
+                                    "kind": "Unqualified",
+                                    "span": {
+                                      "start": 39,
+                                      "end": 48
+                                    }
+                                  }
+                                },
+                                "span": {
+                                  "start": 39,
+                                  "end": 48
+                                }
+                              }
+                            ]
+                          },
+                          "span": {
+                            "start": 29,
+                            "end": 49
+                          }
+                        },
+                        {
+                          "kind": {
+                            "Intersection": [
+                              {
+                                "kind": {
+                                  "Named": {
+                                    "parts": [
+                                      "ArrayAccess"
+                                    ],
+                                    "kind": "Unqualified",
+                                    "span": {
+                                      "start": 51,
+                                      "end": 62
+                                    }
+                                  }
+                                },
+                                "span": {
+                                  "start": 51,
+                                  "end": 62
+                                }
+                              },
+                              {
+                                "kind": {
+                                  "Named": {
+                                    "parts": [
+                                      "Stringable"
+                                    ],
+                                    "kind": "Unqualified",
+                                    "span": {
+                                      "start": 63,
+                                      "end": 73
+                                    }
+                                  }
+                                },
+                                "span": {
+                                  "start": 63,
+                                  "end": 73
+                                }
+                              }
+                            ]
+                          },
+                          "span": {
+                            "start": 50,
+                            "end": 74
+                          }
+                        }
+                      ]
+                    },
+                    "span": {
+                      "start": 29,
+                      "end": 74
+                    }
+                  },
+                  "default": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 22,
+                "end": 80
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 83
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 83
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/type_hints/dnf_return_type.phpt
+++ b/crates/php-parser/tests/fixtures/categories/type_hints/dnf_return_type.phpt
@@ -1,0 +1,130 @@
+===config===
+min_php=8.2
+===source===
+<?php function baz(): (A&B)|(C&D) {}
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Function": {
+          "name": "baz",
+          "params": [],
+          "body": [],
+          "return_type": {
+            "kind": {
+              "Union": [
+                {
+                  "kind": {
+                    "Intersection": [
+                      {
+                        "kind": {
+                          "Named": {
+                            "parts": [
+                              "A"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 23,
+                              "end": 24
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 23,
+                          "end": 24
+                        }
+                      },
+                      {
+                        "kind": {
+                          "Named": {
+                            "parts": [
+                              "B"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 25,
+                              "end": 26
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 25,
+                          "end": 26
+                        }
+                      }
+                    ]
+                  },
+                  "span": {
+                    "start": 22,
+                    "end": 27
+                  }
+                },
+                {
+                  "kind": {
+                    "Intersection": [
+                      {
+                        "kind": {
+                          "Named": {
+                            "parts": [
+                              "C"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 29,
+                              "end": 30
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 29,
+                          "end": 30
+                        }
+                      },
+                      {
+                        "kind": {
+                          "Named": {
+                            "parts": [
+                              "D"
+                            ],
+                            "kind": "Unqualified",
+                            "span": {
+                              "start": 31,
+                              "end": 32
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 31,
+                          "end": 32
+                        }
+                      }
+                    ]
+                  },
+                  "span": {
+                    "start": 28,
+                    "end": 33
+                  }
+                }
+              ]
+            },
+            "span": {
+              "start": 22,
+              "end": 33
+            }
+          },
+          "by_ref": false,
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 36
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 36
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/type_hints/dnf_triple_groups.phpt
+++ b/crates/php-parser/tests/fixtures/categories/type_hints/dnf_triple_groups.phpt
@@ -1,0 +1,210 @@
+===config===
+min_php=8.2
+===source===
+<?php function foo((A&B)|(C&D)|(E&F) $x): void {}
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Function": {
+          "name": "foo",
+          "params": [
+            {
+              "name": "x",
+              "type_hint": {
+                "kind": {
+                  "Union": [
+                    {
+                      "kind": {
+                        "Intersection": [
+                          {
+                            "kind": {
+                              "Named": {
+                                "parts": [
+                                  "A"
+                                ],
+                                "kind": "Unqualified",
+                                "span": {
+                                  "start": 20,
+                                  "end": 21
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 20,
+                              "end": 21
+                            }
+                          },
+                          {
+                            "kind": {
+                              "Named": {
+                                "parts": [
+                                  "B"
+                                ],
+                                "kind": "Unqualified",
+                                "span": {
+                                  "start": 22,
+                                  "end": 23
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 22,
+                              "end": 23
+                            }
+                          }
+                        ]
+                      },
+                      "span": {
+                        "start": 19,
+                        "end": 24
+                      }
+                    },
+                    {
+                      "kind": {
+                        "Intersection": [
+                          {
+                            "kind": {
+                              "Named": {
+                                "parts": [
+                                  "C"
+                                ],
+                                "kind": "Unqualified",
+                                "span": {
+                                  "start": 26,
+                                  "end": 27
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 26,
+                              "end": 27
+                            }
+                          },
+                          {
+                            "kind": {
+                              "Named": {
+                                "parts": [
+                                  "D"
+                                ],
+                                "kind": "Unqualified",
+                                "span": {
+                                  "start": 28,
+                                  "end": 29
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 28,
+                              "end": 29
+                            }
+                          }
+                        ]
+                      },
+                      "span": {
+                        "start": 25,
+                        "end": 30
+                      }
+                    },
+                    {
+                      "kind": {
+                        "Intersection": [
+                          {
+                            "kind": {
+                              "Named": {
+                                "parts": [
+                                  "E"
+                                ],
+                                "kind": "Unqualified",
+                                "span": {
+                                  "start": 32,
+                                  "end": 33
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 32,
+                              "end": 33
+                            }
+                          },
+                          {
+                            "kind": {
+                              "Named": {
+                                "parts": [
+                                  "F"
+                                ],
+                                "kind": "Unqualified",
+                                "span": {
+                                  "start": 34,
+                                  "end": 35
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 34,
+                              "end": 35
+                            }
+                          }
+                        ]
+                      },
+                      "span": {
+                        "start": 31,
+                        "end": 36
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 19,
+                  "end": 36
+                }
+              },
+              "default": null,
+              "by_ref": false,
+              "variadic": false,
+              "is_readonly": false,
+              "is_final": false,
+              "visibility": null,
+              "set_visibility": null,
+              "attributes": [],
+              "span": {
+                "start": 19,
+                "end": 39
+              }
+            }
+          ],
+          "body": [],
+          "return_type": {
+            "kind": {
+              "Named": {
+                "parts": [
+                  "void"
+                ],
+                "kind": "Unqualified",
+                "span": {
+                  "start": 42,
+                  "end": 46
+                }
+              }
+            },
+            "span": {
+              "start": 42,
+              "end": 46
+            }
+          },
+          "by_ref": false,
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 49
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 49
+  }
+}


### PR DESCRIPTION
## Summary

- Add `dnf_triple_groups.phpt` — three parenthesized intersection groups `(A&B)|(C&D)|(E&F)` as a parameter type
- Add `dnf_property_type.phpt` — DNF type `(Iterator&Countable)|(ArrayAccess&Stringable)` on a class property
- Add `dnf_return_type.phpt` — DNF type `(A&B)|(C&D)` as a function return type
- All fixtures include `min_php=8.2` (DNF types require PHP 8.2+)

Closes #187