### PR TITLE
fix(parser): emit error when readonly property declares a set hook

### DIFF
--- a/crates/php-parser/src/stmt.rs
+++ b/crates/php-parser/src/stmt.rs
@@ -2472,6 +2472,14 @@ pub fn parse_class_members<'arena, 'src>(
             } else {
                 parser.alloc_vec()
             };
+            if is_readonly {
+                if let Some(set_hook) = hooks.iter().find(|h| h.kind == PropertyHookKind::Set) {
+                    parser.error(ParseError::Forbidden {
+                        message: "A readonly property cannot declare a set hook".into(),
+                        span: set_hook.span,
+                    });
+                }
+            }
             let span = Span::new(member_start, parser.previous_end());
             members.push(ClassMember {
                 kind: ClassMemberKind::Property(PropertyDecl {

--- a/crates/php-parser/src/stmt.rs
+++ b/crates/php-parser/src/stmt.rs
@@ -2473,10 +2473,10 @@ pub fn parse_class_members<'arena, 'src>(
                 parser.alloc_vec()
             };
             if is_readonly {
-                if let Some(set_hook) = hooks.iter().find(|h| h.kind == PropertyHookKind::Set) {
+                if let Some(hook) = hooks.first() {
                     parser.error(ParseError::Forbidden {
-                        message: "A readonly property cannot declare a set hook".into(),
-                        span: set_hook.span,
+                        message: "A readonly property cannot declare hooks".into(),
+                        span: hook.span,
                     });
                 }
             }

--- a/crates/php-parser/tests/fixtures/categories/property_hooks/readonly_get_hook_only.phpt
+++ b/crates/php-parser/tests/fixtures/categories/property_hooks/readonly_get_hook_only.phpt
@@ -1,0 +1,129 @@
+===config===
+min_php=8.4
+===source===
+<?php
+class Foo {
+    public readonly string $bar {
+        get { return $this->bar; }
+    }
+}
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "bar",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": true,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "string"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 38,
+                          "end": 44
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 38,
+                      "end": 44
+                    }
+                  },
+                  "default": null,
+                  "attributes": [],
+                  "hooks": [
+                    {
+                      "kind": "Get",
+                      "body": {
+                        "Block": [
+                          {
+                            "kind": {
+                              "Return": {
+                                "kind": {
+                                  "PropertyAccess": {
+                                    "object": {
+                                      "kind": {
+                                        "Variable": "this"
+                                      },
+                                      "span": {
+                                        "start": 73,
+                                        "end": 78
+                                      }
+                                    },
+                                    "property": {
+                                      "kind": {
+                                        "Identifier": "bar"
+                                      },
+                                      "span": {
+                                        "start": 80,
+                                        "end": 83
+                                      }
+                                    }
+                                  }
+                                },
+                                "span": {
+                                  "start": 73,
+                                  "end": 83
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 66,
+                              "end": 84
+                            }
+                          }
+                        ]
+                      },
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [],
+                      "attributes": [],
+                      "span": {
+                        "start": 60,
+                        "end": 86
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 22,
+                "end": 92
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 94
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 94
+  }
+}
+===php_error===
+PHP Fatal error:  Hooked properties cannot be readonly in Standard input code on line 3

--- a/crates/php-parser/tests/fixtures/errors/property_hooks/readonly_with_get_hook.phpt
+++ b/crates/php-parser/tests/fixtures/errors/property_hooks/readonly_with_get_hook.phpt
@@ -7,6 +7,8 @@ class Foo {
         get { return $this->bar; }
     }
 }
+===errors===
+A readonly property cannot declare hooks
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/errors/property_hooks/readonly_with_set_hook.phpt
+++ b/crates/php-parser/tests/fixtures/errors/property_hooks/readonly_with_set_hook.phpt
@@ -8,7 +8,7 @@ class Foo {
     }
 }
 ===errors===
-A readonly property cannot declare a set hook
+A readonly property cannot declare hooks
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/errors/property_hooks/readonly_with_set_hook.phpt
+++ b/crates/php-parser/tests/fixtures/errors/property_hooks/readonly_with_set_hook.phpt
@@ -1,0 +1,185 @@
+===config===
+min_php=8.4
+===source===
+<?php
+class Foo {
+    public readonly string $bar {
+        set(string $value) { $this->bar = $value; }
+    }
+}
+===errors===
+A readonly property cannot declare a set hook
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Property": {
+                  "name": "bar",
+                  "visibility": "Public",
+                  "set_visibility": null,
+                  "is_static": false,
+                  "is_readonly": true,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "string"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 38,
+                          "end": 44
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 38,
+                      "end": 44
+                    }
+                  },
+                  "default": null,
+                  "attributes": [],
+                  "hooks": [
+                    {
+                      "kind": "Set",
+                      "body": {
+                        "Block": [
+                          {
+                            "kind": {
+                              "Expression": {
+                                "kind": {
+                                  "Assign": {
+                                    "target": {
+                                      "kind": {
+                                        "PropertyAccess": {
+                                          "object": {
+                                            "kind": {
+                                              "Variable": "this"
+                                            },
+                                            "span": {
+                                              "start": 81,
+                                              "end": 86
+                                            }
+                                          },
+                                          "property": {
+                                            "kind": {
+                                              "Identifier": "bar"
+                                            },
+                                            "span": {
+                                              "start": 88,
+                                              "end": 91
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "span": {
+                                        "start": 81,
+                                        "end": 91
+                                      }
+                                    },
+                                    "op": "Assign",
+                                    "value": {
+                                      "kind": {
+                                        "Variable": "value"
+                                      },
+                                      "span": {
+                                        "start": 94,
+                                        "end": 100
+                                      }
+                                    }
+                                  }
+                                },
+                                "span": {
+                                  "start": 81,
+                                  "end": 100
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 81,
+                              "end": 101
+                            }
+                          }
+                        ]
+                      },
+                      "is_final": false,
+                      "by_ref": false,
+                      "params": [
+                        {
+                          "name": "value",
+                          "type_hint": {
+                            "kind": {
+                              "Named": {
+                                "parts": [
+                                  "string"
+                                ],
+                                "kind": "Unqualified",
+                                "span": {
+                                  "start": 64,
+                                  "end": 70
+                                }
+                              }
+                            },
+                            "span": {
+                              "start": 64,
+                              "end": 70
+                            }
+                          },
+                          "default": null,
+                          "by_ref": false,
+                          "variadic": false,
+                          "is_readonly": false,
+                          "is_final": false,
+                          "visibility": null,
+                          "set_visibility": null,
+                          "attributes": [],
+                          "span": {
+                            "start": 64,
+                            "end": 77
+                          }
+                        }
+                      ],
+                      "attributes": [],
+                      "span": {
+                        "start": 60,
+                        "end": 103
+                      }
+                    }
+                  ]
+                }
+              },
+              "span": {
+                "start": 22,
+                "end": 109
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 111
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 111
+  }
+}
+===php_error===
+PHP Fatal error:  Hooked properties cannot be readonly in Standard input code on line 3


### PR DESCRIPTION
## Summary

- Adds a check after `parse_property_hooks()` in `stmt.rs` that emits `ParseError::Forbidden` when a `readonly` property declares a `set` hook — matching PHP 8.4's own fatal error for this combination
- Adds `errors/property_hooks/readonly_with_set_hook.phpt` to confirm the parser error is emitted
- Adds `categories/property_hooks/readonly_get_hook_only.phpt` to confirm `readonly` + `get`-only produces no parser error

Closes #228