### PR TITLE
test(versioned): add clone-with edge case fixtures for PHP 8.5

### DIFF
--- a/crates/php-parser/tests/fixtures/versioned/clone_with_expression_value_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/clone_with_expression_value_v85.phpt
@@ -1,0 +1,115 @@
+===config===
+min_php=8.5
+===source===
+<?php $b = clone($obj, ['prop' => 1 + 2]);
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "b"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "CloneWith": [
+                    {
+                      "kind": {
+                        "Variable": "obj"
+                      },
+                      "span": {
+                        "start": 17,
+                        "end": 21
+                      }
+                    },
+                    {
+                      "kind": {
+                        "Array": [
+                          {
+                            "key": {
+                              "kind": {
+                                "String": "prop"
+                              },
+                              "span": {
+                                "start": 24,
+                                "end": 30
+                              }
+                            },
+                            "value": {
+                              "kind": {
+                                "Binary": {
+                                  "left": {
+                                    "kind": {
+                                      "Int": 1
+                                    },
+                                    "span": {
+                                      "start": 34,
+                                      "end": 35
+                                    }
+                                  },
+                                  "op": "Add",
+                                  "right": {
+                                    "kind": {
+                                      "Int": 2
+                                    },
+                                    "span": {
+                                      "start": 38,
+                                      "end": 39
+                                    }
+                                  }
+                                }
+                              },
+                              "span": {
+                                "start": 34,
+                                "end": 39
+                              }
+                            },
+                            "unpack": false,
+                            "span": {
+                              "start": 24,
+                              "end": 39
+                            }
+                          }
+                        ]
+                      },
+                      "span": {
+                        "start": 23,
+                        "end": 40
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 41
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 41
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 42
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 42
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/clone_with_function_call_value_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/clone_with_function_call_value_v85.phpt
@@ -1,0 +1,125 @@
+===config===
+min_php=8.5
+===source===
+<?php $b = clone($obj, ['prop' => strtolower('A')]);
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "b"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "CloneWith": [
+                    {
+                      "kind": {
+                        "Variable": "obj"
+                      },
+                      "span": {
+                        "start": 17,
+                        "end": 21
+                      }
+                    },
+                    {
+                      "kind": {
+                        "Array": [
+                          {
+                            "key": {
+                              "kind": {
+                                "String": "prop"
+                              },
+                              "span": {
+                                "start": 24,
+                                "end": 30
+                              }
+                            },
+                            "value": {
+                              "kind": {
+                                "FunctionCall": {
+                                  "name": {
+                                    "kind": {
+                                      "Identifier": "strtolower"
+                                    },
+                                    "span": {
+                                      "start": 34,
+                                      "end": 44
+                                    }
+                                  },
+                                  "args": [
+                                    {
+                                      "name": null,
+                                      "value": {
+                                        "kind": {
+                                          "String": "A"
+                                        },
+                                        "span": {
+                                          "start": 45,
+                                          "end": 48
+                                        }
+                                      },
+                                      "unpack": false,
+                                      "by_ref": false,
+                                      "span": {
+                                        "start": 45,
+                                        "end": 48
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "span": {
+                                "start": 34,
+                                "end": 49
+                              }
+                            },
+                            "unpack": false,
+                            "span": {
+                              "start": 24,
+                              "end": 49
+                            }
+                          }
+                        ]
+                      },
+                      "span": {
+                        "start": 23,
+                        "end": 50
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 51
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 51
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 52
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 52
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/clone_with_multiple_properties_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/clone_with_multiple_properties_v85.phpt
@@ -1,0 +1,145 @@
+===config===
+min_php=8.5
+===source===
+<?php $b = clone($obj, ['a' => 1, 'b' => 2, 'c' => 3]);
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "b"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "CloneWith": [
+                    {
+                      "kind": {
+                        "Variable": "obj"
+                      },
+                      "span": {
+                        "start": 17,
+                        "end": 21
+                      }
+                    },
+                    {
+                      "kind": {
+                        "Array": [
+                          {
+                            "key": {
+                              "kind": {
+                                "String": "a"
+                              },
+                              "span": {
+                                "start": 24,
+                                "end": 27
+                              }
+                            },
+                            "value": {
+                              "kind": {
+                                "Int": 1
+                              },
+                              "span": {
+                                "start": 31,
+                                "end": 32
+                              }
+                            },
+                            "unpack": false,
+                            "span": {
+                              "start": 24,
+                              "end": 32
+                            }
+                          },
+                          {
+                            "key": {
+                              "kind": {
+                                "String": "b"
+                              },
+                              "span": {
+                                "start": 34,
+                                "end": 37
+                              }
+                            },
+                            "value": {
+                              "kind": {
+                                "Int": 2
+                              },
+                              "span": {
+                                "start": 41,
+                                "end": 42
+                              }
+                            },
+                            "unpack": false,
+                            "span": {
+                              "start": 34,
+                              "end": 42
+                            }
+                          },
+                          {
+                            "key": {
+                              "kind": {
+                                "String": "c"
+                              },
+                              "span": {
+                                "start": 44,
+                                "end": 47
+                              }
+                            },
+                            "value": {
+                              "kind": {
+                                "Int": 3
+                              },
+                              "span": {
+                                "start": 51,
+                                "end": 52
+                              }
+                            },
+                            "unpack": false,
+                            "span": {
+                              "start": 44,
+                              "end": 52
+                            }
+                          }
+                        ]
+                      },
+                      "span": {
+                        "start": 23,
+                        "end": 53
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 54
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 54
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 55
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 55
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/clone_with_nested_array_value_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/clone_with_nested_array_value_v85.phpt
@@ -1,0 +1,121 @@
+===config===
+min_php=8.5
+===source===
+<?php $b = clone($obj, ['prop' => ['nested' => 1]]);
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "b"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "CloneWith": [
+                    {
+                      "kind": {
+                        "Variable": "obj"
+                      },
+                      "span": {
+                        "start": 17,
+                        "end": 21
+                      }
+                    },
+                    {
+                      "kind": {
+                        "Array": [
+                          {
+                            "key": {
+                              "kind": {
+                                "String": "prop"
+                              },
+                              "span": {
+                                "start": 24,
+                                "end": 30
+                              }
+                            },
+                            "value": {
+                              "kind": {
+                                "Array": [
+                                  {
+                                    "key": {
+                                      "kind": {
+                                        "String": "nested"
+                                      },
+                                      "span": {
+                                        "start": 35,
+                                        "end": 43
+                                      }
+                                    },
+                                    "value": {
+                                      "kind": {
+                                        "Int": 1
+                                      },
+                                      "span": {
+                                        "start": 47,
+                                        "end": 48
+                                      }
+                                    },
+                                    "unpack": false,
+                                    "span": {
+                                      "start": 35,
+                                      "end": 48
+                                    }
+                                  }
+                                ]
+                              },
+                              "span": {
+                                "start": 34,
+                                "end": 49
+                              }
+                            },
+                            "unpack": false,
+                            "span": {
+                              "start": 24,
+                              "end": 49
+                            }
+                          }
+                        ]
+                      },
+                      "span": {
+                        "start": 23,
+                        "end": 50
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 51
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 51
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 52
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 52
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/clone_with_property_access_value_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/clone_with_property_access_value_v85.phpt
@@ -1,0 +1,114 @@
+===config===
+min_php=8.5
+===source===
+<?php $b = clone($obj, ['prop' => $other->prop]);
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "b"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "CloneWith": [
+                    {
+                      "kind": {
+                        "Variable": "obj"
+                      },
+                      "span": {
+                        "start": 17,
+                        "end": 21
+                      }
+                    },
+                    {
+                      "kind": {
+                        "Array": [
+                          {
+                            "key": {
+                              "kind": {
+                                "String": "prop"
+                              },
+                              "span": {
+                                "start": 24,
+                                "end": 30
+                              }
+                            },
+                            "value": {
+                              "kind": {
+                                "PropertyAccess": {
+                                  "object": {
+                                    "kind": {
+                                      "Variable": "other"
+                                    },
+                                    "span": {
+                                      "start": 34,
+                                      "end": 40
+                                    }
+                                  },
+                                  "property": {
+                                    "kind": {
+                                      "Identifier": "prop"
+                                    },
+                                    "span": {
+                                      "start": 42,
+                                      "end": 46
+                                    }
+                                  }
+                                }
+                              },
+                              "span": {
+                                "start": 34,
+                                "end": 46
+                              }
+                            },
+                            "unpack": false,
+                            "span": {
+                              "start": 24,
+                              "end": 46
+                            }
+                          }
+                        ]
+                      },
+                      "span": {
+                        "start": 23,
+                        "end": 47
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 48
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 48
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 49
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 49
+  }
+}


### PR DESCRIPTION
## Summary

- Add five `.phpt` fixtures under `crates/php-parser/tests/fixtures/versioned/` covering edge cases for PHP 8.5 `clone`-with syntax
- Cases: binary expression value, function call value, nested array value, multiple properties, and property access value
- All fixtures gated with `min_php=8.5`; ASTs and spans manually verified

Closes #180