### PR TITLE
test(parser): add property hooks with asymmetric visibility fixtures

### DIFF
--- a/crates/php-parser/tests/fixtures/categories/property_hooks/abstract_asymmetric_visibility.phpt
+++ b/crates/php-parser/tests/fixtures/categories/property_hooks/abstract_asymmetric_visibility.phpt
@@ -1,0 +1,101 @@
+===config===
+min_php=8.4
+===source===
+<?php
+abstract class Foo {
+    abstract public private(set) int $count {
+        get;
+        set;
+    }
+}
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": true,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "count",
+                  "visibility": "Public",
+                  "set_visibility": "Private",
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "int"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 60,
+                          "end": 63
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 60,
+                      "end": 63
+                    }
+                  },
+                  "default": null,
+                  "attributes": [],
+                  "hooks": [
+                    {
+                      "kind": "Get",
+                      "body": "Abstract",
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [],
+                      "attributes": [],
+                      "span": {
+                        "start": 81,
+                        "end": 85
+                      }
+                    },
+                    {
+                      "kind": "Set",
+                      "body": "Abstract",
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [],
+                      "attributes": [],
+                      "span": {
+                        "start": 94,
+                        "end": 98
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 31,
+                "end": 104
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 15,
+        "end": 106
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 106
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/property_hooks/asymmetric_visibility_get_hook_only.phpt
+++ b/crates/php-parser/tests/fixtures/categories/property_hooks/asymmetric_visibility_get_hook_only.phpt
@@ -1,0 +1,127 @@
+===config===
+min_php=8.4
+===source===
+<?php
+class Foo {
+    public protected(set) string $name {
+        get { return $this->name; }
+    }
+}
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "name",
+                  "visibility": "Public",
+                  "set_visibility": "Protected",
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "string"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 44,
+                          "end": 50
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 44,
+                      "end": 50
+                    }
+                  },
+                  "default": null,
+                  "attributes": [],
+                  "hooks": [
+                    {
+                      "kind": "Get",
+                      "body": {
+                        "Block": [
+                          {
+                            "kind": {
+                              "Return": {
+                                "kind": {
+                                  "PropertyAccess": {
+                                    "object": {
+                                      "kind": {
+                                        "Variable": "this"
+                                      },
+                                      "span": {
+                                        "start": 80,
+                                        "end": 85
+                                      }
+                                    },
+                                    "property": {
+                                      "kind": {
+                                        "Identifier": "name"
+                                      },
+                                      "span": {
+                                        "start": 87,
+                                        "end": 91
+                                      }
+                                    }
+                                  }
+                                },
+                                "span": {
+                                  "start": 80,
+                                  "end": 91
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 73,
+                              "end": 92
+                            }
+                          }
+                        ]
+                      },
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [],
+                      "attributes": [],
+                      "span": {
+                        "start": 67,
+                        "end": 94
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 22,
+                "end": 100
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 102
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 102
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/property_hooks/asymmetric_visibility_with_hooks.phpt
+++ b/crates/php-parser/tests/fixtures/categories/property_hooks/asymmetric_visibility_with_hooks.phpt
@@ -1,0 +1,233 @@
+===config===
+min_php=8.4
+===source===
+<?php
+class Foo {
+    public private(set) int $prop {
+        get { return $this->prop; }
+        set(int $v) { $this->prop = $v; }
+    }
+}
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "prop",
+                  "visibility": "Public",
+                  "set_visibility": "Private",
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "int"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 42,
+                          "end": 45
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 42,
+                      "end": 45
+                    }
+                  },
+                  "default": null,
+                  "attributes": [],
+                  "hooks": [
+                    {
+                      "kind": "Get",
+                      "body": {
+                        "Block": [
+                          {
+                            "kind": {
+                              "Return": {
+                                "kind": {
+                                  "PropertyAccess": {
+                                    "object": {
+                                      "kind": {
+                                        "Variable": "this"
+                                      },
+                                      "span": {
+                                        "start": 75,
+                                        "end": 80
+                                      }
+                                    },
+                                    "property": {
+                                      "kind": {
+                                        "Identifier": "prop"
+                                      },
+                                      "span": {
+                                        "start": 82,
+                                        "end": 86
+                                      }
+                                    }
+                                  }
+                                },
+                                "span": {
+                                  "start": 75,
+                                  "end": 86
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 68,
+                              "end": 87
+                            }
+                          }
+                        ]
+                      },
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [],
+                      "attributes": [],
+                      "span": {
+                        "start": 62,
+                        "end": 89
+                      }
+                    },
+                    {
+                      "kind": "Set",
+                      "body": {
+                        "Block": [
+                          {
+                            "kind": {
+                              "Expression": {
+                                "kind": {
+                                  "Assign": {
+                                    "target": {
+                                      "kind": {
+                                        "PropertyAccess": {
+                                          "object": {
+                                            "kind": {
+                                              "Variable": "this"
+                                            },
+                                            "span": {
+                                              "start": 112,
+                                              "end": 117
+                                            }
+                                          },
+                                          "property": {
+                                            "kind": {
+                                              "Identifier": "prop"
+                                            },
+                                            "span": {
+                                              "start": 119,
+                                              "end": 123
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "span": {
+                                        "start": 112,
+                                        "end": 123
+                                      }
+                                    },
+                                    "op": "Assign",
+                                    "value": {
+                                      "kind": {
+                                        "Variable": "v"
+                                      },
+                                      "span": {
+                                        "start": 126,
+                                        "end": 128
+                                      }
+                                    }
+                                  }
+                                },
+                                "span": {
+                                  "start": 112,
+                                  "end": 128
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 112,
+                              "end": 129
+                            }
+                          }
+                        ]
+                      },
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [
+                        {
+                          "name": "v",
+                          "type_hint": {
+                            "kind": {
+                              "Named": {
+                                "parts": [
+                                  "int"
+                                ],
+                                "kind": "Unqualified",
+                                "span": {
+                                  "start": 102,
+                                  "end": 105
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 102,
+                              "end": 105
+                            }
+                          },
+                          "default": null,
+                          "by_ref": false,
+                          "variadic": false,
+                          "is_readonly": false,
+                          "is_final": false,
+                          "visibility": null,
+                          "set_visibility": null,
+                          "attributes": [],
+                          "span": {
+                            "start": 102,
+                            "end": 108
+                          }
+                        }
+                      ],
+                      "attributes": [],
+                      "span": {
+                        "start": 98,
+                        "end": 131
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 22,
+                "end": 137
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 139
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 139
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.phpt` fixtures under `categories/property_hooks/` for the three missing combinations from issue #186
- Covers `public private(set)` with get+set hooks, `public protected(set)` with get hook only, and `abstract public private(set)` with abstract get+set hooks
- All fixtures use `min_php=8.4` since both property hooks and asymmetric visibility were introduced in PHP 8.4

Closes #186