### PR TITLE
fix(parser): validate property hook parameter counts

### DIFF
--- a/crates/php-parser/src/stmt.rs
+++ b/crates/php-parser/src/stmt.rs
@@ -1961,9 +1961,31 @@ fn parse_property_hooks<'arena, 'src>(
 
         // Parse optional (params) for set hooks
         let params = if parser.check(TokenKind::LeftParen) {
+            let paren_span = parser.current_span();
             parser.advance();
             let p = parse_param_list(parser);
             parser.expect(TokenKind::RightParen);
+
+            // Validate parameter counts against hook kind
+            match kind {
+                PropertyHookKind::Get => {
+                    if !p.is_empty() {
+                        parser.error(ParseError::Forbidden {
+                            message: "get hook must not have a parameter list".into(),
+                            span: paren_span,
+                        });
+                    }
+                }
+                PropertyHookKind::Set => {
+                    if p.len() != 1 {
+                        parser.error(ParseError::Forbidden {
+                            message: "set hook must have exactly one parameter".into(),
+                            span: paren_span,
+                        });
+                    }
+                }
+            }
+
             p
         } else {
             parser.alloc_vec()

--- a/crates/php-parser/tests/fixtures/errors/property_hook_get_with_params.phpt
+++ b/crates/php-parser/tests/fixtures/errors/property_hook_get_with_params.phpt
@@ -1,0 +1,146 @@
+===config===
+min_php=8.4
+===source===
+<?php
+class Foo {
+    public int $x {
+        get(int $a) { return 1; }
+    }
+}
+===errors===
+get hook must not have a parameter list
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "x",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "int"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 29,
+                          "end": 32
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 29,
+                      "end": 32
+                    }
+                  },
+                  "default": null,
+                  "attributes": [],
+                  "hooks": [
+                    {
+                      "kind": "Get",
+                      "body": {
+                        "Block": [
+                          {
+                            "kind": {
+                              "Return": {
+                                "kind": {
+                                  "Int": 1
+                                },
+                                "span": {
+                                  "start": 67,
+                                  "end": 68
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 60,
+                              "end": 69
+                            }
+                          }
+                        ]
+                      },
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [
+                        {
+                          "name": "a",
+                          "type_hint": {
+                            "kind": {
+                              "Named": {
+                                "parts": [
+                                  "int"
+                                ],
+                                "kind": "Unqualified",
+                                "span": {
+                                  "start": 50,
+                                  "end": 53
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 50,
+                              "end": 53
+                            }
+                          },
+                          "default": null,
+                          "by_ref": false,
+                          "variadic": false,
+                          "is_readonly": false,
+                          "is_final": false,
+                          "visibility": null,
+                          "set_visibility": null,
+                          "attributes": [],
+                          "span": {
+                            "start": 50,
+                            "end": 56
+                          }
+                        }
+                      ],
+                      "attributes": [],
+                      "span": {
+                        "start": 46,
+                        "end": 71
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 22,
+                "end": 77
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 79
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 79
+  }
+}
+===php_error===
+PHP Fatal error:  get hook of property Foo::$x must not have a parameter list in Standard input code on line 4

--- a/crates/php-parser/tests/fixtures/errors/property_hook_set_no_params.phpt
+++ b/crates/php-parser/tests/fixtures/errors/property_hook_set_no_params.phpt
@@ -1,0 +1,94 @@
+===config===
+min_php=8.4
+===source===
+<?php
+class Foo {
+    public int $x {
+        set() { }
+    }
+}
+===errors===
+set hook must have exactly one parameter
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "x",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "int"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 29,
+                          "end": 32
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 29,
+                      "end": 32
+                    }
+                  },
+                  "default": null,
+                  "attributes": [],
+                  "hooks": [
+                    {
+                      "kind": "Set",
+                      "body": {
+                        "Block": []
+                      },
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [],
+                      "attributes": [],
+                      "span": {
+                        "start": 46,
+                        "end": 55
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 22,
+                "end": 61
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 63
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 63
+  }
+}
+===php_error===
+PHP Fatal error:  set hook of property Foo::$x must accept exactly one parameters in Standard input code on line 4

--- a/crates/php-parser/tests/fixtures/errors/property_hook_set_too_many_params.phpt
+++ b/crates/php-parser/tests/fixtures/errors/property_hook_set_too_many_params.phpt
@@ -1,0 +1,161 @@
+===config===
+min_php=8.4
+===source===
+<?php
+class Foo {
+    public int $x {
+        set(int $a, int $b) { }
+    }
+}
+===errors===
+set hook must have exactly one parameter
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "x",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "int"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 29,
+                          "end": 32
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 29,
+                      "end": 32
+                    }
+                  },
+                  "default": null,
+                  "attributes": [],
+                  "hooks": [
+                    {
+                      "kind": "Set",
+                      "body": {
+                        "Block": []
+                      },
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [
+                        {
+                          "name": "a",
+                          "type_hint": {
+                            "kind": {
+                              "Named": {
+                                "parts": [
+                                  "int"
+                                ],
+                                "kind": "Unqualified",
+                                "span": {
+                                  "start": 50,
+                                  "end": 53
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 50,
+                              "end": 53
+                            }
+                          },
+                          "default": null,
+                          "by_ref": false,
+                          "variadic": false,
+                          "is_readonly": false,
+                          "is_final": false,
+                          "visibility": null,
+                          "set_visibility": null,
+                          "attributes": [],
+                          "span": {
+                            "start": 50,
+                            "end": 56
+                          }
+                        },
+                        {
+                          "name": "b",
+                          "type_hint": {
+                            "kind": {
+                              "Named": {
+                                "parts": [
+                                  "int"
+                                ],
+                                "kind": "Unqualified",
+                                "span": {
+                                  "start": 58,
+                                  "end": 61
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 58,
+                              "end": 61
+                            }
+                          },
+                          "default": null,
+                          "by_ref": false,
+                          "variadic": false,
+                          "is_readonly": false,
+                          "is_final": false,
+                          "visibility": null,
+                          "set_visibility": null,
+                          "attributes": [],
+                          "span": {
+                            "start": 58,
+                            "end": 64
+                          }
+                        }
+                      ],
+                      "attributes": [],
+                      "span": {
+                        "start": 46,
+                        "end": 69
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 22,
+                "end": 75
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 77
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 77
+  }
+}
+===php_error===
+PHP Fatal error:  set hook of property Foo::$x must accept exactly one parameters in Standard input code on line 4


### PR DESCRIPTION
## Summary

- `get` hooks with any parameters now emit a `ParseError::Forbidden` ("get hook must not have a parameter list")
- `set` hooks with zero or more-than-one parameters now emit a `ParseError::Forbidden` ("set hook must have exactly one parameter")
- Three error fixtures added covering all invalid combinations

Closes #176