### PR TITLE
test(parser): add error-recovery fixtures for property hooks

### DIFF
--- a/crates/php-parser/src/stmt.rs
+++ b/crates/php-parser/src/stmt.rs
@@ -1866,6 +1866,8 @@ fn parse_property_hooks<'arena, 'src>(
     let open_span = open.map(|t| t.span).unwrap_or(parser.current_span());
 
     let mut hooks = parser.alloc_vec();
+    let mut seen_get = false;
+    let mut seen_set = false;
 
     while !parser.check(TokenKind::RightBrace) && !parser.check(TokenKind::Eof) {
         let hook_start = parser.start_span();
@@ -2010,6 +2012,28 @@ fn parse_property_hooks<'arena, 'src>(
             parser.expect(TokenKind::Semicolon);
             PropertyHookBody::Abstract
         };
+
+        // Check for duplicate hook kinds
+        match kind {
+            PropertyHookKind::Get => {
+                if seen_get {
+                    parser.error(ParseError::Forbidden {
+                        message: "duplicate 'get' hook".into(),
+                        span: Span::new(hook_start, parser.previous_end()),
+                    });
+                }
+                seen_get = true;
+            }
+            PropertyHookKind::Set => {
+                if seen_set {
+                    parser.error(ParseError::Forbidden {
+                        message: "duplicate 'set' hook".into(),
+                        span: Span::new(hook_start, parser.previous_end()),
+                    });
+                }
+                seen_set = true;
+            }
+        }
 
         let hook_span = Span::new(hook_start, parser.previous_end());
         hooks.push(PropertyHook {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_5.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_hooks_5.phpt
@@ -15,10 +15,14 @@ class Test {
 expected 'get' or 'set', found 'public'
 expected 'get' or 'set', found 'public'
 expected 'get' or 'set', found 'protected'
+duplicate 'get' hook
 expected 'get' or 'set', found 'private'
+duplicate 'get' hook
 expected 'get' or 'set', found 'abstract'
 expected 'get' or 'set', found 'static'
+duplicate 'get' hook
 expected 'get' or 'set', found 'readonly'
+duplicate 'get' hook
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/errors/property_hooks/abstract_modifier_on_hook.phpt
+++ b/crates/php-parser/tests/fixtures/errors/property_hooks/abstract_modifier_on_hook.phpt
@@ -1,0 +1,112 @@
+===config===
+min_php=8.4
+===source===
+<?php
+class Foo {
+    public int $x {
+        abstract get { return 1; }
+    }
+}
+===errors===
+expected 'get' or 'set', found 'abstract'
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "x",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "int"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 29,
+                          "end": 32
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 29,
+                      "end": 32
+                    }
+                  },
+                  "default": null,
+                  "attributes": [],
+                  "hooks": [
+                    {
+                      "kind": "Get",
+                      "body": {
+                        "Block": [
+                          {
+                            "kind": {
+                              "Return": {
+                                "kind": {
+                                  "Int": 1
+                                },
+                                "span": {
+                                  "start": 68,
+                                  "end": 69
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 61,
+                              "end": 70
+                            }
+                          }
+                        ]
+                      },
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [],
+                      "attributes": [],
+                      "span": {
+                        "start": 46,
+                        "end": 72
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 22,
+                "end": 78
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 80
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 80
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot use the abstract modifier on a property hook in Standard input code on line 4

--- a/crates/php-parser/tests/fixtures/errors/property_hooks/duplicate_hook_kind.phpt
+++ b/crates/php-parser/tests/fixtures/errors/property_hooks/duplicate_hook_kind.phpt
@@ -1,0 +1,145 @@
+===config===
+min_php=8.4
+===source===
+<?php
+class Foo {
+    public int $x {
+        get { return 1; }
+        get { return 2; }
+    }
+}
+===errors===
+duplicate 'get' hook
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "x",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "int"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 29,
+                          "end": 32
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 29,
+                      "end": 32
+                    }
+                  },
+                  "default": null,
+                  "attributes": [],
+                  "hooks": [
+                    {
+                      "kind": "Get",
+                      "body": {
+                        "Block": [
+                          {
+                            "kind": {
+                              "Return": {
+                                "kind": {
+                                  "Int": 1
+                                },
+                                "span": {
+                                  "start": 59,
+                                  "end": 60
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 52,
+                              "end": 61
+                            }
+                          }
+                        ]
+                      },
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [],
+                      "attributes": [],
+                      "span": {
+                        "start": 46,
+                        "end": 63
+                      }
+                    },
+                    {
+                      "kind": "Get",
+                      "body": {
+                        "Block": [
+                          {
+                            "kind": {
+                              "Return": {
+                                "kind": {
+                                  "Int": 2
+                                },
+                                "span": {
+                                  "start": 85,
+                                  "end": 86
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 78,
+                              "end": 87
+                            }
+                          }
+                        ]
+                      },
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [],
+                      "attributes": [],
+                      "span": {
+                        "start": 72,
+                        "end": 89
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 22,
+                "end": 95
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 97
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 97
+  }
+}
+===php_error===
+PHP Fatal error:  Cannot redeclare property hook "get" in Standard input code on line 5

--- a/crates/php-parser/tests/fixtures/errors/property_hooks/malformed_hook_body.phpt
+++ b/crates/php-parser/tests/fixtures/errors/property_hooks/malformed_hook_body.phpt
@@ -1,0 +1,132 @@
+===config===
+min_php=8.4
+===source===
+<?php
+class Foo {
+    public int $x {
+        123;
+        get { return $this->x; }
+    }
+}
+===errors===
+expected 'get' or 'set', found integer
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "x",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": false,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "int"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 29,
+                          "end": 32
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 29,
+                      "end": 32
+                    }
+                  },
+                  "default": null,
+                  "attributes": [],
+                  "hooks": [
+                    {
+                      "kind": "Get",
+                      "body": {
+                        "Block": [
+                          {
+                            "kind": {
+                              "Return": {
+                                "kind": {
+                                  "PropertyAccess": {
+                                    "object": {
+                                      "kind": {
+                                        "Variable": "this"
+                                      },
+                                      "span": {
+                                        "start": 72,
+                                        "end": 77
+                                      }
+                                    },
+                                    "property": {
+                                      "kind": {
+                                        "Identifier": "x"
+                                      },
+                                      "span": {
+                                        "start": 79,
+                                        "end": 80
+                                      }
+                                    }
+                                  }
+                                },
+                                "span": {
+                                  "start": 72,
+                                  "end": 80
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 65,
+                              "end": 81
+                            }
+                          }
+                        ]
+                      },
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [],
+                      "attributes": [],
+                      "span": {
+                        "start": 59,
+                        "end": 83
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 22,
+                "end": 89
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 91
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 91
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected integer "123", expecting identifier in Standard input code on line 4


### PR DESCRIPTION
## Summary

- Add three `.phpt` fixtures in `errors/property_hooks/` to cover previously untested `parse_property_hooks` error-recovery paths: stray non-identifier token, `abstract` as an invalid hook modifier, and duplicate `get`/`set` hook kinds
- Add duplicate hook detection to `parse_property_hooks`: emits a `Forbidden` error when the same `get` or `set` hook appears more than once on a property
- Update `property_hooks_5.phpt` to include the new duplicate-hook errors that now fire alongside existing invalid-modifier errors

Closes #229