### PR TITLE
test(interpolation): error recovery for unclosed string interpolation braces

### DIFF
--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -1127,6 +1127,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                     inner,
                     inner_offset,
                     parser.version,
+                    parser.errors_mut(),
                 );
                 Expr {
                     kind: ExprKind::InterpolatedString(parts),
@@ -1150,6 +1151,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                     inner,
                     inner_offset,
                     parser.version,
+                    parser.errors_mut(),
                 );
                 // Collapse single literal part into String, or use InterpolatedString
                 if parts.len() == 1 {
@@ -1202,6 +1204,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                     inner,
                     inner_offset,
                     parser.version,
+                    parser.errors_mut(),
                 );
                 Expr {
                     kind: ExprKind::ShellExec(parts),
@@ -1227,6 +1230,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                     inner,
                     inner_offset,
                     parser.version,
+                    parser.errors_mut(),
                 );
                 Expr {
                     kind: ExprKind::ShellExec(parts),
@@ -1256,6 +1260,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                         body_offset,
                         &indent,
                         parser.version,
+                        parser.errors_mut(),
                     );
                     Expr {
                         kind: ExprKind::Heredoc { label, parts },
@@ -1269,6 +1274,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
                         raw_body,
                         body_offset,
                         parser.version,
+                        parser.errors_mut(),
                     );
                     Expr {
                         kind: ExprKind::Heredoc { label, parts },

--- a/crates/php-parser/src/interpolation.rs
+++ b/crates/php-parser/src/interpolation.rs
@@ -1,5 +1,6 @@
 use php_ast::*;
 
+use crate::diagnostics::ParseError;
 use crate::version::PhpVersion;
 
 /// Parse the inner content of a double-quoted or backtick string into parts.
@@ -13,6 +14,7 @@ pub fn parse_interpolated_parts<'arena, 'src>(
     inner: &'src str,
     base_offset: u32,
     version: PhpVersion,
+    errors: &mut Vec<ParseError>,
 ) -> ArenaVec<'arena, StringPart<'arena, 'src>> {
     let mut parts = ArenaVec::with_capacity_in(8, arena);
     let bytes = inner.as_bytes();
@@ -173,6 +175,11 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                         );
                         if i < len {
                             i += 1; // skip }
+                        } else {
+                            errors.push(ParseError::Forbidden {
+                                message: "unclosed '${' in string interpolation".into(),
+                                span: Span::new(var_offset, base_offset + i as u32),
+                            });
                         }
                         parts.push(StringPart::Expr(Expr {
                             kind: ExprKind::VariableVariable(arena.alloc(inner_expr)),
@@ -195,6 +202,7 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                         };
                         // Optional [index]
                         if i < len && bytes[i] == b'[' {
+                            let bracket_offset = base_offset + i as u32;
                             i += 1;
                             let idx_start = i;
                             while i < len && bytes[i] != b']' && bytes[i] != b'}' {
@@ -215,6 +223,11 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                                     }),
                                     span,
                                 };
+                            } else {
+                                errors.push(ParseError::Forbidden {
+                                    message: "unclosed '[' in string offset interpolation".into(),
+                                    span: Span::new(bracket_offset, base_offset + i as u32),
+                                });
                             }
                         }
                         // Skip to closing }
@@ -336,6 +349,7 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                     ));
                 }
 
+                let brace_offset = base_offset + i as u32;
                 i += 1; // skip {
                         // Find matching }
                 let expr_start = i;
@@ -369,6 +383,11 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                 let expr_end = i; // position of } or end of string
                 if depth == 0 {
                     i += 1; // skip }
+                } else {
+                    errors.push(ParseError::Forbidden {
+                        message: "unclosed '{' in string interpolation".into(),
+                        span: Span::new(brace_offset, base_offset + expr_end as u32),
+                    });
                 }
 
                 // Parse the expression using a sub-parser starting at the absolute offset
@@ -419,6 +438,7 @@ pub fn parse_interpolated_parts_indented<'arena, 'src>(
     body_offset: u32,
     indent: &str,
     version: PhpVersion,
+    errors: &mut Vec<ParseError>,
 ) -> ArenaVec<'arena, StringPart<'arena, 'src>> {
     let indent_len = indent.len();
     let mut parts: ArenaVec<'arena, StringPart<'arena, 'src>> =
@@ -627,6 +647,7 @@ pub fn parse_interpolated_parts_indented<'arena, 'src>(
                     parts.push(StringPart::Literal(arena.alloc_str(&literal)));
                     literal.clear();
                 }
+                let brace_offset = body_offset + i as u32;
                 i += 1; // skip {
                 let expr_start = i;
                 let mut depth = 1;
@@ -657,6 +678,11 @@ pub fn parse_interpolated_parts_indented<'arena, 'src>(
                 let expr_end = i;
                 if depth == 0 {
                     i += 1; // skip }
+                } else {
+                    errors.push(ParseError::Forbidden {
+                        message: "unclosed '{' in string interpolation".into(),
+                        span: Span::new(brace_offset, body_offset + expr_end as u32),
+                    });
                 }
                 // raw_body is a verbatim source slice, so body_offset + expr_start is the
                 // correct absolute position — use the fast sub-parser path directly.

--- a/crates/php-parser/src/parser.rs
+++ b/crates/php-parser/src/parser.rs
@@ -384,6 +384,10 @@ impl<'arena, 'src> Parser<'arena, 'src> {
         }
     }
 
+    pub fn errors_mut(&mut self) -> &mut Vec<ParseError> {
+        &mut self.errors
+    }
+
     pub fn into_errors(self) -> Vec<ParseError> {
         self.errors
     }

--- a/crates/php-parser/tests/fixtures/errors/string_unclosed_complex_interpolation.phpt
+++ b/crates/php-parser/tests/fixtures/errors/string_unclosed_complex_interpolation.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php $s = "text {$incomplete";
 ===errors===

--- a/crates/php-parser/tests/fixtures/errors/string_unclosed_complex_interpolation.phpt
+++ b/crates/php-parser/tests/fixtures/errors/string_unclosed_complex_interpolation.phpt
@@ -1,0 +1,67 @@
+===source===
+<?php $s = "text {$incomplete";
+===errors===
+unclosed '{' in string interpolation
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "s"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Literal": "text "
+                    },
+                    {
+                      "Expr": {
+                        "kind": {
+                          "Variable": "incomplete"
+                        },
+                        "span": {
+                          "start": 18,
+                          "end": 29
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 30
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 30
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 31
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 31
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected double-quote mark, expecting "->" or "?->" or "[" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/string_unclosed_offset_interpolation.phpt
+++ b/crates/php-parser/tests/fixtures/errors/string_unclosed_offset_interpolation.phpt
@@ -1,0 +1,64 @@
+===source===
+<?php $s = "${arr[";
+===errors===
+unclosed '[' in string offset interpolation
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "s"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Expr": {
+                        "kind": {
+                          "Variable": "arr"
+                        },
+                        "span": {
+                          "start": 14,
+                          "end": 17
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 19
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 19
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 20
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 20
+  }
+}
+===php_error===
+PHP Parse error:  Unclosed '[' in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/string_unclosed_variable_variable_interpolation.phpt
+++ b/crates/php-parser/tests/fixtures/errors/string_unclosed_variable_variable_interpolation.phpt
@@ -1,0 +1,75 @@
+===source===
+<?php $s = "text ${$var";
+===errors===
+unclosed '${' in string interpolation
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "s"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Literal": "text "
+                    },
+                    {
+                      "Expr": {
+                        "kind": {
+                          "VariableVariable": {
+                            "kind": {
+                              "Variable": "var"
+                            },
+                            "span": {
+                              "start": 19,
+                              "end": 23
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 17,
+                          "end": 23
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 24
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 24
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 25
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 25
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected double-quote mark in Standard input code on line 1

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -55,6 +55,9 @@
 ### Releases & Changelog
 - **[CHANGELOG.md](development/CHANGELOG.md)** — Version history and notable changes
 
+### Development Guides
+- **[ERRORS.md](development/ERRORS.md)** — Error types, fixture error sections, and parse-leniency divergences
+
 ---
 
 ## Key Findings
@@ -123,7 +126,8 @@ docs/
 │   ├── COVERAGE_REPORT.md                           # Code coverage (93-94%)
 │   └── STMT_COVERAGE_ANALYSIS.md                    # Statement coverage gaps
 └── development/
-    └── CHANGELOG.md                                  # Version history
+    ├── CHANGELOG.md                                  # Version history
+    └── ERRORS.md                                     # Error types and fixture error sections
 ```
 
 ---

--- a/docs/development/ERRORS.md
+++ b/docs/development/ERRORS.md
@@ -1,0 +1,103 @@
+# Error System
+
+The parser never fails fatally — it always produces a complete AST. Errors are accumulated in a `Vec<ParseError>` and returned alongside the AST in `ParseResult`. This document explains the error types, how they are reported, and how to test them.
+
+---
+
+## `ParseError` enum
+
+Defined in `crates/php-parser/src/diagnostics.rs`. Each variant carries a [`Span`] and implements `Display` via `thiserror`. The `Display` text is what appears in `===errors===` fixture sections.
+
+| Variant | Display message |
+|---------|----------------|
+| `Expected { expected, found, span }` | `expected {expected}, found {found}` |
+| `ExpectedExpression { span }` | `expected expression` |
+| `ExpectedStatement { span }` | `expected statement` |
+| `ExpectedOpenTag { span }` | `expected opening PHP tag` |
+| `UnterminatedString { span }` | `unterminated string literal` |
+| `ExpectedAfter { expected, after, span }` | `expected {expected} after {after}` |
+| `UnclosedDelimiter { delimiter, opened_at, span }` | `unclosed {delimiter} opened at {opened_at:?}` |
+| `Forbidden { message, span }` | `{message}` |
+| `VersionTooLow { feature, required, used, span }` | `'{feature}' requires PHP {required} or higher (targeting PHP {used})` |
+
+### Emitting an error in the parser
+
+Call `parser.error(ParseError::Variant { ... })` anywhere inside a parsing function. The `Parser::error` method appends to `self.errors` (capped at `MAX_ERRORS` to prevent runaway output).
+
+```rust
+parser.error(ParseError::Expected {
+    expected: "';'".into(),
+    found: parser.current_kind(),
+    span: parser.current_span(),
+});
+```
+
+---
+
+## Fixture sections
+
+`.phpt` fixture files have two independent error-related sections:
+
+### `===errors===` — Rust parser errors
+
+Lists one `ParseError` `Display` message per line, in emission order. Its presence asserts that the Rust parser emits at least one error; its absence asserts zero errors.
+
+**This section has no effect on `php_syntax.rs`** — it is checked only by `integration.rs`.
+
+Run `UPDATE_FIXTURES=1 cargo test` to auto-populate or refresh this section.
+
+### `===php_error===` — PHP's rejection message
+
+Present when `php -l` must reject the fixture source. The `php_syntax.rs` test asserts that `php -l` fails and that its stderr matches the stored string (modulo stack traces, which are stripped).
+
+**Absence means `php -l` must succeed.** If a fixture has no `===php_error===` section and PHP rejects it, the PHP syntax test fails.
+
+Run `UPDATE_FIXTURES=1 cargo test` to auto-populate this section too.
+
+### When to use which
+
+| Situation | `===errors===` | `===php_error===` | Directory |
+|-----------|---------------|-------------------|-----------|
+| Parser emits errors, PHP also rejects | yes | yes | `errors/` |
+| Parser emits errors, PHP accepts (lenient parser) | yes | — | `errors/` |
+| Parser is silent, PHP rejects (leniency divergence) | — | yes | `categories/` |
+| Parser is silent, PHP accepts (happy path) | — | — | `categories/` |
+
+> Fixtures in `errors/` must always have an `===errors===` section. If the parser currently does not emit errors for a case where PHP rejects, the fixture belongs in `categories/` (not `errors/`) with `===php_error===` documenting the divergence.
+
+---
+
+## Parse-leniency divergences
+
+When the parser intentionally accepts PHP that `php -l` rejects, document it with:
+
+- `===php_error===` section containing the PHP error
+- A comment in the fixture or nearby doc explaining the intentional leniency
+
+These are cases PHP considers invalid but the parser allows (e.g. unclosed interpolation braces, deprecated syntax still parsed for recovery).
+
+---
+
+## Example: fixture with both sections
+
+```
+===source===
+<?php $x = 1 +;
+===errors===
+expected expression
+===ast===
+{ ... }
+===php_error===
+PHP Parse error:  syntax error, unexpected end of file in Standard input code on line 1
+```
+
+## Example: parser-silent, PHP-rejecting fixture
+
+```
+===source===
+<?php $s = "text {$incomplete";
+===ast===
+{ ... }
+===php_error===
+PHP Parse error:  syntax error, unexpected double-quote mark, expecting "->" or "?->" or "[" in Standard input code on line 1
+```


### PR DESCRIPTION
## Summary

- Emit `Forbidden` parse errors for unclosed `{$...}`, `${$...}`, and `${arr[...` in double-quoted strings and heredocs
- Add `Parser::errors_mut()` accessor and thread `&mut Vec<ParseError>` into `parse_interpolated_parts` / `parse_interpolated_parts_indented`
- Add three `.phpt` fixtures in `errors/` covering each unclosed case, with `===errors===` and `===php_error===` sections
- Add `docs/development/ERRORS.md` documenting all `ParseError` variants and the `===errors===` vs `===php_error===` fixture section mechanics

Closes #182