### PR TITLE
fix(parser): replace risky unwrap in trait alias parsing

### DIFF
--- a/crates/php-parser/src/stmt.rs
+++ b/crates/php-parser/src/stmt.rs
@@ -1851,14 +1851,9 @@ fn parse_alias_rhs<'arena, 'src>(
     };
 
     // New name (optional if visibility was given)
-    let new_name = if parser.check(TokenKind::Identifier) || parser.is_semi_reserved_keyword() {
-        let (text, span) = parser
-            .eat_identifier_or_keyword()
-            .expect("guaranteed by check above");
-        Some(Name::Simple { value: text, span })
-    } else {
-        None
-    };
+    let new_name = parser
+        .eat_identifier_or_keyword()
+        .map(|(text, span)| Name::Simple { value: text, span });
 
     (new_modifier, new_name)
 }

--- a/crates/php-parser/src/stmt.rs
+++ b/crates/php-parser/src/stmt.rs
@@ -1852,7 +1852,9 @@ fn parse_alias_rhs<'arena, 'src>(
 
     // New name (optional if visibility was given)
     let new_name = if parser.check(TokenKind::Identifier) || parser.is_semi_reserved_keyword() {
-        let (text, span) = parser.eat_identifier_or_keyword().unwrap();
+        let (text, span) = parser
+            .eat_identifier_or_keyword()
+            .expect("guaranteed by check above");
         Some(Name::Simple { value: text, span })
     } else {
         None


### PR DESCRIPTION
## Summary

- Replace `.unwrap()` with `.expect()` in `parse_alias_rhs` where the call was preceded by a redundant pre-check
- Simplify further by using `.map()` directly, eliminating the pre-check entirely and making the optional nature of the new name explicit

## Test plan

- [ ] `cargo test -p php-rs-parser` passes
- [ ] No new clippy warnings (`cargo clippy --workspace --tests -- -D warnings`)