### PR TITLE
fix(parser): emit error for invalid assignment targets

### DIFF
--- a/crates/php-parser/src/expr.rs
+++ b/crates/php-parser/src/expr.rs
@@ -51,6 +51,27 @@ fn nonassoc_chain_level_for_op(op: BinaryOp) -> Option<u8> {
     }
 }
 
+/// Returns true if `kind` is a valid PHP assignment target (lvalue).
+///
+/// Valid targets: variable, variable-variable, array access, property access,
+/// static property access, array/list destructuring, and parenthesized valid targets.
+/// Invalid targets emit a `ParseError::Forbidden` diagnostic at the assignment site.
+fn is_valid_assignment_target(kind: &ExprKind<'_, '_>) -> bool {
+    match kind {
+        ExprKind::Variable(_)
+        | ExprKind::VariableVariable(_)
+        | ExprKind::ArrayAccess(_)
+        | ExprKind::PropertyAccess(_)
+        | ExprKind::NullsafePropertyAccess(_)
+        | ExprKind::StaticPropertyAccess(_)
+        | ExprKind::StaticPropertyAccessDynamic { .. }
+        | ExprKind::Array(_)
+        | ExprKind::Error => true,
+        ExprKind::Parenthesized(inner) => is_valid_assignment_target(&inner.kind),
+        _ => false,
+    }
+}
+
 /// Cast keyword strings and their CastKind values
 const CAST_KEYWORDS: &[(&str, CastKind)] = &[
     ("int", CastKind::Int),
@@ -88,6 +109,13 @@ fn parse_assign_continuation<'arena, 'src>(
     lhs: Expr<'arena, 'src>,
 ) -> Expr<'arena, 'src> {
     debug_assert!(parser.current_kind().is_assignment_op());
+    if !is_valid_assignment_target(&lhs.kind) {
+        let span = parser.current_span();
+        parser.error(ParseError::Forbidden {
+            message: "Cannot use expression as assignment target.".into(),
+            span,
+        });
+    }
     let op_token = parser.advance();
     let by_ref = op_token.kind == TokenKind::Equals && parser.check(TokenKind::Ampersand);
     if by_ref {
@@ -353,6 +381,12 @@ pub fn parse_expr_bp<'arena, 'src>(
                 let span = parser.current_span();
                 parser.error(ParseError::Forbidden {
                     message: "Cannot use increment/decrement as an assignment target.".into(),
+                    span,
+                });
+            } else if !is_valid_assignment_target(&lhs.kind) {
+                let span = parser.current_span();
+                parser.error(ParseError::Forbidden {
+                    message: "Cannot use expression as assignment target.".into(),
                     span,
                 });
             }

--- a/crates/php-parser/tests/fixtures/errors/assign_to_binary_expr.phpt
+++ b/crates/php-parser/tests/fixtures/errors/assign_to_binary_expr.phpt
@@ -1,0 +1,72 @@
+===source===
+<?php 1 + 2 = $x;
+===errors===
+Cannot use expression as assignment target.
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Binary": {
+                    "left": {
+                      "kind": {
+                        "Int": 1
+                      },
+                      "span": {
+                        "start": 6,
+                        "end": 7
+                      }
+                    },
+                    "op": "Add",
+                    "right": {
+                      "kind": {
+                        "Int": 2
+                      },
+                      "span": {
+                        "start": 10,
+                        "end": 11
+                      }
+                    }
+                  }
+                },
+                "span": {
+                  "start": 6,
+                  "end": 11
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 14,
+                  "end": 16
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 16
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 17
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 17
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected token "=" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/assign_to_function_call.phpt
+++ b/crates/php-parser/tests/fixtures/errors/assign_to_function_call.phpt
@@ -1,0 +1,63 @@
+===source===
+<?php func() = $x;
+===errors===
+Cannot use expression as assignment target.
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "FunctionCall": {
+                    "name": {
+                      "kind": {
+                        "Identifier": "func"
+                      },
+                      "span": {
+                        "start": 6,
+                        "end": 10
+                      }
+                    },
+                    "args": []
+                  }
+                },
+                "span": {
+                  "start": 6,
+                  "end": 12
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 15,
+                  "end": 17
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 17
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 18
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 18
+  }
+}
+===php_error===
+PHP Fatal error:  Can't use function return value in write context in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/assign_to_string_literal.phpt
+++ b/crates/php-parser/tests/fixtures/errors/assign_to_string_literal.phpt
@@ -1,0 +1,52 @@
+===source===
+<?php "string" = $x;
+===errors===
+Cannot use expression as assignment target.
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "String": "string"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 14
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 17,
+                  "end": 19
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 19
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 20
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 20
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected token "=" in Standard input code on line 1


### PR DESCRIPTION
## Summary

- Add `is_valid_assignment_target()` to whitelist valid PHP lvalues (variables, array/property access, static property access, destructuring patterns)
- Apply the check in both the main Pratt loop and `parse_assign_continuation`, so all assignment contexts are covered
- Emit `ParseError::Forbidden` with "Cannot use expression as assignment target." for invalid LHS expressions like string literals, function calls, and binary expressions

Closes #174