### PR TITLE
refactor(test): replace parse_version config with min_php

### DIFF
--- a/crates/php-parser/tests/common.rs
+++ b/crates/php-parser/tests/common.rs
@@ -1,24 +1,33 @@
-/// Parse a fixture file and return `(parse_version, source)`.
+/// Configuration parsed from a fixture's `===config===` section.
+pub struct FixtureConfig {
+    pub min_php: Option<(u32, u32)>,
+    pub max_php: Option<(u32, u32)>,
+}
+
+/// Parse a fixture file and return `(config, source)`.
 ///
-/// `parse_version` is read from an optional `===config===` section.
+/// Config is read from an optional `===config===` section.
 /// `source` is the PHP code between `===source===` and the next section marker.
 ///
 /// All other section contents (`===errors===`, `===ast===`, `===php_error===`) are
 /// left for each test binary to extract directly from the original content, since
 /// different test binaries need different subsets.
-pub fn parse_fixture(content: &str) -> (Option<(u32, u32)>, &str) {
+pub fn parse_fixture(content: &str) -> (FixtureConfig, &str) {
     let parse_ver = |val: &str| -> Option<(u32, u32)> {
         val.split_once('.')
             .and_then(|(a, b)| Some((a.parse().ok()?, b.parse().ok()?)))
     };
 
-    let mut parse_version = None;
+    let mut min_php = None;
+    let mut max_php = None;
 
     let rest = if let Some(rest) = content.strip_prefix("===config===\n") {
         let source_marker = rest.find("===source===\n").unwrap_or(rest.len());
         for line in rest[..source_marker].lines() {
-            if let Some(val) = line.strip_prefix("parse_version=") {
-                parse_version = parse_ver(val);
+            if let Some(val) = line.strip_prefix("min_php=") {
+                min_php = parse_ver(val);
+            } else if let Some(val) = line.strip_prefix("max_php=") {
+                max_php = parse_ver(val);
             }
         }
         &rest[source_marker..]
@@ -45,5 +54,5 @@ pub fn parse_fixture(content: &str) -> (Option<(u32, u32)>, &str) {
         source_raw.strip_suffix('\n').unwrap_or(source_raw)
     };
 
-    (parse_version, source)
+    (FixtureConfig { min_php, max_php }, source)
 }

--- a/crates/php-parser/tests/common.rs
+++ b/crates/php-parser/tests/common.rs
@@ -1,33 +1,25 @@
-/// Configuration parsed from a fixture's `===config===` section.
-pub struct FixtureConfig {
-    pub min_php: Option<(u32, u32)>,
-    pub max_php: Option<(u32, u32)>,
-}
-
-/// Parse a fixture file and return `(config, source)`.
+/// Parse a fixture file and return `(min_php, source)`.
 ///
-/// Config is read from an optional `===config===` section.
+/// `min_php` is read from an optional `===config===` section and controls both
+/// the Rust parse target version and the minimum PHP version for `php -l` gating.
 /// `source` is the PHP code between `===source===` and the next section marker.
 ///
 /// All other section contents (`===errors===`, `===ast===`, `===php_error===`) are
 /// left for each test binary to extract directly from the original content, since
 /// different test binaries need different subsets.
-pub fn parse_fixture(content: &str) -> (FixtureConfig, &str) {
+pub fn parse_fixture(content: &str) -> (Option<(u32, u32)>, &str) {
     let parse_ver = |val: &str| -> Option<(u32, u32)> {
         val.split_once('.')
             .and_then(|(a, b)| Some((a.parse().ok()?, b.parse().ok()?)))
     };
 
     let mut min_php = None;
-    let mut max_php = None;
 
     let rest = if let Some(rest) = content.strip_prefix("===config===\n") {
         let source_marker = rest.find("===source===\n").unwrap_or(rest.len());
         for line in rest[..source_marker].lines() {
             if let Some(val) = line.strip_prefix("min_php=") {
                 min_php = parse_ver(val);
-            } else if let Some(val) = line.strip_prefix("max_php=") {
-                max_php = parse_ver(val);
             }
         }
         &rest[source_marker..]
@@ -54,5 +46,5 @@ pub fn parse_fixture(content: &str) -> (FixtureConfig, &str) {
         source_raw.strip_suffix('\n').unwrap_or(source_raw)
     };
 
-    (FixtureConfig { min_php, max_php }, source)
+    (min_php, source)
 }

--- a/crates/php-parser/tests/fixtures/abstract_readonly_class.phpt
+++ b/crates/php-parser/tests/fixtures/abstract_readonly_class.phpt
@@ -1,5 +1,5 @@
 ===config===
-min_php=8.2
+min_php=8.4
 ===source===
 <?php abstract readonly class Foo {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/constructor_final_param_typed.phpt
+++ b/crates/php-parser/tests/fixtures/constructor_final_param_typed.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.5
+min_php=8.5
 ===source===
 <?php class P { public function __construct(final int $i) {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/errors/ternary_unparenthesized_chain.phpt
+++ b/crates/php-parser/tests/fixtures/errors/ternary_unparenthesized_chain.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.0
+min_php=8.0
 ===source===
 <?php $x = true ? 1 : 2 ? 3 : 4;
 ===errors===

--- a/crates/php-parser/tests/fixtures/explicit_octal_81.phpt
+++ b/crates/php-parser/tests/fixtures/explicit_octal_81.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.1
+min_php=8.1
 ===source===
 <?php $x = 0o777;
 ===ast===

--- a/crates/php-parser/tests/fixtures/param_final_preserved.phpt
+++ b/crates/php-parser/tests/fixtures/param_final_preserved.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.5
+min_php=8.5
 ===source===
 <?php class Foo { public function __construct(public final string $bar) {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/param_is_final.phpt
+++ b/crates/php-parser/tests/fixtures/param_is_final.phpt
@@ -1,6 +1,5 @@
 ===config===
 min_php=8.5
-parse_version=8.5
 ===source===
 <?php class Foo { public function __construct(public final string $bar) {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/param_is_readonly.phpt
+++ b/crates/php-parser/tests/fixtures/param_is_readonly.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.1
+min_php=8.1
 ===source===
 <?php function foo(readonly string $x) {}
 ===ast===
@@ -61,3 +61,5 @@ parse_version=8.1
     "end": 41
   }
 }
+===php_error===
+PHP Fatal error:  Cannot declare promoted property outside a constructor in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/param_readonly_preserved.phpt
+++ b/crates/php-parser/tests/fixtures/param_readonly_preserved.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.1
+min_php=8.1
 ===source===
 <?php function foo(readonly string $x) {}
 ===ast===
@@ -61,3 +61,5 @@ parse_version=8.1
     "end": 41
   }
 }
+===php_error===
+PHP Fatal error:  Cannot declare promoted property outside a constructor in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/ternary_chain_with_parens.phpt
+++ b/crates/php-parser/tests/fixtures/ternary_chain_with_parens.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.0
+min_php=8.0
 ===source===
 <?php $x = (true ? 1 : 2) ? 3 : 4;
 ===ast===

--- a/crates/php-parser/tests/fixtures/ternary_simple_no_chain.phpt
+++ b/crates/php-parser/tests/fixtures/ternary_simple_no_chain.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.0
+min_php=8.0
 ===source===
 <?php $x = true ? 1 : 2;
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/abstract_readonly_class_requires_84_v83.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/abstract_readonly_class_requires_84_v83.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.3
+min_php=8.3
 ===source===
 <?php abstract readonly class Foo {}
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/abstract_readonly_class_requires_84_v83.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/abstract_readonly_class_requires_84_v83.phpt
@@ -1,5 +1,6 @@
 ===config===
 min_php=8.3
+max_php=8.3
 ===source===
 <?php abstract readonly class Foo {}
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/abstract_readonly_class_requires_84_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/abstract_readonly_class_requires_84_v84.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.4
+min_php=8.4
 ===source===
 <?php abstract readonly class Foo {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/clone_callable_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/clone_callable_requires_85_v84.phpt
@@ -63,3 +63,5 @@ max_php=8.4
     "end": 23
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "..." in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/versioned/clone_callable_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/clone_callable_requires_85_v84.phpt
@@ -1,5 +1,6 @@
 ===config===
 min_php=8.4
+max_php=8.4
 ===source===
 <?php $fn = clone(...);
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/clone_callable_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/clone_callable_requires_85_v84.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.4
+min_php=8.4
 ===source===
 <?php $fn = clone(...);
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/clone_with_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/clone_with_requires_85_v84.phpt
@@ -96,3 +96,5 @@ max_php=8.4
     "end": 39
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "," in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/versioned/clone_with_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/clone_with_requires_85_v84.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.4
+min_php=8.4
 ===source===
 <?php $b = clone($a, ['alpha' => 128]);
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/clone_with_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/clone_with_requires_85_v84.phpt
@@ -1,5 +1,6 @@
 ===config===
 min_php=8.4
+max_php=8.4
 ===source===
 <?php $b = clone($a, ['alpha' => 128]);
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/clone_with_requires_85_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/clone_with_requires_85_v85.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.5
+min_php=8.5
 ===source===
 <?php $b = clone($a, ['alpha' => 128]);
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/const_attributes_require_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/const_attributes_require_85_v84.phpt
@@ -1,5 +1,6 @@
 ===config===
 min_php=8.4
+max_php=8.4
 ===source===
 <?php #[MyAttr] const VERSION = '8.5';
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/const_attributes_require_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/const_attributes_require_85_v84.phpt
@@ -59,3 +59,5 @@ max_php=8.4
     "end": 38
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "const" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/versioned/const_attributes_require_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/const_attributes_require_85_v84.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.4
+min_php=8.4
 ===source===
 <?php #[MyAttr] const VERSION = '8.5';
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/const_attributes_require_85_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/const_attributes_require_85_v85.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.5
+min_php=8.5
 ===source===
 <?php #[MyAttr] const VERSION = '8.5';
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/dnf_types_require_82_v81.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/dnf_types_require_82_v81.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.1
+min_php=8.1
 ===source===
 <?php function f((A&B)|C $x) {}
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/dnf_types_require_82_v82.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/dnf_types_require_82_v82.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.2
+min_php=8.2
 ===source===
 <?php function f((A&B)|C $x) {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/dynamic_class_const_requires_83_v82.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/dynamic_class_const_requires_83_v82.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.2
+min_php=8.2
 ===source===
 <?php
 $x = Foo::{$name};

--- a/crates/php-parser/tests/fixtures/versioned/dynamic_class_const_requires_83_v82.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/dynamic_class_const_requires_83_v82.phpt
@@ -71,3 +71,5 @@ $x = Foo::{$name};
     "end": 24
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token ";", expecting "(" in Standard input code on line 2

--- a/crates/php-parser/tests/fixtures/versioned/dynamic_class_const_requires_83_v82.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/dynamic_class_const_requires_83_v82.phpt
@@ -1,5 +1,6 @@
 ===config===
 min_php=8.2
+max_php=8.2
 ===source===
 <?php
 $x = Foo::{$name};

--- a/crates/php-parser/tests/fixtures/versioned/enum_requires_81_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/enum_requires_81_v80.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.0
+min_php=8.0
 ===source===
 <?php enum Status { case Active; case Inactive; }
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/enum_requires_81_v81.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/enum_requires_81_v81.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.1
+min_php=8.1
 ===source===
 <?php enum Status { case Active; case Inactive; }
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/final_promoted_property_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/final_promoted_property_requires_85_v84.phpt
@@ -89,3 +89,5 @@ max_php=8.4
     "end": 76
   }
 }
+===php_error===
+PHP Fatal error:  Cannot use the final modifier on a parameter in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/versioned/final_promoted_property_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/final_promoted_property_requires_85_v84.phpt
@@ -1,5 +1,6 @@
 ===config===
 min_php=8.4
+max_php=8.4
 ===source===
 <?php class Foo { public function __construct(public final string $bar) {} }
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/final_promoted_property_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/final_promoted_property_requires_85_v84.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.4
+min_php=8.4
 ===source===
 <?php class Foo { public function __construct(public final string $bar) {} }
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/final_promoted_property_requires_85_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/final_promoted_property_requires_85_v85.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.5
+min_php=8.5
 ===source===
 <?php class Foo { public function __construct(public final string $bar) {} }
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/first_class_callable_requires_81_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/first_class_callable_requires_81_v80.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.0
+min_php=8.0
 ===source===
 <?php $fn = strlen(...);
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/first_class_callable_requires_81_v81.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/first_class_callable_requires_81_v81.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.1
+min_php=8.1
 ===source===
 <?php $fn = strlen(...);
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/interpolation_respects_version_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/interpolation_respects_version_v80.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.0
+min_php=8.0
 ===source===
 <?php
 $x = "{$obj?->prop}";

--- a/crates/php-parser/tests/fixtures/versioned/match_requires_80_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/match_requires_80_v80.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.0
+min_php=8.0
 ===source===
 <?php $x = match($y) { 1 => 'a', default => 'b' };
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/mixed_type_requires_80_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/mixed_type_requires_80_v80.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.0
+min_php=8.0
 ===source===
 <?php function f(mixed $x) {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/never_type_requires_81_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/never_type_requires_81_v80.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.0
+min_php=8.0
 ===source===
 <?php function f(): never { throw new \Exception(); }
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/never_type_requires_81_v81.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/never_type_requires_81_v81.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.1
+min_php=8.1
 ===source===
 <?php function f(): never { throw new \Exception(); }
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/nonassoc_chaining_rejected_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/nonassoc_chaining_rejected_v80.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.0
+min_php=8.0
 ===source===
 <?php
 $a = 1 < 2 < 3;

--- a/crates/php-parser/tests/fixtures/versioned/pipe_operator_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/pipe_operator_requires_85_v84.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.4
+min_php=8.4
 ===source===
 <?php $x = $value |> trim(...) |> strtolower(...);
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/pipe_operator_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/pipe_operator_requires_85_v84.phpt
@@ -116,3 +116,5 @@ max_php=8.4
     "end": 50
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token ">" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/versioned/pipe_operator_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/pipe_operator_requires_85_v84.phpt
@@ -1,5 +1,6 @@
 ===config===
 min_php=8.4
+max_php=8.4
 ===source===
 <?php $x = $value |> trim(...) |> strtolower(...);
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/pipe_operator_requires_85_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/pipe_operator_requires_85_v85.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.5
+min_php=8.5
 ===source===
 <?php $x = $value |> trim(...) |> strtolower(...);
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/readonly_class_requires_82_v81.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/readonly_class_requires_82_v81.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.1
+min_php=8.1
 ===source===
 <?php readonly class Foo { public string $bar; }
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/readonly_class_requires_82_v82.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/readonly_class_requires_82_v82.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.2
+min_php=8.2
 ===source===
 <?php readonly class Foo { public string $bar; }
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/real_cast_allowed_in_74_v74.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/real_cast_allowed_in_74_v74.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=7.4
+min_php=7.4
 ===source===
 <?php $a = (real) 1.5;
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/real_cast_rejected_in_80_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/real_cast_rejected_in_80_v80.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.0
+min_php=8.0
 ===source===
 <?php $a = (real) 1.5;
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/static_asymmetric_visibility_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/static_asymmetric_visibility_requires_85_v84.phpt
@@ -1,5 +1,6 @@
 ===config===
 min_php=8.4
+max_php=8.4
 ===source===
 <?php class Foo { public static private(set) string $bar = 'x'; }
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/static_asymmetric_visibility_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/static_asymmetric_visibility_requires_85_v84.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.4
+min_php=8.4
 ===source===
 <?php class Foo { public static private(set) string $bar = 'x'; }
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/static_asymmetric_visibility_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/static_asymmetric_visibility_requires_85_v84.phpt
@@ -78,3 +78,5 @@ max_php=8.4
     "end": 65
   }
 }
+===php_error===
+PHP Fatal error:  Static property may not have asymmetric visibility in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/versioned/static_asymmetric_visibility_requires_85_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/static_asymmetric_visibility_requires_85_v85.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.5
+min_php=8.5
 ===source===
 <?php class Foo { public static private(set) string $bar = 'x'; }
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/ternary_chain_requires_parens_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/ternary_chain_requires_parens_v80.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.0
+min_php=8.0
 ===source===
 <?php $x = true ? 1 : 2 ? 3 : 4;
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/ternary_chaining_rejected_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/ternary_chaining_rejected_v80.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.0
+min_php=8.0
 ===source===
 <?php
 $a = $x ? $y ? 1 : 2 : 3;

--- a/crates/php-parser/tests/fixtures/versioned/true_type_requires_82_v81.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/true_type_requires_82_v81.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.1
+min_php=8.1
 ===source===
 <?php function f(true $x) {}
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/true_type_requires_82_v82.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/true_type_requires_82_v82.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.2
+min_php=8.2
 ===source===
 <?php function f(true $x) {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/typed_constants_require_83_v82.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/typed_constants_require_83_v82.phpt
@@ -1,5 +1,6 @@
 ===config===
 min_php=8.2
+max_php=8.2
 ===source===
 <?php class Foo { public const string NAME = 'foo'; }
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/typed_constants_require_83_v82.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/typed_constants_require_83_v82.phpt
@@ -75,3 +75,5 @@ max_php=8.2
     "end": 53
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected identifier "NAME", expecting "=" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/versioned/typed_constants_require_83_v82.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/typed_constants_require_83_v82.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.2
+min_php=8.2
 ===source===
 <?php class Foo { public const string NAME = 'foo'; }
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/typed_constants_require_83_v83.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/typed_constants_require_83_v83.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.3
+min_php=8.3
 ===source===
 <?php class Foo { public const string NAME = 'foo'; }
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/union_types_require_80_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/union_types_require_80_v80.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.0
+min_php=8.0
 ===source===
 <?php function f(int|string $x) {}
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/unset_cast_allowed_in_74_v74.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/unset_cast_allowed_in_74_v74.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=7.4
+min_php=7.4
 ===source===
 <?php (unset)$x;
 ===ast===

--- a/crates/php-parser/tests/fixtures/versioned/unset_cast_rejected_in_80_v80.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/unset_cast_rejected_in_80_v80.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.0
+min_php=8.0
 ===source===
 <?php (unset)$x;
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/void_cast_array.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/void_cast_array.phpt
@@ -1,5 +1,4 @@
 ===config===
-parse_version=8.5
 min_php=8.5
 ===source===
 <?php (void)[1, 2, 3];

--- a/crates/php-parser/tests/fixtures/versioned/void_cast_chained.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/void_cast_chained.phpt
@@ -1,5 +1,4 @@
 ===config===
-parse_version=8.5
 min_php=8.5
 ===source===
 <?php (void)(void)$x;
@@ -51,3 +50,5 @@ min_php=8.5
     "end": 21
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "(void)" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/versioned/void_cast_function_call.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/void_cast_function_call.phpt
@@ -1,5 +1,4 @@
 ===config===
-parse_version=8.5
 min_php=8.5
 ===source===
 <?php (void)someFn();

--- a/crates/php-parser/tests/fixtures/versioned/void_cast_in_expression.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/void_cast_in_expression.phpt
@@ -1,5 +1,4 @@
 ===config===
-parse_version=8.5
 min_php=8.5
 ===source===
 <?php $x = (void)1 + 2;
@@ -80,3 +79,5 @@ min_php=8.5
     "end": 23
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected token "(void)" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/versioned/void_cast_match.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/void_cast_match.phpt
@@ -1,5 +1,4 @@
 ===config===
-parse_version=8.5
 min_php=8.5
 ===source===
 <?php (void)match($x) { default => 1 };

--- a/crates/php-parser/tests/fixtures/versioned/void_cast_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/void_cast_requires_85_v84.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.4
+min_php=8.4
 ===source===
 <?php (void) getVersion();
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/void_cast_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/void_cast_requires_85_v84.phpt
@@ -53,3 +53,5 @@ max_php=8.4
     "end": 26
   }
 }
+===php_error===
+PHP Parse error:  syntax error, unexpected identifier "getVersion" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/versioned/void_cast_requires_85_v84.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/void_cast_requires_85_v84.phpt
@@ -1,5 +1,6 @@
 ===config===
 min_php=8.4
+max_php=8.4
 ===source===
 <?php (void) getVersion();
 ===errors===

--- a/crates/php-parser/tests/fixtures/versioned/void_cast_requires_85_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/void_cast_requires_85_v85.phpt
@@ -1,5 +1,5 @@
 ===config===
-parse_version=8.5
+min_php=8.5
 ===source===
 <?php (void) getVersion();
 ===ast===

--- a/crates/php-parser/tests/integration.rs
+++ b/crates/php-parser/tests/integration.rs
@@ -89,10 +89,10 @@ fn fixtures() {
     for path in paths {
         let rel = path.strip_prefix(&dir).unwrap().to_string_lossy();
         let content = std::fs::read_to_string(&path).unwrap();
-        let (config, source) = common::parse_fixture(&content);
+        let (min_php, source) = common::parse_fixture(&content);
         let arena = bumpalo::Bump::new();
 
-        let result = if let Some(ver) = config.min_php {
+        let result = if let Some(ver) = min_php {
             php_rs_parser::parse_versioned(&arena, source, php_version(ver))
         } else {
             php_rs_parser::parse(&arena, source)

--- a/crates/php-parser/tests/integration.rs
+++ b/crates/php-parser/tests/integration.rs
@@ -89,10 +89,10 @@ fn fixtures() {
     for path in paths {
         let rel = path.strip_prefix(&dir).unwrap().to_string_lossy();
         let content = std::fs::read_to_string(&path).unwrap();
-        let (parse_version, source) = common::parse_fixture(&content);
+        let (config, source) = common::parse_fixture(&content);
         let arena = bumpalo::Bump::new();
 
-        let result = if let Some(ver) = parse_version {
+        let result = if let Some(ver) = config.min_php {
             php_rs_parser::parse_versioned(&arena, source, php_version(ver))
         } else {
             php_rs_parser::parse(&arena, source)

--- a/crates/php-parser/tests/php_syntax.rs
+++ b/crates/php-parser/tests/php_syntax.rs
@@ -91,32 +91,6 @@ fn collect_phpt_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
     paths
 }
 
-type VersionPair = (u32, u32);
-
-/// Parse the `===config===` section of a fixture, returning `(min_php, max_php)`.
-fn parse_config_versions(content: &str) -> (Option<VersionPair>, Option<VersionPair>) {
-    let parse_ver = |val: &str| -> Option<(u32, u32)> {
-        val.split_once('.')
-            .and_then(|(a, b)| Some((a.parse().ok()?, b.parse().ok()?)))
-    };
-
-    let mut min_php = None;
-    let mut max_php = None;
-
-    if let Some(rest) = content.strip_prefix("===config===\n") {
-        let source_marker = rest.find("===source===\n").unwrap_or(rest.len());
-        for line in rest[..source_marker].lines() {
-            if let Some(val) = line.strip_prefix("min_php=") {
-                min_php = parse_ver(val);
-            } else if let Some(val) = line.strip_prefix("max_php=") {
-                max_php = parse_ver(val);
-            }
-        }
-    }
-
-    (min_php, max_php)
-}
-
 /// Extract the `===php_error===` section from fixture content, if present.
 fn parse_php_error(content: &str) -> Option<String> {
     content.find("===php_error===\n").map(|p| {
@@ -136,7 +110,7 @@ fn update_fixture_php_error(path: &str, actual: &str) {
     } else {
         // Append a new section.
         format!(
-            "{}===php_error===\n{}\n",
+            "{}\n===php_error===\n{}\n",
             content.trim_end_matches('\n'),
             actual
         )
@@ -171,24 +145,18 @@ fn fixture_files_are_valid_php() {
             .to_string_lossy()
             .to_string();
         let src = std::fs::read_to_string(&path).unwrap();
-        let (parse_version, source) = common::parse_fixture(&src);
-        let (min_php, max_php) = parse_config_versions(&src);
+        let (config, source) = common::parse_fixture(&src);
         let php_error = parse_php_error(&src);
 
-        if let Some(min) = min_php {
+        if let Some(min) = config.min_php {
             if !php_version_met(min) {
                 continue;
             }
         }
-        if let Some(max) = max_php {
+        if let Some(max) = config.max_php {
             if php_version_exceeded(max) {
                 continue;
             }
-        }
-        // Skip version-specific fixtures — they test parser behavior at a particular
-        // PHP version and may contain syntax that PHP itself rejects semantically.
-        if parse_version.is_some() {
-            continue;
         }
 
         let out = php_lint(source);
@@ -210,10 +178,12 @@ fn fixture_files_are_valid_php() {
         } else {
             // No ===php_error=== — PHP must accept.
             if !out.status.success() {
-                failures.push(format!(
-                    "{label}:\n  {}",
-                    String::from_utf8_lossy(&out.stderr).trim()
-                ));
+                let actual = strip_stack_trace(String::from_utf8_lossy(&out.stderr).trim());
+                if update {
+                    update_fixture_php_error(path.to_str().unwrap(), &actual);
+                } else {
+                    failures.push(format!("{label}:\n  {actual}"));
+                }
             }
         }
     }

--- a/crates/php-parser/tests/php_syntax.rs
+++ b/crates/php-parser/tests/php_syntax.rs
@@ -91,6 +91,22 @@ fn collect_phpt_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
     paths
 }
 
+/// Parse `max_php` from the `===config===` section of a fixture, if present.
+fn parse_max_php(content: &str) -> Option<(u32, u32)> {
+    let parse_ver = |val: &str| -> Option<(u32, u32)> {
+        val.split_once('.')
+            .and_then(|(a, b)| Some((a.parse().ok()?, b.parse().ok()?)))
+    };
+    let rest = content.strip_prefix("===config===\n")?;
+    let source_marker = rest.find("===source===\n").unwrap_or(rest.len());
+    for line in rest[..source_marker].lines() {
+        if let Some(val) = line.strip_prefix("max_php=") {
+            return parse_ver(val);
+        }
+    }
+    None
+}
+
 /// Extract the `===php_error===` section from fixture content, if present.
 fn parse_php_error(content: &str) -> Option<String> {
     content.find("===php_error===\n").map(|p| {
@@ -145,15 +161,16 @@ fn fixture_files_are_valid_php() {
             .to_string_lossy()
             .to_string();
         let src = std::fs::read_to_string(&path).unwrap();
-        let (config, source) = common::parse_fixture(&src);
+        let (min_php, source) = common::parse_fixture(&src);
+        let max_php = parse_max_php(&src);
         let php_error = parse_php_error(&src);
 
-        if let Some(min) = config.min_php {
+        if let Some(min) = min_php {
             if !php_version_met(min) {
                 continue;
             }
         }
-        if let Some(max) = config.max_php {
+        if let Some(max) = max_php {
             if php_version_exceeded(max) {
                 continue;
             }


### PR DESCRIPTION
## Summary

- Removes the `parse_version` fixture config key; `min_php` now serves double duty as both the Rust parse target version (used by `integration.rs`) and the minimum PHP version for `php -l` gating (used by `php_syntax.rs`)
- `UPDATE_FIXTURES=1` now also creates new `===php_error===` sections (previously it only updated existing ones), making it truly self-contained
- Fixes a pre-existing wrong value: `abstract_readonly_class.phpt` had `min_php=8.2` but `abstract readonly class` requires PHP 8.4

## Details

55 fixtures had `parse_version=X.Y` replaced with `min_php=X.Y`. Four fixtures (`param_is_readonly`, `param_readonly_preserved`, `void_cast_chained`, `void_cast_in_expression`) were previously skipped by `php_syntax.rs` via the `parse_version` check — they are now correctly gated by their `min_php` and have `===php_error===` sections populated.