### PR TITLE
fix(parser): emit error for invalid heredoc/nowdoc body indentation

### DIFF
--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -1247,6 +1247,7 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
             let (label, body_start_in_text, body_end_in_text, indent) = parse_heredoc_content(text);
             let body_offset = token.span.start + body_start_in_text as u32;
             let raw_body = &src[body_offset as usize..token.span.start as usize + body_end_in_text];
+            validate_heredoc_indentation(raw_body, &indent, body_offset, parser.errors_mut());
             if crate::interpolation::has_interpolation(raw_body) {
                 if !indent.is_empty() {
                     // Indented heredoc — raw_body is a verbatim source slice but each line
@@ -1307,7 +1308,9 @@ fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'arena
             let src = parser.source();
             let text = &src[token.span.start as usize..token.span.end as usize];
             let (label, body_start_in_text, body_end_in_text, indent) = parse_heredoc_content(text);
+            let body_offset = token.span.start + body_start_in_text as u32;
             let raw_body = &text[body_start_in_text..body_end_in_text];
+            validate_heredoc_indentation(raw_body, &indent, body_offset, parser.errors_mut());
             let value: &'arena str = if !indent.is_empty() {
                 let s = raw_body
                     .lines()
@@ -2880,6 +2883,30 @@ fn parse_heredoc_content(text: &str) -> (&str, usize, usize, String) {
     let body_end_in_text = body_start_in_text + content.len();
 
     (label, body_start_in_text, body_end_in_text, indent)
+}
+
+/// Validate that every non-empty body line of an indented heredoc/nowdoc starts with `indent`.
+/// Emits `ParseError::Forbidden` for each line that violates the indentation requirement.
+/// Empty lines are always valid.
+fn validate_heredoc_indentation(
+    raw_body: &str,
+    indent: &str,
+    body_offset: u32,
+    errors: &mut Vec<ParseError>,
+) {
+    if indent.is_empty() {
+        return;
+    }
+    let mut offset = body_offset as usize;
+    for line in raw_body.split('\n') {
+        if !line.is_empty() && !line.starts_with(indent) {
+            errors.push(ParseError::Forbidden {
+                message: "Invalid body indentation level".into(),
+                span: Span::new(offset as u32, (offset + line.len()) as u32),
+            });
+        }
+        offset += line.len() + 1; // +1 for the '\n'
+    }
 }
 
 /// Parse an integer literal from raw bytes, skipping underscores, without heap allocation.

--- a/crates/php-parser/tests/fixtures/errors/heredoc_insufficient_indentation.phpt
+++ b/crates/php-parser/tests/fixtures/errors/heredoc_insufficient_indentation.phpt
@@ -1,0 +1,62 @@
+===source===
+<?php
+$x = <<<END
+  line with only 2 spaces
+    END;
+===errors===
+Invalid body indentation level
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Heredoc": {
+                    "label": "END",
+                    "parts": [
+                      {
+                        "Literal": "  line with only 2 spaces"
+                      }
+                    ]
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 51
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 51
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 52
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 52
+  }
+}
+===php_error===
+PHP Parse error:  Invalid body indentation level (expecting an indentation level of at least 4) in Standard input code on line 3

--- a/crates/php-parser/tests/fixtures/errors/heredoc_insufficient_indentation_with_interpolation.phpt
+++ b/crates/php-parser/tests/fixtures/errors/heredoc_insufficient_indentation_with_interpolation.phpt
@@ -1,0 +1,111 @@
+===source===
+<?php
+$y = "world";
+$x = <<<END
+  hello $y
+    END;
+===errors===
+Invalid body indentation level
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "y"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "String": "world"
+                },
+                "span": {
+                  "start": 11,
+                  "end": 18
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 18
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 19
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 20,
+                  "end": 22
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Heredoc": {
+                    "label": "END",
+                    "parts": [
+                      {
+                        "Literal": "  hello "
+                      },
+                      {
+                        "Expr": {
+                          "kind": {
+                            "Variable": "y"
+                          },
+                          "span": {
+                            "start": 40,
+                            "end": 42
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "span": {
+                  "start": 25,
+                  "end": 50
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 20,
+            "end": 50
+          }
+        }
+      },
+      "span": {
+        "start": 20,
+        "end": 51
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 51
+  }
+}
+===php_error===
+PHP Parse error:  Invalid body indentation level (expecting an indentation level of at least 4) in Standard input code on line 4

--- a/crates/php-parser/tests/fixtures/errors/heredoc_mixed_indentation.phpt
+++ b/crates/php-parser/tests/fixtures/errors/heredoc_mixed_indentation.phpt
@@ -1,0 +1,62 @@
+===source===
+<?php
+$x = <<<END
+	    mixed line
+    END;
+===errors===
+Invalid body indentation level
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Heredoc": {
+                    "label": "END",
+                    "parts": [
+                      {
+                        "Literal": "\t    mixed line"
+                      }
+                    ]
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 41
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 41
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 42
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 42
+  }
+}
+===php_error===
+PHP Parse error:  Invalid indentation - tabs and spaces cannot be mixed in Standard input code on line 3

--- a/crates/php-parser/tests/fixtures/errors/nowdoc_insufficient_indentation.phpt
+++ b/crates/php-parser/tests/fixtures/errors/nowdoc_insufficient_indentation.phpt
@@ -1,0 +1,58 @@
+===source===
+<?php
+$x = <<<'END'
+  line with only 2 spaces
+    END;
+===errors===
+Invalid body indentation level
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Nowdoc": {
+                    "label": "END",
+                    "value": "  line with only 2 spaces"
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 53
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 53
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 54
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 54
+  }
+}
+===php_error===
+PHP Parse error:  Invalid body indentation level (expecting an indentation level of at least 4) in Standard input code on line 3

--- a/crates/php-parser/tests/fixtures/errors/nowdoc_mixed_indentation.phpt
+++ b/crates/php-parser/tests/fixtures/errors/nowdoc_mixed_indentation.phpt
@@ -1,0 +1,58 @@
+===source===
+<?php
+$x = <<<'END'
+	    mixed line
+    END;
+===errors===
+Invalid body indentation level
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Nowdoc": {
+                    "label": "END",
+                    "value": "\t    mixed line"
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 43
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 43
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 44
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 44
+  }
+}
+===php_error===
+PHP Parse error:  Invalid indentation - tabs and spaces cannot be mixed in Standard input code on line 3

--- a/crates/php-parser/tests/fixtures/heredoc_zero_indent_closing_marker.phpt
+++ b/crates/php-parser/tests/fixtures/heredoc_zero_indent_closing_marker.phpt
@@ -1,0 +1,58 @@
+===source===
+<?php
+$x = <<<END
+    indented content
+END;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Heredoc": {
+                    "label": "END",
+                    "parts": [
+                      {
+                        "Literal": "    indented content"
+                      }
+                    ]
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 42
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 42
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 43
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 43
+  }
+}


### PR DESCRIPTION
## Summary

- Added `validate_heredoc_indentation` helper in `expr.rs` that emits `ParseError::Forbidden("Invalid body indentation level")` for each content line that does not start with the closing marker's indentation prefix
- Validation fires for heredoc (both with and without interpolation) and nowdoc
- Added 5 error fixtures covering mixed tabs/spaces and insufficient indentation, plus 1 valid fixture for zero-indented closing marker

Closes #178