### PR TITLE
feat(visitor): add visit_name() hook and wire up all unvisited Name fields

### DIFF
--- a/crates/php-ast/src/visitor.rs
+++ b/crates/php-ast/src/visitor.rs
@@ -95,11 +95,22 @@ pub trait Visitor<'arena, 'src> {
     ) -> ControlFlow<()> {
         ControlFlow::Continue(())
     }
+
+    fn visit_name(&mut self, _name: &Name<'arena, 'src>) -> ControlFlow<()> {
+        ControlFlow::Continue(())
+    }
 }
 
 // =============================================================================
 // Walk functions
 // =============================================================================
+
+pub fn walk_name<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
+    visitor: &mut V,
+    name: &Name<'arena, 'src>,
+) -> ControlFlow<()> {
+    visitor.visit_name(name)
+}
 
 pub fn walk_program<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
@@ -226,12 +237,21 @@ pub fn walk_stmt<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
         }
         StmtKind::Class(class) => {
             walk_attributes(visitor, &class.attributes)?;
+            if let Some(extends) = &class.extends {
+                visitor.visit_name(extends)?;
+            }
+            for name in class.implements.iter() {
+                visitor.visit_name(name)?;
+            }
             for member in class.members.iter() {
                 visitor.visit_class_member(member)?;
             }
         }
         StmtKind::Interface(iface) => {
             walk_attributes(visitor, &iface.attributes)?;
+            for name in iface.extends.iter() {
+                visitor.visit_name(name)?;
+            }
             for member in iface.members.iter() {
                 visitor.visit_class_member(member)?;
             }
@@ -244,6 +264,12 @@ pub fn walk_stmt<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
         }
         StmtKind::Enum(enum_decl) => {
             walk_attributes(visitor, &enum_decl.attributes)?;
+            if let Some(scalar_type) = &enum_decl.scalar_type {
+                visitor.visit_name(scalar_type)?;
+            }
+            for name in enum_decl.implements.iter() {
+                visitor.visit_name(name)?;
+            }
             for member in enum_decl.members.iter() {
                 visitor.visit_enum_member(member)?;
             }
@@ -268,8 +294,12 @@ pub fn walk_stmt<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
                 }
             }
         }
-        StmtKind::Use(_)
-        | StmtKind::Goto(_)
+        StmtKind::Use(decl) => {
+            for item in decl.uses.iter() {
+                visitor.visit_name(&item.name)?;
+            }
+        }
+        StmtKind::Goto(_)
         | StmtKind::Label(_)
         | StmtKind::Nop
         | StmtKind::InlineHtml(_)
@@ -596,7 +626,10 @@ pub fn walk_type_hint<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
                 visitor.visit_type_hint(ty)?;
             }
         }
-        TypeHintKind::Named(_) | TypeHintKind::Keyword(_, _) => {}
+        TypeHintKind::Named(name) => {
+            visitor.visit_name(name)?;
+        }
+        TypeHintKind::Keyword(_, _) => {}
     }
     ControlFlow::Continue(())
 }
@@ -605,6 +638,7 @@ pub fn walk_attribute<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     attribute: &Attribute<'arena, 'src>,
 ) -> ControlFlow<()> {
+    visitor.visit_name(&attribute.name)?;
     for arg in attribute.args.iter() {
         visitor.visit_arg(arg)?;
     }
@@ -615,6 +649,9 @@ pub fn walk_catch_clause<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     catch: &CatchClause<'arena, 'src>,
 ) -> ControlFlow<()> {
+    for ty in catch.types.iter() {
+        visitor.visit_name(ty)?;
+    }
     for stmt in catch.body.iter() {
         visitor.visit_stmt(stmt)?;
     }
@@ -637,6 +674,9 @@ pub fn walk_trait_use<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     trait_use: &TraitUseDecl<'arena, 'src>,
 ) -> ControlFlow<()> {
+    for name in trait_use.traits.iter() {
+        visitor.visit_name(name)?;
+    }
     for adaptation in trait_use.adaptations.iter() {
         visitor.visit_trait_adaptation(adaptation)?;
     }

--- a/crates/php-parser/tests/visitor.rs
+++ b/crates/php-parser/tests/visitor.rs
@@ -6,6 +6,19 @@ use php_ast::ast::*;
 use php_ast::visitor::{self, walk_trait_use, Scope, ScopeVisitor, ScopeWalker, Visitor};
 use std::ops::ControlFlow;
 
+/// Collects all Name nodes seen during traversal as string representations.
+#[derive(Default)]
+struct NameCollector {
+    names: Vec<String>,
+}
+
+impl<'arena, 'src> Visitor<'arena, 'src> for NameCollector {
+    fn visit_name(&mut self, name: &Name<'arena, 'src>) -> ControlFlow<()> {
+        self.names.push(name.to_string_repr().to_string());
+        ControlFlow::Continue(())
+    }
+}
+
 /// Parse PHP source and run a callback with the resulting program.
 /// Keeps the arena alive for the duration of the callback.
 fn with_parsed<F: for<'arena, 'src> FnOnce(&'src str, &Program<'arena, 'src>)>(src: &str, f: F) {
@@ -754,6 +767,112 @@ fn scope_visitor_visits_trait_adaptations() {
             let c = walker.into_inner();
             assert_eq!(c.adaptation_count, 2);
             assert_eq!(c.class_names, vec![Some("Foo".into()), Some("Foo".into())]);
+        },
+    );
+}
+
+// =============================================================================
+// visit_name tests
+// =============================================================================
+
+#[test]
+fn visits_class_extends_and_implements() {
+    with_parsed(
+        "<?php class Foo extends Bar implements Baz, Qux {}",
+        |_src, program| {
+            let mut v = NameCollector::default();
+            let _ = v.visit_program(program);
+            assert!(v.names.contains(&"Bar".to_string()));
+            assert!(v.names.contains(&"Baz".to_string()));
+            assert!(v.names.contains(&"Qux".to_string()));
+        },
+    );
+}
+
+#[test]
+fn visits_interface_extends() {
+    with_parsed("<?php interface A extends B, C {}", |_src, program| {
+        let mut v = NameCollector::default();
+        let _ = v.visit_program(program);
+        assert!(v.names.contains(&"B".to_string()));
+        assert!(v.names.contains(&"C".to_string()));
+    });
+}
+
+#[test]
+fn visits_enum_scalar_type_and_implements() {
+    with_parsed(
+        "<?php enum Status: string implements Stringable { case Active = 'active'; }",
+        |_src, program| {
+            let mut v = NameCollector::default();
+            let _ = v.visit_program(program);
+            assert!(v.names.contains(&"string".to_string()));
+            assert!(v.names.contains(&"Stringable".to_string()));
+        },
+    );
+}
+
+#[test]
+fn visits_catch_clause_types() {
+    with_parsed(
+        "<?php try { foo(); } catch (RuntimeException|LogicException $e) { bar(); }",
+        |_src, program| {
+            let mut v = NameCollector::default();
+            let _ = v.visit_program(program);
+            assert!(v.names.contains(&"RuntimeException".to_string()));
+            assert!(v.names.contains(&"LogicException".to_string()));
+        },
+    );
+}
+
+#[test]
+fn visits_trait_use_names() {
+    with_parsed(
+        "<?php class Foo { use Loggable, Serializable; }",
+        |_src, program| {
+            let mut v = NameCollector::default();
+            let _ = v.visit_program(program);
+            assert!(v.names.contains(&"Loggable".to_string()));
+            assert!(v.names.contains(&"Serializable".to_string()));
+        },
+    );
+}
+
+#[test]
+fn visits_attribute_names() {
+    with_parsed(
+        "<?php #[Route('/api')] #[Middleware\\Auth] function handler(): void {}",
+        |_src, program| {
+            let mut v = NameCollector::default();
+            let _ = v.visit_program(program);
+            assert!(v.names.contains(&"Route".to_string()));
+            assert!(v.names.contains(&"Middleware\\Auth".to_string()));
+        },
+    );
+}
+
+#[test]
+fn visits_named_type_hints() {
+    with_parsed(
+        "<?php function foo(App\\Request $req): App\\Response {}",
+        |_src, program| {
+            let mut v = NameCollector::default();
+            let _ = v.visit_program(program);
+            assert!(v.names.contains(&"App\\Request".to_string()));
+            assert!(v.names.contains(&"App\\Response".to_string()));
+        },
+    );
+}
+
+#[test]
+fn visits_use_statement_names() {
+    with_parsed(
+        "<?php use App\\Http\\Request; use App\\Http\\Response as Resp;",
+        |_src, program| {
+            let mut v = NameCollector::default();
+            let _ = v.visit_program(program);
+            assert!(v.names.contains(&"App\\Http\\Request".to_string()));
+            assert!(v.names.contains(&"App\\Http\\Response".to_string()));
         },
     );
 }

--- a/crates/php-parser/tests/visitor.rs
+++ b/crates/php-parser/tests/visitor.rs
@@ -782,9 +782,8 @@ fn visits_class_extends_and_implements() {
         |_src, program| {
             let mut v = NameCollector::default();
             let _ = v.visit_program(program);
-            assert!(v.names.contains(&"Bar".to_string()));
-            assert!(v.names.contains(&"Baz".to_string()));
-            assert!(v.names.contains(&"Qux".to_string()));
+            // Exact: extends first, then implements in order. No other names in this snippet.
+            assert_eq!(v.names, vec!["Bar", "Baz", "Qux"]);
         },
     );
 }
@@ -794,22 +793,28 @@ fn visits_interface_extends() {
     with_parsed("<?php interface A extends B, C {}", |_src, program| {
         let mut v = NameCollector::default();
         let _ = v.visit_program(program);
-        assert!(v.names.contains(&"B".to_string()));
-        assert!(v.names.contains(&"C".to_string()));
+        assert_eq!(v.names, vec!["B", "C"]);
     });
 }
 
 #[test]
-fn visits_enum_scalar_type_and_implements() {
-    with_parsed(
-        "<?php enum Status: string implements Stringable { case Active = 'active'; }",
-        |_src, program| {
-            let mut v = NameCollector::default();
-            let _ = v.visit_program(program);
-            assert!(v.names.contains(&"string".to_string()));
-            assert!(v.names.contains(&"Stringable".to_string()));
-        },
-    );
+fn visits_enum_scalar_type() {
+    // Split from implements so each path is independently verified.
+    with_parsed("<?php enum E: string {}", |_src, program| {
+        let mut v = NameCollector::default();
+        let _ = v.visit_program(program);
+        // "string" must come from scalar_type — no other names in this snippet.
+        assert_eq!(v.names, vec!["string"]);
+    });
+}
+
+#[test]
+fn visits_enum_implements() {
+    with_parsed("<?php enum E implements Countable {}", |_src, program| {
+        let mut v = NameCollector::default();
+        let _ = v.visit_program(program);
+        assert_eq!(v.names, vec!["Countable"]);
+    });
 }
 
 #[test]
@@ -819,8 +824,7 @@ fn visits_catch_clause_types() {
         |_src, program| {
             let mut v = NameCollector::default();
             let _ = v.visit_program(program);
-            assert!(v.names.contains(&"RuntimeException".to_string()));
-            assert!(v.names.contains(&"LogicException".to_string()));
+            assert_eq!(v.names, vec!["RuntimeException", "LogicException"]);
         },
     );
 }
@@ -832,8 +836,7 @@ fn visits_trait_use_names() {
         |_src, program| {
             let mut v = NameCollector::default();
             let _ = v.visit_program(program);
-            assert!(v.names.contains(&"Loggable".to_string()));
-            assert!(v.names.contains(&"Serializable".to_string()));
+            assert_eq!(v.names, vec!["Loggable", "Serializable"]);
         },
     );
 }
@@ -845,8 +848,7 @@ fn visits_attribute_names() {
         |_src, program| {
             let mut v = NameCollector::default();
             let _ = v.visit_program(program);
-            assert!(v.names.contains(&"Route".to_string()));
-            assert!(v.names.contains(&"Middleware\\Auth".to_string()));
+            assert_eq!(v.names, vec!["Route", "Middleware\\Auth"]);
         },
     );
 }
@@ -858,8 +860,8 @@ fn visits_named_type_hints() {
         |_src, program| {
             let mut v = NameCollector::default();
             let _ = v.visit_program(program);
-            assert!(v.names.contains(&"App\\Request".to_string()));
-            assert!(v.names.contains(&"App\\Response".to_string()));
+            // param type hint first, then return type.
+            assert_eq!(v.names, vec!["App\\Request", "App\\Response"]);
         },
     );
 }
@@ -871,8 +873,7 @@ fn visits_use_statement_names() {
         |_src, program| {
             let mut v = NameCollector::default();
             let _ = v.visit_program(program);
-            assert!(v.names.contains(&"App\\Http\\Request".to_string()));
-            assert!(v.names.contains(&"App\\Http\\Response".to_string()));
+            assert_eq!(v.names, vec!["App\\Http\\Request", "App\\Http\\Response"]);
         },
     );
 }


### PR DESCRIPTION
## Summary

- Add `visit_name()` to the `Visitor` trait with a default no-op — fully backwards compatible, all existing visitors compile unchanged
- Add `walk_name()` as the corresponding free function
- Wire up every `Name<'arena, 'src>` field that was previously invisible to visitors:

| Walk function | Field now visited |
|---|---|
| `walk_stmt` (Use arm) | `UseItem.name` — was entirely skipped |
| `walk_stmt` (Class arm) | `ClassDecl.extends`, `ClassDecl.implements` |
| `walk_stmt` (Interface arm) | `InterfaceDecl.extends` |
| `walk_stmt` (Enum arm) | `EnumDecl.scalar_type`, `EnumDecl.implements` |
| `walk_catch_clause` | `CatchClause.types` |
| `walk_trait_use` | `TraitUseDecl.traits` |
| `walk_attribute` | `Attribute.name` |
| `walk_type_hint` | `Name` inside `TypeHintKind::Named` |

- 8 new integration tests in `visitor.rs` covering each newly-exposed hook point

Closes #224