### PR TITLE
test(versioned): add pipe operator edge case fixtures for PHP 8.5

### DIFF
--- a/crates/php-parser/tests/fixtures/versioned/pipe_operator_chained_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/pipe_operator_chained_v85.phpt
@@ -1,0 +1,94 @@
+===config===
+min_php=8.5
+===source===
+<?php $x |> strlen(...) |> abs(...);
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Binary": {
+              "left": {
+                "kind": {
+                  "Binary": {
+                    "left": {
+                      "kind": {
+                        "Variable": "x"
+                      },
+                      "span": {
+                        "start": 6,
+                        "end": 8
+                      }
+                    },
+                    "op": "Pipe",
+                    "right": {
+                      "kind": {
+                        "CallableCreate": {
+                          "kind": {
+                            "Function": {
+                              "kind": {
+                                "Identifier": "strlen"
+                              },
+                              "span": {
+                                "start": 12,
+                                "end": 18
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "span": {
+                        "start": 12,
+                        "end": 23
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 6,
+                  "end": 23
+                }
+              },
+              "op": "Pipe",
+              "right": {
+                "kind": {
+                  "CallableCreate": {
+                    "kind": {
+                      "Function": {
+                        "kind": {
+                          "Identifier": "abs"
+                        },
+                        "span": {
+                          "start": 27,
+                          "end": 30
+                        }
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 27,
+                  "end": 35
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 35
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 36
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 36
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/pipe_operator_in_assignment_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/pipe_operator_in_assignment_v85.phpt
@@ -1,0 +1,82 @@
+===config===
+min_php=8.5
+===source===
+<?php $y = $x |> strlen(...);
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "y"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Binary": {
+                    "left": {
+                      "kind": {
+                        "Variable": "x"
+                      },
+                      "span": {
+                        "start": 11,
+                        "end": 13
+                      }
+                    },
+                    "op": "Pipe",
+                    "right": {
+                      "kind": {
+                        "CallableCreate": {
+                          "kind": {
+                            "Function": {
+                              "kind": {
+                                "Identifier": "strlen"
+                              },
+                              "span": {
+                                "start": 17,
+                                "end": 23
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "span": {
+                        "start": 17,
+                        "end": 28
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 28
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 28
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 29
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 29
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/pipe_operator_null_coalesce_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/pipe_operator_null_coalesce_v85.phpt
@@ -1,0 +1,77 @@
+===config===
+min_php=8.5
+===source===
+<?php $x |> ($x ?? 'default');
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Binary": {
+              "left": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Pipe",
+              "right": {
+                "kind": {
+                  "Parenthesized": {
+                    "kind": {
+                      "NullCoalesce": {
+                        "left": {
+                          "kind": {
+                            "Variable": "x"
+                          },
+                          "span": {
+                            "start": 13,
+                            "end": 15
+                          }
+                        },
+                        "right": {
+                          "kind": {
+                            "String": "default"
+                          },
+                          "span": {
+                            "start": 19,
+                            "end": 28
+                          }
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 13,
+                      "end": 28
+                    }
+                  }
+                },
+                "span": {
+                  "start": 12,
+                  "end": 29
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 29
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 30
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 30
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/pipe_operator_ternary_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/pipe_operator_ternary_v85.phpt
@@ -1,0 +1,86 @@
+===config===
+min_php=8.5
+===source===
+<?php $x |> ($x ? 'a' : 'b');
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Binary": {
+              "left": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Pipe",
+              "right": {
+                "kind": {
+                  "Parenthesized": {
+                    "kind": {
+                      "Ternary": {
+                        "condition": {
+                          "kind": {
+                            "Variable": "x"
+                          },
+                          "span": {
+                            "start": 13,
+                            "end": 15
+                          }
+                        },
+                        "then_expr": {
+                          "kind": {
+                            "String": "a"
+                          },
+                          "span": {
+                            "start": 18,
+                            "end": 21
+                          }
+                        },
+                        "else_expr": {
+                          "kind": {
+                            "String": "b"
+                          },
+                          "span": {
+                            "start": 24,
+                            "end": 27
+                          }
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 13,
+                      "end": 27
+                    }
+                  }
+                },
+                "span": {
+                  "start": 12,
+                  "end": 28
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 28
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 29
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 29
+  }
+}

--- a/crates/php-parser/tests/fixtures/versioned/pipe_operator_with_match_v85.phpt
+++ b/crates/php-parser/tests/fixtures/versioned/pipe_operator_with_match_v85.phpt
@@ -1,0 +1,78 @@
+===config===
+min_php=8.5
+===source===
+<?php $x |> match(true) { default => 'a' };
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Binary": {
+              "left": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Pipe",
+              "right": {
+                "kind": {
+                  "Match": {
+                    "subject": {
+                      "kind": {
+                        "Bool": true
+                      },
+                      "span": {
+                        "start": 18,
+                        "end": 22
+                      }
+                    },
+                    "arms": [
+                      {
+                        "conditions": null,
+                        "body": {
+                          "kind": {
+                            "String": "a"
+                          },
+                          "span": {
+                            "start": 37,
+                            "end": 40
+                          }
+                        },
+                        "span": {
+                          "start": 26,
+                          "end": 40
+                        }
+                      }
+                    ]
+                  }
+                },
+                "span": {
+                  "start": 12,
+                  "end": 42
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 42
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 43
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 43
+  }
+}


### PR DESCRIPTION
## Summary

- Add 5 dedicated `.phpt` fixtures covering pipe operator edge cases: chained pipes, pipe in assignment, pipe with match expression, pipe with null coalesce, and pipe with ternary
- All fixtures use `min_php=8.5` config so they are skipped on older PHP CI runners

Closes #179