### PR TITLE
test(arrow_function): add edge case fixtures for body expressions

### DIFF
--- a/crates/php-parser/tests/fixtures/categories/arrow_function/arrow_nested.phpt
+++ b/crates/php-parser/tests/fixtures/categories/arrow_function/arrow_nested.phpt
@@ -1,0 +1,93 @@
+===source===
+<?php $f = fn() => fn() => fn() => 1;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "f"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "ArrowFunction": {
+                    "is_static": false,
+                    "by_ref": false,
+                    "params": [],
+                    "return_type": null,
+                    "body": {
+                      "kind": {
+                        "ArrowFunction": {
+                          "is_static": false,
+                          "by_ref": false,
+                          "params": [],
+                          "return_type": null,
+                          "body": {
+                            "kind": {
+                              "ArrowFunction": {
+                                "is_static": false,
+                                "by_ref": false,
+                                "params": [],
+                                "return_type": null,
+                                "body": {
+                                  "kind": {
+                                    "Int": 1
+                                  },
+                                  "span": {
+                                    "start": 35,
+                                    "end": 36
+                                  }
+                                },
+                                "attributes": []
+                              }
+                            },
+                            "span": {
+                              "start": 27,
+                              "end": 36
+                            }
+                          },
+                          "attributes": []
+                        }
+                      },
+                      "span": {
+                        "start": 19,
+                        "end": 36
+                      }
+                    },
+                    "attributes": []
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 36
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 36
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 37
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 37
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/arrow_function/arrow_returning_assignment.phpt
+++ b/crates/php-parser/tests/fixtures/categories/arrow_function/arrow_returning_assignment.phpt
@@ -1,0 +1,83 @@
+===source===
+<?php $f = fn() => $x = 1;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "f"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "ArrowFunction": {
+                    "is_static": false,
+                    "by_ref": false,
+                    "params": [],
+                    "return_type": null,
+                    "body": {
+                      "kind": {
+                        "Assign": {
+                          "target": {
+                            "kind": {
+                              "Variable": "x"
+                            },
+                            "span": {
+                              "start": 19,
+                              "end": 21
+                            }
+                          },
+                          "op": "Assign",
+                          "value": {
+                            "kind": {
+                              "Int": 1
+                            },
+                            "span": {
+                              "start": 24,
+                              "end": 25
+                            }
+                          }
+                        }
+                      },
+                      "span": {
+                        "start": 19,
+                        "end": 25
+                      }
+                    },
+                    "attributes": []
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 25
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 25
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 26
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 26
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/arrow_function/arrow_with_throw.phpt
+++ b/crates/php-parser/tests/fixtures/categories/arrow_function/arrow_with_throw.phpt
@@ -1,0 +1,82 @@
+===source===
+<?php $f = fn() => throw new Exception();
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "f"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "ArrowFunction": {
+                    "is_static": false,
+                    "by_ref": false,
+                    "params": [],
+                    "return_type": null,
+                    "body": {
+                      "kind": {
+                        "ThrowExpr": {
+                          "kind": {
+                            "New": {
+                              "class": {
+                                "kind": {
+                                  "Identifier": "Exception"
+                                },
+                                "span": {
+                                  "start": 29,
+                                  "end": 38
+                                }
+                              },
+                              "args": []
+                            }
+                          },
+                          "span": {
+                            "start": 25,
+                            "end": 40
+                          }
+                        }
+                      },
+                      "span": {
+                        "start": 19,
+                        "end": 40
+                      }
+                    },
+                    "attributes": []
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 40
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 40
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 41
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 41
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/arrow_function/arrow_with_yield.phpt
+++ b/crates/php-parser/tests/fixtures/categories/arrow_function/arrow_with_yield.phpt
@@ -1,0 +1,75 @@
+===source===
+<?php $f = fn() => yield $x;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "f"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "ArrowFunction": {
+                    "is_static": false,
+                    "by_ref": false,
+                    "params": [],
+                    "return_type": null,
+                    "body": {
+                      "kind": {
+                        "Yield": {
+                          "key": null,
+                          "value": {
+                            "kind": {
+                              "Variable": "x"
+                            },
+                            "span": {
+                              "start": 25,
+                              "end": 27
+                            }
+                          },
+                          "is_from": false
+                        }
+                      },
+                      "span": {
+                        "start": 19,
+                        "end": 27
+                      }
+                    },
+                    "attributes": []
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 27
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 27
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 28
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 28
+  }
+}


### PR DESCRIPTION
## Summary

- Add fixtures for arrow functions returning assignment, yield, throw, and triple-nested arrow functions
- `fn() => yield $x` is valid PHP (creates a generator), so it is placed in `categories/` not `errors/`

Closes #189