### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-04-17
+
+### Added
+
+- Spans on static method/member/argument identifiers in the AST (`php-ast`, #197).
+- Named argument ordering and uniqueness validation: duplicate names and non-trailing named arguments now produce diagnostics (`php-rs-parser`, #193).
+- `Name::src_repr(&self, src: &'src str) -> &'src str` — zero-alloc slice into source for any name shape (`php-ast`, #169).
+
+### Changed (breaking)
+
+- `ScopeWalker::new` now requires the source string (`src: &'src str`) to support zero-alloc namespace resolution. Update call sites to pass `result.source` or your source buffer (#169).
+- `Scope` now derives `Copy`; `Scope::namespace` changed from `Option<Cow<'src, str>>` to `Option<&'src str>` (#169).
+- `ArenaVec::len` and `ArenaVec::last` explicit methods removed — both remain accessible via `Deref<Target=[T]>` and continue to work without call-site changes (#170).
+
+### Performance
+
+- `ScopeWalker` namespace tracking is now zero-alloc; scope saves/restores are a free word copy (#169).
+- `Printer` internal strings changed from heap-allocated `String` to `&'static str` (#164).
+- Lexer heredoc label now borrows from source instead of allocating a `String` (#163).
+
+### Fixed
+
+- Guard against silent `u32` truncation for source files larger than 4 GB in the lexer (#166).
+- Eliminated panic-prone `unwrap()` calls after explicit length checks in the parser (#165).
+- Replaced bare `unreachable!()` calls with descriptive messages and `Option` returns in the parser (#167).
+- Removed dead `ParseError::Unexpected` variant from diagnostics (#168).
+- Variable name extraction now guarded against empty-span tokens (#160).
+
+---
+
 ## [0.6.2] - 2026-04-12
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -24,10 +24,10 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.6.2" }
-php-lexer = { path = "crates/php-lexer", version = "0.6.2" }
-php-rs-parser = { path = "crates/php-parser", version = "0.6.2" }
-php-printer = { path = "crates/php-printer", version = "0.6.2" }
+php-ast = { path = "crates/php-ast", version = "0.7.0" }
+php-lexer = { path = "crates/php-lexer", version = "0.7.0" }
+php-rs-parser = { path = "crates/php-parser", version = "0.7.0" }
+php-printer = { path = "crates/php-printer", version = "0.7.0" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Bumps all crates from `0.6.2` → `0.7.0`
- Adds `[0.7.0]` entry to `CHANGELOG.md`

## What's in this release

**Added**
- Spans on static method/member/argument identifiers (#197)
- Named argument ordering and uniqueness validation (#193)
- `Name::src_repr` for zero-alloc source slice (#169)

**Breaking**
- `ScopeWalker::new` now requires `src: &'src str` (#169)
- `Scope::namespace` changed from `Option<Cow<'src, str>>` to `Option<&'src str>` (#169)
- `ArenaVec::len` / `ArenaVec::last` explicit methods removed (still available via `Deref`) (#170)

**Performance**
- Zero-alloc scope tracking in `ScopeWalker` (#169)
- Printer uses `&'static str` internally (#164)
- Lexer borrows heredoc label from source (#163)

**Fixed**
- `u32` truncation guard for files > 4 GB (#166)
- Panic-prone `unwrap()` calls eliminated (#165)
- Bare `unreachable!()` replaced with descriptive messages (#167)
- Dead `ParseError::Unexpected` variant removed (#168)
- Empty-span variable name guard (#160)

## Test plan

- [ ] CI passes on all PHP versions (8.2, 8.3, 8.4, 8.5)
- [ ] After merge, tag `v0.7.0` and publish crates