### PR TITLE
feat(parser): add parse_statement / parse_statement_versioned API

### DIFF
--- a/crates/php-parser/src/lib.rs
+++ b/crates/php-parser/src/lib.rs
@@ -58,7 +58,8 @@ pub(crate) mod stmt;
 pub mod version;
 
 use diagnostics::ParseError;
-use php_ast::{Comment, Program};
+use php_ast::{Comment, Program, Stmt};
+use php_lexer::TokenKind;
 use source_map::SourceMap;
 pub use version::PhpVersion;
 
@@ -118,6 +119,69 @@ pub fn parse_versioned<'arena, 'src>(
         comments: parser.take_comments(),
         errors: parser.into_errors(),
         source_map: SourceMap::new(source),
+    }
+}
+
+/// The result of parsing a single PHP statement.
+pub struct StmtResult<'arena, 'src> {
+    /// The parsed statement, or `None` if the offset points to end-of-file or
+    /// only whitespace/comments remain.
+    pub stmt: Option<Stmt<'arena, 'src>>,
+    /// All comments found from `offset` to the end of the consumed statement.
+    pub comments: Vec<Comment<'src>>,
+    /// Parse errors and diagnostics. Empty on a successful parse.
+    pub errors: Vec<ParseError>,
+}
+
+/// Parse a single PHP statement from `source` starting at byte `offset`.
+///
+/// The parser starts in **PHP mode** (not inline HTML mode), so
+/// `source[offset..]` must contain a PHP statement without a `<?php` open tag.
+/// Spans in the returned statement are absolute byte offsets into `source`.
+///
+/// Returns `None` for [`StmtResult::stmt`] if the source at `offset` is empty
+/// or only contains whitespace/comments.
+///
+/// # Example
+///
+/// ```
+/// let arena = bumpalo::Bump::new();
+/// let source = "<?php $x = 1; $y = 2;";
+/// // offset 6 skips "<?php " and lands on "$x = 1;"
+/// let result = php_rs_parser::parse_statement(&arena, source, 6);
+/// assert!(result.errors.is_empty());
+/// assert!(result.stmt.is_some());
+/// ```
+pub fn parse_statement<'arena, 'src>(
+    arena: &'arena bumpalo::Bump,
+    source: &'src str,
+    offset: usize,
+) -> StmtResult<'arena, 'src> {
+    parse_statement_versioned(arena, source, offset, PhpVersion::default())
+}
+
+/// Parse a single PHP statement targeting the given PHP `version`.
+///
+/// See [`parse_statement`] for details on the `offset` parameter and return value.
+pub fn parse_statement_versioned<'arena, 'src>(
+    arena: &'arena bumpalo::Bump,
+    source: &'src str,
+    offset: usize,
+    version: PhpVersion,
+) -> StmtResult<'arena, 'src> {
+    let mut parser = parser::Parser::new_at(arena, source, offset, version);
+    if parser.check(TokenKind::Eof) {
+        return StmtResult {
+            stmt: None,
+            comments: parser.take_comments(),
+            errors: parser.into_errors(),
+        };
+    }
+    let stmt = stmt::parse_stmt(&mut parser);
+    StmtResult {
+        stmt: Some(stmt),
+        comments: parser.take_comments(),
+        errors: parser.into_errors(),
     }
 }
 

--- a/crates/php-parser/tests/malformed_php.rs
+++ b/crates/php-parser/tests/malformed_php.rs
@@ -223,3 +223,82 @@ fn unterminated_b_prefixed_double_quoted_ends_with_multibyte_char() {
     let arena = bumpalo::Bump::new();
     let _ = php_rs_parser::parse(&arena, src);
 }
+
+// ============================================================================
+// parse_statement — single-statement API
+// These tests use parse_statement/parse_statement_versioned, which start in
+// PHP mode at a given byte offset and return a single Stmt.  They cannot be
+// expressed as .phpt fixtures because the fixture runner always invokes the
+// full parse() API.
+// ============================================================================
+
+#[test]
+fn parse_statement_basic() {
+    let arena = bumpalo::Bump::new();
+    // Skip the "<?php " prefix (6 bytes) so we start right at the statement.
+    let source = "<?php $x = 42;";
+    let result = php_rs_parser::parse_statement(&arena, source, 6);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    assert!(result.stmt.is_some(), "expected a statement");
+}
+
+#[test]
+fn parse_statement_second_statement() {
+    let arena = bumpalo::Bump::new();
+    // Source has two statements; we skip ahead to parse only the second one.
+    let source = "<?php $x = 1; $y = 2;";
+    //                           ^ offset 14 — "$y = 2;"
+    let result = php_rs_parser::parse_statement(&arena, source, 14);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected errors: {:?}",
+        result.errors
+    );
+    assert!(result.stmt.is_some(), "expected a statement");
+}
+
+#[test]
+fn parse_statement_at_eof_returns_none() {
+    let arena = bumpalo::Bump::new();
+    let source = "<?php $x = 1;";
+    // Offset at the end of source → should return None (no statement).
+    let result = php_rs_parser::parse_statement(&arena, source, source.len());
+    assert!(result.stmt.is_none(), "expected None at EOF");
+}
+
+#[test]
+fn parse_statement_versioned_emits_version_error() {
+    let arena = bumpalo::Bump::new();
+    // Enum syntax requires PHP 8.1; targeting 8.0 should emit a VersionTooLow error.
+    let source = "<?php enum Status { case Active; }";
+    let result = php_rs_parser::parse_statement_versioned(
+        &arena,
+        source,
+        6,
+        php_rs_parser::PhpVersion::Php80,
+    );
+    assert!(result.stmt.is_some(), "statement should still be produced");
+    assert!(
+        !result.errors.is_empty(),
+        "expected a VersionTooLow error for enum on PHP 8.0"
+    );
+    let msg = result.errors[0].to_string();
+    assert!(msg.contains("requires PHP"), "unexpected error: {msg}");
+}
+
+#[test]
+fn parse_statement_with_syntax_error() {
+    let arena = bumpalo::Bump::new();
+    // Missing semicolon — parser should recover and still return a stmt.
+    let source = "<?php $x = 42";
+    let result = php_rs_parser::parse_statement(&arena, source, 6);
+    assert!(result.stmt.is_some(), "expected a (recovered) statement");
+    assert!(
+        !result.errors.is_empty(),
+        "expected a parse error for missing semicolon"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `parse_statement(arena, source, offset)` and `parse_statement_versioned(arena, source, offset, version)` — parse a single PHP statement starting at an arbitrary byte offset, in PHP mode (no `<?php` tag required); spans are absolute offsets into `source`
- Adds `StmtResult` struct with `stmt`, `comments`, and `errors` fields
- Reuses the existing `Parser::new_at` constructor (already present for string interpolation) — no lexer changes needed
- 5 programmatic tests added to `malformed_php.rs` (basic use, second-statement offset, EOF→None, version error, syntax error recovery)

Closes #158