### PR TITLE
refactor(parser): simplify lazy buffer init in interpolation using get_or_insert_with

### DIFF
--- a/crates/php-parser/src/interpolation.rs
+++ b/crates/php-parser/src/interpolation.rs
@@ -30,10 +30,7 @@ pub fn parse_interpolated_parts<'arena, 'src>(
         match bytes[i] {
             b'\\' => {
                 // Materialise an owned buffer for this run if not already done.
-                if owned.is_none() {
-                    owned = Some(inner[literal_start..i].to_string());
-                }
-                let buf = owned.as_mut().unwrap();
+                let buf = owned.get_or_insert_with(|| inner[literal_start..i].to_string());
                 if i + 1 < len {
                     let next = bytes[i + 1];
                     match next {


### PR DESCRIPTION
## Summary

- Replaces the `is_none` check + `unwrap` pattern in `interpolation.rs` with `get_or_insert_with`, eliminating the `unwrap` entirely
- Semantics are identical: the closure only runs on the first `\\` escape encountered, capturing `literal_start` and `i` at that point

## Test plan

- [ ] `cargo test -p php-rs-parser` passes