### PR TITLE
test(parser): add fixtures for string interpolation edge cases

### DIFF
--- a/crates/php-parser/src/interpolation.rs
+++ b/crates/php-parser/src/interpolation.rs
@@ -440,6 +440,15 @@ pub fn parse_interpolated_parts<'arena, 'src>(
                 let end_offset = base_offset + expr_end as u32;
                 let expr =
                     parse_complex_interpolation(arena, source, expr_offset, end_offset, version);
+                if matches!(
+                    expr.kind,
+                    ExprKind::ClassConstAccess(_) | ExprKind::ClassConstAccessDynamic { .. }
+                ) {
+                    errors.push(ParseError::Forbidden {
+                        message: "class constant access is not valid as a standalone interpolation expression".into(),
+                        span: expr.span,
+                    });
+                }
                 parts.push(StringPart::Expr(expr));
                 literal_start = i;
             }
@@ -774,6 +783,15 @@ pub fn parse_interpolated_parts_indented<'arena, 'src>(
                 let end_offset = body_offset + expr_end as u32;
                 let expr =
                     parse_complex_interpolation(arena, source, expr_offset, end_offset, version);
+                if matches!(
+                    expr.kind,
+                    ExprKind::ClassConstAccess(_) | ExprKind::ClassConstAccessDynamic { .. }
+                ) {
+                    errors.push(ParseError::Forbidden {
+                        message: "class constant access is not valid as a standalone interpolation expression".into(),
+                        span: expr.span,
+                    });
+                }
                 parts.push(StringPart::Expr(expr));
             }
             _ => {

--- a/crates/php-parser/tests/fixtures/categories/string_interpolation/class_const_in_curly.phpt
+++ b/crates/php-parser/tests/fixtures/categories/string_interpolation/class_const_in_curly.phpt
@@ -1,0 +1,81 @@
+===source===
+<?php $x = "{$obj::CONST}";
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Expr": {
+                        "kind": {
+                          "ClassConstAccess": {
+                            "class": {
+                              "kind": {
+                                "Variable": "obj"
+                              },
+                              "span": {
+                                "start": 13,
+                                "end": 17
+                              }
+                            },
+                            "member": {
+                              "kind": {
+                                "Identifier": "CONST"
+                              },
+                              "span": {
+                                "start": 19,
+                                "end": 24
+                              }
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 13,
+                          "end": 24
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 26
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 26
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 27
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 27
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected token "}", expecting "->" or "?->" or "[" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/categories/string_interpolation/nested_prop_chain_no_curly.phpt
+++ b/crates/php-parser/tests/fixtures/categories/string_interpolation/nested_prop_chain_no_curly.phpt
@@ -1,0 +1,85 @@
+===source===
+<?php $x = "val $obj->a->b end";
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Literal": "val "
+                    },
+                    {
+                      "Expr": {
+                        "kind": {
+                          "PropertyAccess": {
+                            "object": {
+                              "kind": {
+                                "Variable": "obj"
+                              },
+                              "span": {
+                                "start": 16,
+                                "end": 20
+                              }
+                            },
+                            "property": {
+                              "kind": {
+                                "Identifier": "a"
+                              },
+                              "span": {
+                                "start": 22,
+                                "end": 23
+                              }
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 16,
+                          "end": 23
+                        }
+                      }
+                    },
+                    {
+                      "Literal": "->b end"
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 31
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 31
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 32
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 32
+  }
+}

--- a/crates/php-parser/tests/fixtures/errors/class_const_dynamic_in_curly.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_const_dynamic_in_curly.phpt
@@ -1,0 +1,85 @@
+===config===
+min_php=8.4
+===source===
+<?php $x = "{$obj::{$name}}";
+===errors===
+class constant access is not valid as a standalone interpolation expression
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "Assign": {
+              "target": {
+                "kind": {
+                  "Variable": "x"
+                },
+                "span": {
+                  "start": 6,
+                  "end": 8
+                }
+              },
+              "op": "Assign",
+              "value": {
+                "kind": {
+                  "InterpolatedString": [
+                    {
+                      "Expr": {
+                        "kind": {
+                          "ClassConstAccessDynamic": {
+                            "class": {
+                              "kind": {
+                                "Variable": "obj"
+                              },
+                              "span": {
+                                "start": 13,
+                                "end": 17
+                              }
+                            },
+                            "member": {
+                              "kind": {
+                                "Variable": "name"
+                              },
+                              "span": {
+                                "start": 20,
+                                "end": 25
+                              }
+                            }
+                          }
+                        },
+                        "span": {
+                          "start": 13,
+                          "end": 26
+                        }
+                      }
+                    }
+                  ]
+                },
+                "span": {
+                  "start": 11,
+                  "end": 28
+                }
+              }
+            }
+          },
+          "span": {
+            "start": 6,
+            "end": 28
+          }
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 29
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 29
+  }
+}
+===php_error===
+PHP Parse error:  syntax error, unexpected token "}", expecting "->" or "?->" or "[" in Standard input code on line 1

--- a/crates/php-parser/tests/fixtures/errors/class_const_in_curly.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_const_in_curly.phpt
@@ -1,5 +1,7 @@
 ===source===
 <?php $x = "{$obj::CONST}";
+===errors===
+class constant access is not valid as a standalone interpolation expression
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/errors/class_const_in_curly.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_const_in_curly.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.4
 ===source===
 <?php $x = "{$obj::CONST}";
 ===errors===


### PR DESCRIPTION
## Summary

- Add `nested_prop_chain_no_curly.phpt`: documents that `"$obj->a->b"` without curly braces only interpolates the first dereference (`$obj->a`), leaving `->b` as literal text
- Add `errors/class_const_in_curly.phpt`: documents that `"{$obj::CONST}"` is rejected by both PHP and the Rust parser — `ClassConstAccess` is not a valid lvalue as the root of `{$...}` interpolation; a following dereference like `{$obj::CONST->prop}` is valid
- Fix `parse_interpolated_parts` and `parse_interpolated_parts_indented` to emit `ParseError::Forbidden` when the root expression of `{$...}` is `ClassConstAccess` or `ClassConstAccessDynamic`

Closes #232