### PR TITLE
fix(parser): restrict nonassoc chain detection to same-precedence group

### DIFF
--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -10,39 +10,45 @@ use crate::precedence::{self, ASSIGNMENT_BP, NULL_COALESCE_LEFT_BP, TERNARY_BP};
 use crate::stmt;
 use crate::version::PhpVersion;
 
-/// Returns true if the token is a non-associative operator in PHP 8.
-/// Chaining these (e.g. `1 < 2 < 3`) is a fatal error in PHP 8.0+.
-fn is_nonassoc_token(kind: TokenKind) -> bool {
-    matches!(
-        kind,
+/// Returns the "chain group" binding power for a non-associative token, if applicable.
+///
+/// PHP 8.0+ rejects chaining non-associative operators within the same precedence group:
+/// - Equality group (bp 25): `==`, `!=`, `===`, `!==`, `<=>`
+/// - Comparison group (bp 27): `<`, `>`, `<=`, `>=`
+///
+/// `instanceof` is intentionally excluded: PHP allows `$a instanceof Foo instanceof Bar`
+/// at parse time and does not reject cross-group chains like `$a > $b == $c`.
+fn nonassoc_chain_level_for_token(kind: TokenKind) -> Option<u8> {
+    match kind {
         TokenKind::EqualsEquals
-            | TokenKind::BangEquals
-            | TokenKind::EqualsEqualsEquals
-            | TokenKind::BangEqualsEquals
-            | TokenKind::Spaceship
-            | TokenKind::LessThan
-            | TokenKind::GreaterThan
-            | TokenKind::LessThanEquals
-            | TokenKind::GreaterThanEquals
-            | TokenKind::Instanceof
-    )
+        | TokenKind::BangEquals
+        | TokenKind::EqualsEqualsEquals
+        | TokenKind::BangEqualsEquals
+        | TokenKind::Spaceship => Some(25),
+        TokenKind::LessThan
+        | TokenKind::GreaterThan
+        | TokenKind::LessThanEquals
+        | TokenKind::GreaterThanEquals => Some(27),
+        _ => None,
+    }
 }
 
-/// Returns true if the binary op is a non-associative operator.
-fn is_nonassoc_binary_op(op: BinaryOp) -> bool {
-    matches!(
-        op,
+/// Returns the "chain group" binding power for a binary op produced by a non-associative token.
+///
+/// Mirrors `nonassoc_chain_level_for_token` but operates on the already-parsed binary op.
+/// `instanceof` returns `None` for the same reasons described above.
+fn nonassoc_chain_level_for_op(op: BinaryOp) -> Option<u8> {
+    match op {
         BinaryOp::Equal
-            | BinaryOp::NotEqual
-            | BinaryOp::Identical
-            | BinaryOp::NotIdentical
-            | BinaryOp::Spaceship
-            | BinaryOp::Less
-            | BinaryOp::Greater
-            | BinaryOp::LessOrEqual
-            | BinaryOp::GreaterOrEqual
-            | BinaryOp::Instanceof
-    )
+        | BinaryOp::NotEqual
+        | BinaryOp::Identical
+        | BinaryOp::NotIdentical
+        | BinaryOp::Spaceship => Some(25),
+        BinaryOp::Less | BinaryOp::Greater | BinaryOp::LessOrEqual | BinaryOp::GreaterOrEqual => {
+            Some(27)
+        }
+        _ => None,
+    }
 }
 
 /// Cast keyword strings and their CastKind values
@@ -648,19 +654,23 @@ pub fn parse_expr_bp<'arena, 'src>(
             if left_bp < min_bp {
                 break;
             }
-            // PHP 8.0+: chaining non-associative operators is a fatal error.
-            // Detect when the LHS is already a binary expression with a non-assoc op
-            // and the current token is also a non-assoc op at the same precedence level.
-            if parser.version >= PhpVersion::Php80
-                && is_nonassoc_token(kind)
-                && matches!(&lhs.kind, ExprKind::Binary(b) if is_nonassoc_binary_op(b.op))
-            {
-                let span = parser.current_span();
-                parser.error(ParseError::Forbidden {
-                    message: "Chaining non-associative operators requires explicit parentheses."
-                        .into(),
-                    span,
-                });
+            // PHP 8.0+: chaining non-associative operators within the same precedence group
+            // is a fatal error (e.g. `1 < 2 < 3`, `$a === $b == $c`).
+            // Cross-group chains (e.g. `$a > $b == $c`) and instanceof chains are
+            // allowed by PHP and must not be flagged here.
+            if parser.version >= PhpVersion::Php80 {
+                if let Some(current_level) = nonassoc_chain_level_for_token(kind) {
+                    if matches!(&lhs.kind, ExprKind::Binary(b) if nonassoc_chain_level_for_op(b.op) == Some(current_level))
+                    {
+                        let span = parser.current_span();
+                        parser.error(ParseError::Forbidden {
+                            message:
+                                "Chaining non-associative operators requires explicit parentheses."
+                                    .into(),
+                            span,
+                        });
+                    }
+                }
             }
             let op_token = parser.advance();
             if op_token.kind == TokenKind::PipeArrow {

--- a/crates/php-parser/tests/fixtures/categories/nonassoc_crossgroup_valid.phpt
+++ b/crates/php-parser/tests/fixtures/categories/nonassoc_crossgroup_valid.phpt
@@ -1,0 +1,187 @@
+===config===
+min_php=8.1
+===source===
+<?php
+$a > $b == $c;
+$a >= $b == $c;
+$a instanceof Foo == $c;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Binary": {
+              "left": {
+                "kind": {
+                  "Binary": {
+                    "left": {
+                      "kind": {
+                        "Variable": "a"
+                      },
+                      "span": {
+                        "start": 6,
+                        "end": 8
+                      }
+                    },
+                    "op": "Greater",
+                    "right": {
+                      "kind": {
+                        "Variable": "b"
+                      },
+                      "span": {
+                        "start": 11,
+                        "end": 13
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 6,
+                  "end": 13
+                }
+              },
+              "op": "Equal",
+              "right": {
+                "kind": {
+                  "Variable": "c"
+                },
+                "span": {
+                  "start": 17,
+                  "end": 19
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 19
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 20
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Binary": {
+              "left": {
+                "kind": {
+                  "Binary": {
+                    "left": {
+                      "kind": {
+                        "Variable": "a"
+                      },
+                      "span": {
+                        "start": 21,
+                        "end": 23
+                      }
+                    },
+                    "op": "GreaterOrEqual",
+                    "right": {
+                      "kind": {
+                        "Variable": "b"
+                      },
+                      "span": {
+                        "start": 27,
+                        "end": 29
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 21,
+                  "end": 29
+                }
+              },
+              "op": "Equal",
+              "right": {
+                "kind": {
+                  "Variable": "c"
+                },
+                "span": {
+                  "start": 33,
+                  "end": 35
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 21,
+            "end": 35
+          }
+        }
+      },
+      "span": {
+        "start": 21,
+        "end": 36
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Binary": {
+              "left": {
+                "kind": {
+                  "Binary": {
+                    "left": {
+                      "kind": {
+                        "Variable": "a"
+                      },
+                      "span": {
+                        "start": 37,
+                        "end": 39
+                      }
+                    },
+                    "op": "Instanceof",
+                    "right": {
+                      "kind": {
+                        "Identifier": "Foo"
+                      },
+                      "span": {
+                        "start": 51,
+                        "end": 54
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 37,
+                  "end": 54
+                }
+              },
+              "op": "Equal",
+              "right": {
+                "kind": {
+                  "Variable": "c"
+                },
+                "span": {
+                  "start": 58,
+                  "end": 60
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 37,
+            "end": 60
+          }
+        }
+      },
+      "span": {
+        "start": 37,
+        "end": 61
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 61
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/nonassoc_parenthesized_not_chained.phpt
+++ b/crates/php-parser/tests/fixtures/categories/nonassoc_parenthesized_not_chained.phpt
@@ -1,0 +1,134 @@
+===source===
+<?php
+($a < $b) > $c;
+$a ?? $b instanceof X;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Binary": {
+              "left": {
+                "kind": {
+                  "Parenthesized": {
+                    "kind": {
+                      "Binary": {
+                        "left": {
+                          "kind": {
+                            "Variable": "a"
+                          },
+                          "span": {
+                            "start": 7,
+                            "end": 9
+                          }
+                        },
+                        "op": "Less",
+                        "right": {
+                          "kind": {
+                            "Variable": "b"
+                          },
+                          "span": {
+                            "start": 12,
+                            "end": 14
+                          }
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 7,
+                      "end": 14
+                    }
+                  }
+                },
+                "span": {
+                  "start": 6,
+                  "end": 15
+                }
+              },
+              "op": "Greater",
+              "right": {
+                "kind": {
+                  "Variable": "c"
+                },
+                "span": {
+                  "start": 18,
+                  "end": 20
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 20
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 21
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "NullCoalesce": {
+              "left": {
+                "kind": {
+                  "Variable": "a"
+                },
+                "span": {
+                  "start": 22,
+                  "end": 24
+                }
+              },
+              "right": {
+                "kind": {
+                  "Binary": {
+                    "left": {
+                      "kind": {
+                        "Variable": "b"
+                      },
+                      "span": {
+                        "start": 28,
+                        "end": 30
+                      }
+                    },
+                    "op": "Instanceof",
+                    "right": {
+                      "kind": {
+                        "Identifier": "X"
+                      },
+                      "span": {
+                        "start": 42,
+                        "end": 43
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 28,
+                  "end": 43
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 22,
+            "end": 43
+          }
+        }
+      },
+      "span": {
+        "start": 22,
+        "end": 44
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 44
+  }
+}

--- a/crates/php-parser/tests/fixtures/errors/nonassoc_chain_cross_group.phpt
+++ b/crates/php-parser/tests/fixtures/errors/nonassoc_chain_cross_group.phpt
@@ -1,0 +1,75 @@
+===config===
+min_php=8.1
+===source===
+<?php
+$a === $b == $c;
+===errors===
+Chaining non-associative operators requires explicit parentheses.
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Binary": {
+              "left": {
+                "kind": {
+                  "Binary": {
+                    "left": {
+                      "kind": {
+                        "Variable": "a"
+                      },
+                      "span": {
+                        "start": 6,
+                        "end": 8
+                      }
+                    },
+                    "op": "Identical",
+                    "right": {
+                      "kind": {
+                        "Variable": "b"
+                      },
+                      "span": {
+                        "start": 13,
+                        "end": 15
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 6,
+                  "end": 15
+                }
+              },
+              "op": "Equal",
+              "right": {
+                "kind": {
+                  "Variable": "c"
+                },
+                "span": {
+                  "start": 19,
+                  "end": 21
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 21
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 22
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 22
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected token "==" in Standard input code on line 2


### PR DESCRIPTION
## Summary

- The nonassoc chain check previously fired for any two nonassoc operators in sequence, including cross-group chains like `$a > $b == $c` (relational bp=27 then equality bp=25) and `$a instanceof Foo == $c`. These are valid PHP — the rule only applies within a precedence group.
- Fixed by replacing the broad boolean checks with precedence-level comparison: only flag chaining when both operators belong to the same group (equality bp=25 or comparison bp=27). `instanceof` is excluded entirely since PHP allows it to chain.
- Added three fixtures covering the specific patterns from the issue: a same-group error case, cross-group valid cases, and parenthesized/`??` valid cases.

Closes #175