### PR TITLE
fix(tests): gate php_error fixtures to PHP versions where messages match

### DIFF
--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_12.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_12.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php
 new

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_12_php82.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_12_php82.phpt
@@ -1,0 +1,47 @@
+===config===
+max_php=8.2
+===source===
+<?php
+new
+===errors===
+expected identifier, found end of file
+expected ';' after expression
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "New": {
+              "class": {
+                "kind": {
+                  "Identifier": "<error>"
+                },
+                "span": {
+                  "start": 9,
+                  "end": 9
+                }
+              },
+              "args": []
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 9
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 9
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 9
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected end of file in Standard input code on line 2

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_20.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_20.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_20_php82.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_20_php82.phpt
@@ -1,0 +1,115 @@
+===config===
+max_php=8.2
+===source===
+<?php
+
+class Foo {
+    public $bar1;
+    publi $foo;
+    public $bar;
+}
+===errors===
+expected modifier, found identifier
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "bar1",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": null,
+                  "default": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 23,
+                "end": 35
+              }
+            },
+            {
+              "kind": {
+                "Property": {
+                  "name": "foo",
+                  "visibility": null,
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "publi"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 41,
+                          "end": 46
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 41,
+                      "end": 46
+                    }
+                  },
+                  "default": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 41,
+                "end": 51
+              }
+            },
+            {
+              "kind": {
+                "Property": {
+                  "name": "bar",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": null,
+                  "default": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 57,
+                "end": 68
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 7,
+        "end": 71
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 71
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected identifier "publi", expecting "function" or "const" in Standard input code on line 5

--- a/crates/php-parser/tests/fixtures/corpus/expr/cast.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/cast.phpt
@@ -4,8 +4,8 @@ min_php=8.5
 <?php
 (array)   $a;
 (bool)    $a;
-(boolean) $a;
 (real)    $a;
+(boolean) $a;
 (double)  $a;
 (float)   $a;
 (int)     $a;
@@ -80,7 +80,7 @@ the (unset) cast is no longer supported
         "Expression": {
           "kind": {
             "Cast": [
-              "Bool",
+              "Float",
               {
                 "kind": {
                   "Variable": "a"
@@ -108,7 +108,7 @@ the (unset) cast is no longer supported
         "Expression": {
           "kind": {
             "Cast": [
-              "Float",
+              "Bool",
               {
                 "kind": {
                   "Variable": "a"
@@ -334,5 +334,4 @@ the (unset) cast is no longer supported
   }
 }
 ===php_error===
-PHP Deprecated:  Non-canonical cast (boolean) is deprecated, use the (bool) cast instead in Standard input code on line 4
-PHP Parse error:  The (real) cast has been removed, use (float) instead in Standard input code on line 5
+PHP Parse error:  The (real) cast has been removed, use (float) instead in Standard input code on line 4

--- a/crates/php-parser/tests/fixtures/corpus/expr/newWithoutClass.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/newWithoutClass.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php
 new;

--- a/crates/php-parser/tests/fixtures/corpus/expr/newWithoutClass_php82.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/newWithoutClass_php82.phpt
@@ -1,0 +1,46 @@
+===config===
+max_php=8.2
+===source===
+<?php
+new;
+===errors===
+expected identifier, found ';'
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "New": {
+              "class": {
+                "kind": {
+                  "Identifier": "<error>"
+                },
+                "span": {
+                  "start": 9,
+                  "end": 10
+                }
+              },
+              "args": []
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 9
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 10
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 10
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected token ";" in Standard input code on line 2

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_1.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php
 class A {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_1_php82.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_1_php82.phpt
@@ -1,0 +1,63 @@
+===config===
+max_php=8.2
+===source===
+<?php
+class A {
+    static const X = 1;
+}
+===errors===
+cannot use 'static' as constant modifier
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "A",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "ClassConst": {
+                  "name": "X",
+                  "visibility": null,
+                  "value": {
+                    "kind": {
+                      "Int": 1
+                    },
+                    "span": {
+                      "start": 37,
+                      "end": 38
+                    }
+                  },
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 20,
+                "end": 39
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 41
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 41
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use 'static' as constant modifier in Standard input code on line 3

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_2.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php
 class A {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_2_php82.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_2_php82.phpt
@@ -1,0 +1,63 @@
+===config===
+max_php=8.2
+===source===
+<?php
+class A {
+    abstract const X = 1;
+}
+===errors===
+cannot use 'abstract' as constant modifier
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "A",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "ClassConst": {
+                  "name": "X",
+                  "visibility": null,
+                  "value": {
+                    "kind": {
+                      "Int": 1
+                    },
+                    "span": {
+                      "start": 39,
+                      "end": 40
+                    }
+                  },
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 20,
+                "end": 41
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 43
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 43
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use 'abstract' as constant modifier in Standard input code on line 3

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_3.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_3.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php
 class A {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_3_php82.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/constModifierErrors_3_php82.phpt
@@ -1,0 +1,63 @@
+===config===
+max_php=8.2
+===source===
+<?php
+class A {
+    readonly const X = 1;
+}
+===errors===
+cannot use 'readonly' as constant modifier
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "A",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "ClassConst": {
+                  "name": "X",
+                  "visibility": null,
+                  "value": {
+                    "kind": {
+                      "Int": 1
+                    },
+                    "span": {
+                      "start": 39,
+                      "end": 40
+                    }
+                  },
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 20,
+                "end": 41
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 43
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 43
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use 'readonly' as constant modifier in Standard input code on line 3

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_7.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_7.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php class A { abstract final function a(); }
 ===errors===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_7_php82.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/modifier_error_7_php82.phpt
@@ -1,0 +1,58 @@
+===config===
+max_php=8.2
+===source===
+<?php class A { abstract final function a(); }
+===errors===
+cannot use 'abstract' and 'final' together
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "A",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Method": {
+                  "name": "a",
+                  "visibility": null,
+                  "is_static": false,
+                  "is_abstract": true,
+                  "is_final": true,
+                  "by_ref": false,
+                  "params": [],
+                  "return_type": null,
+                  "body": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 16,
+                "end": 44
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 46
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 46
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use the final modifier on an abstract class member in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_1.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_1.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php class self {}
 ===errors===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_10.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_10.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php interface self {}
 ===errors===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_10_php83.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_10_php83.phpt
@@ -1,0 +1,31 @@
+===config===
+max_php=8.3
+===source===
+<?php interface self {}
+===errors===
+cannot use 'self' as interface name
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Interface": {
+          "name": "self",
+          "extends": [],
+          "members": [],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 23
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 23
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use 'self' as class name as it is reserved in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_11.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_11.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php interface PARENT {}
 ===errors===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_11_php83.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_11_php83.phpt
@@ -1,0 +1,31 @@
+===config===
+max_php=8.3
+===source===
+<?php interface PARENT {}
+===errors===
+cannot use 'PARENT' as interface name
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Interface": {
+          "name": "PARENT",
+          "extends": [],
+          "members": [],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 25
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 25
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use 'PARENT' as class name as it is reserved in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_1_php83.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_1_php83.phpt
@@ -1,0 +1,37 @@
+===config===
+max_php=8.3
+===source===
+<?php class self {}
+===errors===
+cannot use 'self' as class name
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "self",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 19
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 19
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use 'self' as class name as it is reserved in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_2.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_2.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php class PARENT {}
 ===errors===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/name_2_php83.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/name_2_php83.phpt
@@ -1,0 +1,37 @@
+===config===
+max_php=8.3
+===source===
+<?php class PARENT {}
+===errors===
+cannot use 'PARENT' as class name
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "PARENT",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 21
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 21
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use 'PARENT' as class name as it is reserved in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/php4Style.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/php4Style.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.5
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/php4Style_php84.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/php4Style_php84.phpt
@@ -1,0 +1,102 @@
+===config===
+max_php=8.4
+===source===
+<?php
+
+class A {
+    var $foo;
+    function bar() {}
+    static abstract function baz() {}
+}
+===errors===
+abstract method cannot contain a body
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "A",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "foo",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": null,
+                  "default": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 21,
+                "end": 29
+              }
+            },
+            {
+              "kind": {
+                "Method": {
+                  "name": "bar",
+                  "visibility": null,
+                  "is_static": false,
+                  "is_abstract": false,
+                  "is_final": false,
+                  "by_ref": false,
+                  "params": [],
+                  "return_type": null,
+                  "body": [],
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 35,
+                "end": 52
+              }
+            },
+            {
+              "kind": {
+                "Method": {
+                  "name": "baz",
+                  "visibility": null,
+                  "is_static": true,
+                  "is_abstract": true,
+                  "is_final": false,
+                  "by_ref": false,
+                  "params": [],
+                  "return_type": null,
+                  "body": [],
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 57,
+                "end": 90
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 7,
+        "end": 92
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 92
+  }
+}
+===php_error===
+PHP Fatal error:  Abstract function A::baz() cannot contain body in Standard input code on line 6

--- a/crates/php-parser/tests/fixtures/corpus/stmt/const.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/const.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.5
 ===source===
 <?php
 

--- a/crates/php-parser/tests/fixtures/corpus/stmt/const_php84.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/const_php84.phpt
@@ -1,0 +1,342 @@
+===config===
+max_php=8.4
+===source===
+<?php
+
+const A = 0, B = 1.0, C = 'A', D = E;
+
+#[Example]
+const WithOneAttribute = 1;
+
+#[First]
+#[Second]
+const WithUngroupedAttriutes = 2;
+
+#[First, Second]
+const WithGroupAttributes = 3;
+
+#[Example]
+const ThisIsInvalid = 4,
+    AttributesOnMultipleConstants = 5;
+===errors===
+cannot use attributes on multi-constant declaration
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Const": [
+          {
+            "name": "A",
+            "value": {
+              "kind": {
+                "Int": 0
+              },
+              "span": {
+                "start": 17,
+                "end": 18
+              }
+            },
+            "attributes": [],
+            "span": {
+              "start": 13,
+              "end": 18
+            }
+          },
+          {
+            "name": "B",
+            "value": {
+              "kind": {
+                "Float": 1.0
+              },
+              "span": {
+                "start": 24,
+                "end": 27
+              }
+            },
+            "attributes": [],
+            "span": {
+              "start": 20,
+              "end": 27
+            }
+          },
+          {
+            "name": "C",
+            "value": {
+              "kind": {
+                "String": "A"
+              },
+              "span": {
+                "start": 33,
+                "end": 36
+              }
+            },
+            "attributes": [],
+            "span": {
+              "start": 29,
+              "end": 36
+            }
+          },
+          {
+            "name": "D",
+            "value": {
+              "kind": {
+                "Identifier": "E"
+              },
+              "span": {
+                "start": 42,
+                "end": 43
+              }
+            },
+            "attributes": [],
+            "span": {
+              "start": 38,
+              "end": 43
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 7,
+        "end": 44
+      }
+    },
+    {
+      "kind": {
+        "Const": [
+          {
+            "name": "WithOneAttribute",
+            "value": {
+              "kind": {
+                "Int": 1
+              },
+              "span": {
+                "start": 82,
+                "end": 83
+              }
+            },
+            "attributes": [
+              {
+                "name": {
+                  "parts": [
+                    "Example"
+                  ],
+                  "kind": "Unqualified",
+                  "span": {
+                    "start": 48,
+                    "end": 55
+                  }
+                },
+                "args": [],
+                "span": {
+                  "start": 48,
+                  "end": 55
+                }
+              }
+            ],
+            "span": {
+              "start": 63,
+              "end": 83
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 57,
+        "end": 84
+      }
+    },
+    {
+      "kind": {
+        "Const": [
+          {
+            "name": "WithUngroupedAttriutes",
+            "value": {
+              "kind": {
+                "Int": 2
+              },
+              "span": {
+                "start": 136,
+                "end": 137
+              }
+            },
+            "attributes": [
+              {
+                "name": {
+                  "parts": [
+                    "First"
+                  ],
+                  "kind": "Unqualified",
+                  "span": {
+                    "start": 88,
+                    "end": 93
+                  }
+                },
+                "args": [],
+                "span": {
+                  "start": 88,
+                  "end": 93
+                }
+              },
+              {
+                "name": {
+                  "parts": [
+                    "Second"
+                  ],
+                  "kind": "Unqualified",
+                  "span": {
+                    "start": 97,
+                    "end": 103
+                  }
+                },
+                "args": [],
+                "span": {
+                  "start": 97,
+                  "end": 103
+                }
+              }
+            ],
+            "span": {
+              "start": 111,
+              "end": 137
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 105,
+        "end": 138
+      }
+    },
+    {
+      "kind": {
+        "Const": [
+          {
+            "name": "WithGroupAttributes",
+            "value": {
+              "kind": {
+                "Int": 3
+              },
+              "span": {
+                "start": 185,
+                "end": 186
+              }
+            },
+            "attributes": [
+              {
+                "name": {
+                  "parts": [
+                    "First"
+                  ],
+                  "kind": "Unqualified",
+                  "span": {
+                    "start": 142,
+                    "end": 147
+                  }
+                },
+                "args": [],
+                "span": {
+                  "start": 142,
+                  "end": 147
+                }
+              },
+              {
+                "name": {
+                  "parts": [
+                    "Second"
+                  ],
+                  "kind": "Unqualified",
+                  "span": {
+                    "start": 149,
+                    "end": 155
+                  }
+                },
+                "args": [],
+                "span": {
+                  "start": 149,
+                  "end": 155
+                }
+              }
+            ],
+            "span": {
+              "start": 163,
+              "end": 186
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 157,
+        "end": 187
+      }
+    },
+    {
+      "kind": {
+        "Const": [
+          {
+            "name": "ThisIsInvalid",
+            "value": {
+              "kind": {
+                "Int": 4
+              },
+              "span": {
+                "start": 222,
+                "end": 223
+              }
+            },
+            "attributes": [
+              {
+                "name": {
+                  "parts": [
+                    "Example"
+                  ],
+                  "kind": "Unqualified",
+                  "span": {
+                    "start": 191,
+                    "end": 198
+                  }
+                },
+                "args": [],
+                "span": {
+                  "start": 191,
+                  "end": 198
+                }
+              }
+            ],
+            "span": {
+              "start": 206,
+              "end": 223
+            }
+          },
+          {
+            "name": "AttributesOnMultipleConstants",
+            "value": {
+              "kind": {
+                "Int": 5
+              },
+              "span": {
+                "start": 261,
+                "end": 262
+              }
+            },
+            "attributes": [],
+            "span": {
+              "start": 229,
+              "end": 262
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 200,
+        "end": 263
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 263
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected token "const" in Standard input code on line 6

--- a/crates/php-parser/tests/fixtures/errors/abstract_const_error.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_const_error.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php class A { abstract const X = 1; }
 ===errors===

--- a/crates/php-parser/tests/fixtures/errors/abstract_const_error_php82.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_const_error_php82.phpt
@@ -1,0 +1,60 @@
+===config===
+max_php=8.2
+===source===
+<?php class A { abstract const X = 1; }
+===errors===
+cannot use 'abstract' as constant modifier
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "A",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "ClassConst": {
+                  "name": "X",
+                  "visibility": null,
+                  "value": {
+                    "kind": {
+                      "Int": 1
+                    },
+                    "span": {
+                      "start": 35,
+                      "end": 36
+                    }
+                  },
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 16,
+                "end": 37
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 39
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 39
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use 'abstract' as constant modifier in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/abstract_final_conflict.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_final_conflict.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php class A { abstract final function a(); }
 ===errors===

--- a/crates/php-parser/tests/fixtures/errors/abstract_final_conflict_php82.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_final_conflict_php82.phpt
@@ -1,0 +1,58 @@
+===config===
+max_php=8.2
+===source===
+<?php class A { abstract final function a(); }
+===errors===
+cannot use 'abstract' and 'final' together
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "A",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Method": {
+                  "name": "a",
+                  "visibility": null,
+                  "is_static": false,
+                  "is_abstract": true,
+                  "is_final": true,
+                  "by_ref": false,
+                  "params": [],
+                  "return_type": null,
+                  "body": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 16,
+                "end": 44
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 46
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 46
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use the final modifier on an abstract class member in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/abstract_method_in_enum.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_method_in_enum.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.5
 ===source===
 <?php enum Status { abstract public function label(): string; }
 ===errors===

--- a/crates/php-parser/tests/fixtures/errors/abstract_method_in_enum_php84.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_method_in_enum_php84.phpt
@@ -1,0 +1,70 @@
+===config===
+max_php=8.4
+===source===
+<?php enum Status { abstract public function label(): string; }
+===errors===
+enum methods cannot be abstract
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Enum": {
+          "name": "Status",
+          "scalar_type": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Method": {
+                  "name": "label",
+                  "visibility": "Public",
+                  "is_static": false,
+                  "is_abstract": true,
+                  "is_final": false,
+                  "by_ref": false,
+                  "params": [],
+                  "return_type": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "string"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 54,
+                          "end": 60
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 54,
+                      "end": 60
+                    }
+                  },
+                  "body": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 20,
+                "end": 61
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 63
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 63
+  }
+}
+===php_error===
+PHP Fatal error:  Enum Status must implement 1 abstract private method (Status::label) in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/abstract_property_in_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_property_in_class.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php class Foo { abstract public string $bar; }
 ===errors===

--- a/crates/php-parser/tests/fixtures/errors/abstract_property_in_class_php82.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_property_in_class_php82.phpt
@@ -1,0 +1,73 @@
+===config===
+max_php=8.2
+===source===
+<?php class Foo { abstract public string $bar; }
+===errors===
+properties cannot be abstract
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "bar",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "string"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 34,
+                          "end": 40
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 34,
+                      "end": 40
+                    }
+                  },
+                  "default": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 18,
+                "end": 45
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 48
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 48
+  }
+}
+===php_error===
+PHP Fatal error:  Properties cannot be declared abstract in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/abstract_property_in_class_php83.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_property_in_class_php83.phpt
@@ -1,0 +1,74 @@
+===config===
+min_php=8.3
+max_php=8.3
+===source===
+<?php class Foo { abstract public string $bar; }
+===errors===
+properties cannot be abstract
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "bar",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "string"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 34,
+                          "end": 40
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 34,
+                      "end": 40
+                    }
+                  },
+                  "default": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 18,
+                "end": 45
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 48
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 48
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use the abstract modifier on a property in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/abstract_property_no_visibility.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_property_no_visibility.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php class Foo { abstract string $bar; }
 ===errors===

--- a/crates/php-parser/tests/fixtures/errors/abstract_property_no_visibility_php82.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_property_no_visibility_php82.phpt
@@ -1,0 +1,73 @@
+===config===
+max_php=8.2
+===source===
+<?php class Foo { abstract string $bar; }
+===errors===
+properties cannot be abstract
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "bar",
+                  "visibility": null,
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "string"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 27,
+                          "end": 33
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 27,
+                      "end": 33
+                    }
+                  },
+                  "default": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 18,
+                "end": 38
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 41
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 41
+  }
+}
+===php_error===
+PHP Fatal error:  Properties cannot be declared abstract in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/abstract_property_no_visibility_php83.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_property_no_visibility_php83.phpt
@@ -1,0 +1,74 @@
+===config===
+min_php=8.3
+max_php=8.3
+===source===
+<?php class Foo { abstract string $bar; }
+===errors===
+properties cannot be abstract
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "bar",
+                  "visibility": null,
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "string"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 27,
+                          "end": 33
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 27,
+                      "end": 33
+                    }
+                  },
+                  "default": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 18,
+                "end": 38
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 41
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 41
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use the abstract modifier on a property in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/function_unclosed_params.phpt
+++ b/crates/php-parser/tests/fixtures/errors/function_unclosed_params.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php function test(int $x { }
 ===errors===

--- a/crates/php-parser/tests/fixtures/errors/function_unclosed_params_php83.phpt
+++ b/crates/php-parser/tests/fixtures/errors/function_unclosed_params_php83.phpt
@@ -1,0 +1,67 @@
+===config===
+max_php=8.3
+===source===
+<?php function test(int $x { }
+===errors===
+unclosed '')'' opened at Span { start: 19, end: 20 }
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Function": {
+          "name": "test",
+          "params": [
+            {
+              "name": "x",
+              "type_hint": {
+                "kind": {
+                  "Named": {
+                    "parts": [
+                      "int"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 20,
+                      "end": 23
+                    }
+                  }
+                },
+                "span": {
+                  "start": 20,
+                  "end": 23
+                }
+              },
+              "default": null,
+              "by_ref": false,
+              "variadic": false,
+              "is_readonly": false,
+              "is_final": false,
+              "visibility": null,
+              "set_visibility": null,
+              "attributes": [],
+              "span": {
+                "start": 20,
+                "end": 26
+              }
+            }
+          ],
+          "body": [],
+          "return_type": null,
+          "by_ref": false,
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 30
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 30
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected token "{", expecting ")" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/invalid_double_readonly_anonymous_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_double_readonly_anonymous_class.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php new readonly readonly class {};
 ===errors===

--- a/crates/php-parser/tests/fixtures/errors/invalid_double_readonly_anonymous_class_php82.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_double_readonly_anonymous_class_php82.phpt
@@ -1,0 +1,73 @@
+===config===
+max_php=8.2
+===source===
+<?php new readonly readonly class {};
+===errors===
+expected ';' after expression
+expected class name, found '{'
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "New": {
+              "class": {
+                "kind": {
+                  "Identifier": "readonly"
+                },
+                "span": {
+                  "start": 10,
+                  "end": 18
+                }
+              },
+              "args": []
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 18
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 18
+      }
+    },
+    {
+      "kind": {
+        "Class": {
+          "name": "<error>",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": true
+          },
+          "extends": null,
+          "implements": [],
+          "members": [],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 28,
+        "end": 36
+      }
+    },
+    {
+      "kind": "Nop",
+      "span": {
+        "start": 36,
+        "end": 37
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 37
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected token "readonly" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/invalid_missing_closing_paren_function.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_missing_closing_paren_function.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php
 function foo(int $a, $b {

--- a/crates/php-parser/tests/fixtures/errors/invalid_missing_closing_paren_function_php83.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_missing_closing_paren_function_php83.phpt
@@ -1,0 +1,124 @@
+===config===
+max_php=8.3
+===source===
+<?php
+function foo(int $a, $b {
+    return $a + $b;
+}
+===errors===
+unclosed '')'' opened at Span { start: 18, end: 19 }
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Function": {
+          "name": "foo",
+          "params": [
+            {
+              "name": "a",
+              "type_hint": {
+                "kind": {
+                  "Named": {
+                    "parts": [
+                      "int"
+                    ],
+                    "kind": "Unqualified",
+                    "span": {
+                      "start": 19,
+                      "end": 22
+                    }
+                  }
+                },
+                "span": {
+                  "start": 19,
+                  "end": 22
+                }
+              },
+              "default": null,
+              "by_ref": false,
+              "variadic": false,
+              "is_readonly": false,
+              "is_final": false,
+              "visibility": null,
+              "set_visibility": null,
+              "attributes": [],
+              "span": {
+                "start": 19,
+                "end": 25
+              }
+            },
+            {
+              "name": "b",
+              "type_hint": null,
+              "default": null,
+              "by_ref": false,
+              "variadic": false,
+              "is_readonly": false,
+              "is_final": false,
+              "visibility": null,
+              "set_visibility": null,
+              "attributes": [],
+              "span": {
+                "start": 27,
+                "end": 29
+              }
+            }
+          ],
+          "body": [
+            {
+              "kind": {
+                "Return": {
+                  "kind": {
+                    "Binary": {
+                      "left": {
+                        "kind": {
+                          "Variable": "a"
+                        },
+                        "span": {
+                          "start": 43,
+                          "end": 45
+                        }
+                      },
+                      "op": "Add",
+                      "right": {
+                        "kind": {
+                          "Variable": "b"
+                        },
+                        "span": {
+                          "start": 48,
+                          "end": 50
+                        }
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 43,
+                    "end": 50
+                  }
+                }
+              },
+              "span": {
+                "start": 36,
+                "end": 51
+              }
+            }
+          ],
+          "return_type": null,
+          "by_ref": false,
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 53
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 53
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected token "{", expecting ")" in Standard input code on line 2

--- a/crates/php-parser/tests/fixtures/errors/readonly_const_error.phpt
+++ b/crates/php-parser/tests/fixtures/errors/readonly_const_error.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php class A { readonly const X = 1; }
 ===errors===

--- a/crates/php-parser/tests/fixtures/errors/readonly_const_error_php82.phpt
+++ b/crates/php-parser/tests/fixtures/errors/readonly_const_error_php82.phpt
@@ -1,0 +1,60 @@
+===config===
+max_php=8.2
+===source===
+<?php class A { readonly const X = 1; }
+===errors===
+cannot use 'readonly' as constant modifier
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "A",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "ClassConst": {
+                  "name": "X",
+                  "visibility": null,
+                  "value": {
+                    "kind": {
+                      "Int": 1
+                    },
+                    "span": {
+                      "start": 35,
+                      "end": 36
+                    }
+                  },
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 16,
+                "end": 37
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 39
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 39
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use 'readonly' as constant modifier in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/reserved_class_name_parent.phpt
+++ b/crates/php-parser/tests/fixtures/errors/reserved_class_name_parent.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php class parent {}
 ===errors===

--- a/crates/php-parser/tests/fixtures/errors/reserved_class_name_parent_php83.phpt
+++ b/crates/php-parser/tests/fixtures/errors/reserved_class_name_parent_php83.phpt
@@ -1,0 +1,37 @@
+===config===
+max_php=8.3
+===source===
+<?php class parent {}
+===errors===
+cannot use 'parent' as class name
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "parent",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 21
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 21
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use 'parent' as class name as it is reserved in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/reserved_class_name_self.phpt
+++ b/crates/php-parser/tests/fixtures/errors/reserved_class_name_self.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php class self {}
 ===errors===

--- a/crates/php-parser/tests/fixtures/errors/reserved_class_name_self_php83.phpt
+++ b/crates/php-parser/tests/fixtures/errors/reserved_class_name_self_php83.phpt
@@ -1,0 +1,37 @@
+===config===
+max_php=8.3
+===source===
+<?php class self {}
+===errors===
+cannot use 'self' as class name
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "self",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 19
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 19
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use 'self' as class name as it is reserved in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/static_const_error.phpt
+++ b/crates/php-parser/tests/fixtures/errors/static_const_error.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.3
 ===source===
 <?php class A { static const X = 1; }
 ===errors===

--- a/crates/php-parser/tests/fixtures/errors/static_const_error_php82.phpt
+++ b/crates/php-parser/tests/fixtures/errors/static_const_error_php82.phpt
@@ -1,0 +1,60 @@
+===config===
+max_php=8.2
+===source===
+<?php class A { static const X = 1; }
+===errors===
+cannot use 'static' as constant modifier
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "A",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "ClassConst": {
+                  "name": "X",
+                  "visibility": null,
+                  "value": {
+                    "kind": {
+                      "Int": 1
+                    },
+                    "span": {
+                      "start": 33,
+                      "end": 34
+                    }
+                  },
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 16,
+                "end": 35
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 37
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 37
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use 'static' as constant modifier in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/true_false_union_is_invalid.phpt
+++ b/crates/php-parser/tests/fixtures/errors/true_false_union_is_invalid.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php function f(): true|false {}
 ===errors===

--- a/crates/php-parser/tests/fixtures/errors/true_false_union_is_invalid_php83.phpt
+++ b/crates/php-parser/tests/fixtures/errors/true_false_union_is_invalid_php83.phpt
@@ -1,0 +1,78 @@
+===config===
+max_php=8.3
+===source===
+<?php function f(): true|false {}
+===errors===
+Type contains both true and false, bool must be used instead
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Function": {
+          "name": "f",
+          "params": [],
+          "body": [],
+          "return_type": {
+            "kind": {
+              "Union": [
+                {
+                  "kind": {
+                    "Named": {
+                      "parts": [
+                        "true"
+                      ],
+                      "kind": "Unqualified",
+                      "span": {
+                        "start": 20,
+                        "end": 24
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 20,
+                    "end": 24
+                  }
+                },
+                {
+                  "kind": {
+                    "Named": {
+                      "parts": [
+                        "false"
+                      ],
+                      "kind": "Unqualified",
+                      "span": {
+                        "start": 25,
+                        "end": 30
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 25,
+                    "end": 30
+                  }
+                }
+              ]
+            },
+            "span": {
+              "start": 20,
+              "end": 30
+            }
+          },
+          "by_ref": false,
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 33
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 33
+  }
+}
+===php_error===
+PHP Fatal error:  Type contains both true and false, bool should be used instead in Standard input code on line 1


### PR DESCRIPTION
## Summary

The `===php_error===` sections in 27 fixtures were set to PHP 8.5 error messages, but PHP 8.2–8.4 produce different wording for the same errors, causing all PHP Syntax CI jobs to fail.

- **min_php=8.5** (3 fixtures): `php4Style`, `const` (global const attributes are 8.5+), `abstract_method_in_enum` — all changed error message in 8.5
- **min_php=8.4** (11 fixtures): class-name reserved wording ("as a class name"), abstract property errors (property hooks are 8.4+), unclosed-paren improved messages, `true|false` union "must" vs "should"
- **min_php=8.3** (12 fixtures): const modifier messages, abstract/final conflict wording, double-readonly, error recovery improved messages
- **cast.phpt** (1 fixture): swap `(real)` before `(boolean)` so PHP 8.5 hits the parse error first — avoids flaky deprecation notice that only appears in some 8.5 patch releases

## Test plan

- [ ] All PHP Syntax CI jobs pass (8.2, 8.3, 8.4, 8.5)
- [ ] Integration and Coverage jobs pass
- [ ] Local: `cargo test` and `cargo test --test php_syntax` both pass