### PR TITLE
fix(parser): emit error for empty index in string interpolation

### DIFF
--- a/crates/php-parser/src/interpolation.rs
+++ b/crates/php-parser/src/interpolation.rs
@@ -242,18 +242,26 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                             if i < len && bytes[i] == b']' {
                                 let idx_str = &inner[idx_start..i];
                                 i += 1;
-                                let idx_offset = base_offset + idx_start as u32;
-                                let idx_end = base_offset + (i - 1) as u32;
-                                let index_expr =
-                                    parse_simple_index(arena, source, idx_str, idx_offset, idx_end);
-                                let span = Span::new(var_offset, base_offset + i as u32);
-                                expr = Expr {
-                                    kind: ExprKind::ArrayAccess(ArrayAccessExpr {
-                                        array: arena.alloc(expr),
-                                        index: Some(arena.alloc(index_expr)),
-                                    }),
-                                    span,
-                                };
+                                if idx_str.is_empty() {
+                                    errors.push(ParseError::Forbidden {
+                                        message: "empty index in string interpolation".into(),
+                                        span: Span::new(bracket_offset, base_offset + i as u32),
+                                    });
+                                } else {
+                                    let idx_offset = base_offset + idx_start as u32;
+                                    let idx_end = base_offset + (i - 1) as u32;
+                                    let index_expr = parse_simple_index(
+                                        arena, source, idx_str, idx_offset, idx_end,
+                                    );
+                                    let span = Span::new(var_offset, base_offset + i as u32);
+                                    expr = Expr {
+                                        kind: ExprKind::ArrayAccess(ArrayAccessExpr {
+                                            array: arena.alloc(expr),
+                                            index: Some(arena.alloc(index_expr)),
+                                        }),
+                                        span,
+                                    };
+                                }
                             } else {
                                 errors.push(ParseError::Forbidden {
                                     message: "unclosed '[' in string offset interpolation".into(),
@@ -340,21 +348,30 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                             let idx_str = &inner[idx_start..i];
                             i += 1; // skip ]
 
-                            let idx_offset = base_offset + idx_start as u32;
-                            let idx_end = base_offset + (i - 1) as u32;
+                            if idx_str.is_empty() {
+                                errors.push(ParseError::Forbidden {
+                                    message: "empty index in string interpolation".into(),
+                                    span: Span::new(
+                                        base_offset + bracket_start as u32,
+                                        base_offset + i as u32,
+                                    ),
+                                });
+                            } else {
+                                let idx_offset = base_offset + idx_start as u32;
+                                let idx_end = base_offset + (i - 1) as u32;
 
-                            let index_expr =
-                                parse_simple_index(arena, source, idx_str, idx_offset, idx_end);
+                                let index_expr =
+                                    parse_simple_index(arena, source, idx_str, idx_offset, idx_end);
 
-                            let span = Span::new(var_offset, base_offset + i as u32);
-                            let _ = bracket_start; // used implicitly
-                            expr = Expr {
-                                kind: ExprKind::ArrayAccess(ArrayAccessExpr {
-                                    array: arena.alloc(expr),
-                                    index: Some(arena.alloc(index_expr)),
-                                }),
-                                span,
-                            };
+                                let span = Span::new(var_offset, base_offset + i as u32);
+                                expr = Expr {
+                                    kind: ExprKind::ArrayAccess(ArrayAccessExpr {
+                                        array: arena.alloc(expr),
+                                        index: Some(arena.alloc(index_expr)),
+                                    }),
+                                    span,
+                                };
+                            }
                         }
                     }
 
@@ -673,6 +690,7 @@ pub fn parse_interpolated_parts_indented<'arena, 'src>(
                     }
 
                     if i < len && bytes[i] == b'[' {
+                        let bracket_start = i;
                         i += 1; // skip [
                         let idx_start = i;
                         while i < len && bytes[i] != b']' {
@@ -681,18 +699,28 @@ pub fn parse_interpolated_parts_indented<'arena, 'src>(
                         if i < len && bytes[i] == b']' {
                             let idx_str = &raw_body[idx_start..i];
                             i += 1; // skip ]
-                            let idx_offset = body_offset + idx_start as u32;
-                            let idx_end = body_offset + (i - 1) as u32;
-                            let index_expr =
-                                parse_simple_index(arena, source, idx_str, idx_offset, idx_end);
-                            let span = Span::new(var_offset, body_offset + i as u32);
-                            expr = Expr {
-                                kind: ExprKind::ArrayAccess(ArrayAccessExpr {
-                                    array: arena.alloc(expr),
-                                    index: Some(arena.alloc(index_expr)),
-                                }),
-                                span,
-                            };
+                            if idx_str.is_empty() {
+                                errors.push(ParseError::Forbidden {
+                                    message: "empty index in string interpolation".into(),
+                                    span: Span::new(
+                                        body_offset + bracket_start as u32,
+                                        body_offset + i as u32,
+                                    ),
+                                });
+                            } else {
+                                let idx_offset = body_offset + idx_start as u32;
+                                let idx_end = body_offset + (i - 1) as u32;
+                                let index_expr =
+                                    parse_simple_index(arena, source, idx_str, idx_offset, idx_end);
+                                let span = Span::new(var_offset, body_offset + i as u32);
+                                expr = Expr {
+                                    kind: ExprKind::ArrayAccess(ArrayAccessExpr {
+                                        array: arena.alloc(expr),
+                                        index: Some(arena.alloc(index_expr)),
+                                    }),
+                                    span,
+                                };
+                            }
                         }
                     }
                     parts.push(StringPart::Expr(expr));

--- a/crates/php-parser/tests/fixtures/categories/string_interpolation/dollar_brace_constant_index.phpt
+++ b/crates/php-parser/tests/fixtures/categories/string_interpolation/dollar_brace_constant_index.phpt
@@ -1,0 +1,79 @@
+===source===
+<?php $x = "${var[PHP_INT_MAX]}";
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Expr": {
+                        "kind": {
+                          "ArrayAccess": {
+                            "array": {
+                              "kind": {
+                                "Variable": "var"
+                              },
+                              "span": {
+                                "start": 14,
+                                "end": 17
+                              }
+                            },
+                            "index": {
+                              "kind": {
+                                "String": "PHP_INT_MAX"
+                              },
+                              "span": {
+                                "start": 18,
+                                "end": 29
+                              }
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 12,
+                          "end": 30
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 32
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 32
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 33
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 33
+  }
+}

--- a/crates/php-parser/tests/fixtures/categories/string_interpolation/dollar_brace_negative_index.phpt
+++ b/crates/php-parser/tests/fixtures/categories/string_interpolation/dollar_brace_negative_index.phpt
@@ -1,0 +1,79 @@
+===source===
+<?php $x = "${var[-1]}";
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Expr": {
+                        "kind": {
+                          "ArrayAccess": {
+                            "array": {
+                              "kind": {
+                                "Variable": "var"
+                              },
+                              "span": {
+                                "start": 14,
+                                "end": 17
+                              }
+                            },
+                            "index": {
+                              "kind": {
+                                "Int": -1
+                              },
+                              "span": {
+                                "start": 18,
+                                "end": 20
+                              }
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 12,
+                          "end": 21
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 23
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 23
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 24
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 24
+  }
+}

--- a/crates/php-parser/tests/fixtures/errors/heredoc_empty_bracket_index.phpt
+++ b/crates/php-parser/tests/fixtures/errors/heredoc_empty_bracket_index.phpt
@@ -1,0 +1,69 @@
+===source===
+<?php $x = <<<EOT
+$arr[]
+EOT;
+===errors===
+empty index in string interpolation
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "Heredoc": {
+                    "label": "EOT",
+                    "parts": [
+                      {
+                        "Expr": {
+                          "kind": {
+                            "Variable": "arr"
+                          },
+                          "span": {
+                            "start": 18,
+                            "end": 22
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "span": {
+                  "start": 11,
+                  "end": 28
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 28
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 29
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 29
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected token "]", expecting "-" or identifier or variable or number in Standard input code on line 2

--- a/crates/php-parser/tests/fixtures/errors/string_dollar_brace_empty_bracket_index.phpt
+++ b/crates/php-parser/tests/fixtures/errors/string_dollar_brace_empty_bracket_index.phpt
@@ -1,0 +1,64 @@
+===source===
+<?php $x = "${arr[]}";
+===errors===
+empty index in string interpolation
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Expr": {
+                        "kind": {
+                          "Variable": "arr"
+                        },
+                        "span": {
+                          "start": 14,
+                          "end": 17
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 21
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 21
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 22
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 22
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected token "]" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/string_empty_bracket_index.phpt
+++ b/crates/php-parser/tests/fixtures/errors/string_empty_bracket_index.phpt
@@ -1,0 +1,64 @@
+===source===
+<?php $x = "$arr[]";
+===errors===
+empty index in string interpolation
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Expr": {
+                        "kind": {
+                          "Variable": "arr"
+                        },
+                        "span": {
+                          "start": 12,
+                          "end": 16
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 19
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 19
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 20
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 20
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected token "]", expecting "-" or identifier or variable or number in Standard input code on line 1


### PR DESCRIPTION
## Summary

- Empty brackets in string interpolation (`"$arr[]"`, `"${arr[]}"`, heredoc `$arr[]`) are PHP syntax errors — the parser now emits `empty index in string interpolation` for all three interpolation contexts instead of silently producing an `ArrayAccess` with an empty string index
- Adds fixture coverage for `${var[-1]}` (negative index) and `${var[PHP_INT_MAX]}` (constant-name index) to document correct span and AST output for those valid cases

Closes #172