### PR TITLE
test(versioned): add void cast edge case fixtures for PHP 8.5

### DIFF
--- a/crates/php-parser/tests/fixtures/versioned/void_cast_array.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/void_cast_array.phpt
@@ -1,0 +1,94 @@
+===config===
+parse_version=8.5
+min_php=8.5
+===source===
+<?php (void)[1, 2, 3];
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Cast": [
+              "Void",
+              {
+                "kind": {
+                  "Array": [
+                    {
+                      "key": null,
+                      "value": {
+                        "kind": {
+                          "Int": 1
+                        },
+                        "span": {
+                          "start": 13,
+                          "end": 14
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 13,
+                        "end": 14
+                      }
+                    },
+                    {
+                      "key": null,
+                      "value": {
+                        "kind": {
+                          "Int": 2
+                        },
+                        "span": {
+                          "start": 16,
+                          "end": 17
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 16,
+                        "end": 17
+                      }
+                    },
+                    {
+                      "key": null,
+                      "value": {
+                        "kind": {
+                          "Int": 3
+                        },
+                        "span": {
+                          "start": 19,
+                          "end": 20
+                        }
+                      },
+                      "unpack": false,
+                      "span": {
+                        "start": 19,
+                        "end": 20
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 12,
+                  "end": 21
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 6,
+            "end": 21
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 22
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 22
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/void_cast_chained.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/void_cast_chained.phpt
@@ -1,0 +1,53 @@
+===config===
+parse_version=8.5
+min_php=8.5
+===source===
+<?php (void)(void)$x;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Cast": [
+              "Void",
+              {
+                "kind": {
+                  "Cast": [
+                    "Void",
+                    {
+                      "kind": {
+                        "Variable": "x"
+                      },
+                      "span": {
+                        "start": 18,
+                        "end": 20
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 12,
+                  "end": 20
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 6,
+            "end": 20
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 21
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 21
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/void_cast_function_call.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/void_cast_function_call.phpt
@@ -1,0 +1,53 @@
+===config===
+parse_version=8.5
+min_php=8.5
+===source===
+<?php (void)someFn();
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Cast": [
+              "Void",
+              {
+                "kind": {
+                  "FunctionCall": {
+                    "name": {
+                      "kind": {
+                        "Identifier": "someFn"
+                      },
+                      "span": {
+                        "start": 12,
+                        "end": 18
+                      }
+                    },
+                    "args": []
+                  }
+                },
+                "span": {
+                  "start": 12,
+                  "end": 20
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 6,
+            "end": 20
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 21
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 21
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/void_cast_in_expression.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/void_cast_in_expression.phpt
@@ -1,0 +1,82 @@
+===config===
+parse_version=8.5
+min_php=8.5
+===source===
+<?php $x = (void)1 + 2;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Binary": {
+                    "left": {
+                      "kind": {
+                        "Cast": [
+                          "Void",
+                          {
+                            "kind": {
+                              "Int": 1
+                            },
+                            "span": {
+                              "start": 17,
+                              "end": 18
+                            }
+                          }
+                        ]
+                      },
+                      "span": {
+                        "start": 11,
+                        "end": 18
+                      }
+                    },
+                    "op": "Add",
+                    "right": {
+                      "kind": {
+                        "Int": 2
+                      },
+                      "span": {
+                        "start": 21,
+                        "end": 22
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 22
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 22
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 23
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 23
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/void_cast_match.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/void_cast_match.phpt
@@ -1,0 +1,70 @@
+===config===
+parse_version=8.5
+min_php=8.5
+===source===
+<?php (void)match($x) { default => 1 };
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Cast": [
+              "Void",
+              {
+                "kind": {
+                  "Match": {
+                    "subject": {
+                      "kind": {
+                        "Variable": "x"
+                      },
+                      "span": {
+                        "start": 18,
+                        "end": 20
+                      }
+                    },
+                    "arms": [
+                      {
+                        "conditions": null,
+                        "body": {
+                          "kind": {
+                            "Int": 1
+                          },
+                          "span": {
+                            "start": 35,
+                            "end": 36
+                          }
+                        },
+                        "span": {
+                          "start": 24,
+                          "end": 36
+                        }
+                      }
+                    ]
+                  }
+                },
+                "span": {
+                  "start": 12,
+                  "end": 38
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 6,
+            "end": 38
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 39
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 39
+  }
+}


### PR DESCRIPTION
## Summary

- Add 5 `.phpt` fixtures covering void cast edge cases: array operand, chained casts, expression precedence, function call, and match expression
- All fixtures use `parse_version=8.5` and `min_php=8.5` under `crates/php-parser/tests/fixtures/versioned/`

Closes #181