### PR TITLE
docs(ast,lexer): complete public API documentation coverage

### DIFF
--- a/crates/php-ast/src/ast.rs
+++ b/crates/php-ast/src/ast.rs
@@ -233,9 +233,13 @@ impl<'arena, 'src> serde::Serialize for Name<'arena, 'src> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum NameKind {
+    /// A bare identifier with no namespace separator: `Foo`, `strlen`.
     Unqualified,
+    /// A name with at least one internal `\` but no leading backslash: `Foo\Bar`.
     Qualified,
+    /// A name with a leading `\`: `\Foo\Bar`.
     FullyQualified,
+    /// A name starting with the `namespace` keyword: `namespace\Foo`.
     Relative,
 }
 
@@ -244,25 +248,45 @@ pub enum NameKind {
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum BuiltinType {
+    /// `int` — integer scalar type.
     Int,
+    /// `integer` — alias for `int`, accepted in type casts.
     Integer,
+    /// `float` — floating-point scalar type.
     Float,
+    /// `double` — alias for `float`, accepted in type casts.
     Double,
+    /// `string` — string scalar type.
     String,
+    /// `bool` — boolean scalar type.
     Bool,
+    /// `boolean` — alias for `bool`, accepted in type casts.
     Boolean,
+    /// `void` — return-only type indicating no value is returned.
     Void,
+    /// `never` — return-only type for functions that never return normally (PHP 8.1+).
     Never,
+    /// `mixed` — top type; accepts any value.
     Mixed,
+    /// `object` — any object instance.
     Object,
+    /// `iterable` — `array` or `Traversable` (deprecated in PHP 8.2; use `array|Traversable`).
     Iterable,
+    /// `callable` — any callable value.
     Callable,
+    /// `array` — any PHP array.
     Array,
+    /// `self` — refers to the class in which the type hint appears.
     Self_,
+    /// `parent` — refers to the parent class of the class in which the type hint appears.
     Parent_,
+    /// `static` — late-static-bound type; the class on which the method was called.
     Static,
+    /// `null` — the null type; only valid in union types.
     Null,
+    /// `true` — the literal boolean `true` (PHP 8.2+).
     True,
+    /// `false` — the literal boolean `false`.
     False,
 }
 
@@ -310,11 +334,15 @@ pub struct TypeHint<'arena, 'src> {
 /// Serialises identically to `Named` so all existing snapshots remain unchanged.
 #[derive(Debug)]
 pub enum TypeHintKind<'arena, 'src> {
+    /// A user-defined or qualified class name: `Foo`, `\Ns\Bar`.
     Named(Name<'arena, 'src>),
-    /// Built-in type keyword — serialises as `Named` for snapshot compatibility.
+    /// Built-in type keyword (`int`, `string`, `bool`, `self`, …) — serialises as `Named` for snapshot compatibility.
     Keyword(BuiltinType, Span),
+    /// Nullable type: `?T` — equivalent to `T|null`.
     Nullable(&'arena TypeHint<'arena, 'src>),
+    /// Union type: `A|B|C` (PHP 8.0+).
     Union(ArenaVec<'arena, TypeHint<'arena, 'src>>),
+    /// Intersection type: `A&B` (PHP 8.1+).
     Intersection(ArenaVec<'arena, TypeHint<'arena, 'src>>),
 }
 
@@ -594,8 +622,11 @@ pub struct CatchClause<'arena, 'src> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum Visibility {
+    /// `public` — accessible from anywhere.
     Public,
+    /// `protected` — accessible within the class and its subclasses.
     Protected,
+    /// `private` — accessible only within the declaring class.
     Private,
 }
 
@@ -650,14 +681,19 @@ pub struct PropertyDecl<'arena, 'src> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum PropertyHookKind {
+    /// `get` hook — called when the property is read.
     Get,
+    /// `set` hook — called when the property is written; receives the incoming value as `$value`.
     Set,
 }
 
 #[derive(Debug, Serialize)]
 pub enum PropertyHookBody<'arena, 'src> {
+    /// `{ stmts }` — a full statement block.
     Block(ArenaVec<'arena, Stmt<'arena, 'src>>),
+    /// `=> expr` — short-form expression body.
     Expression(Expr<'arena, 'src>),
+    /// No body — the hook is declared abstract (on an abstract class or interface).
     Abstract,
 }
 
@@ -767,9 +803,13 @@ pub struct EnumMember<'arena, 'src> {
 
 #[derive(Debug, Serialize)]
 pub enum EnumMemberKind<'arena, 'src> {
+    /// An enum case: `case Foo;` or `case Foo = 'foo';` (backed enum).
     Case(EnumCase<'arena, 'src>),
+    /// A method defined inside the enum body.
     Method(MethodDecl<'arena, 'src>),
+    /// A constant defined inside the enum body: `const X = 1;`.
     ClassConst(ClassConstDecl<'arena, 'src>),
+    /// A trait use inside the enum body: `use SomeTrait;`.
     TraitUse(TraitUseDecl<'arena, 'src>),
 }
 
@@ -794,7 +834,9 @@ pub struct NamespaceDecl<'arena, 'src> {
 
 #[derive(Debug, Serialize)]
 pub enum NamespaceBody<'arena, 'src> {
+    /// `namespace Foo { … }` — braced form; the statements are scoped to this namespace.
     Braced(ArenaVec<'arena, Stmt<'arena, 'src>>),
+    /// `namespace Foo;` — simple form; all subsequent statements until the next `namespace` or EOF are in scope.
     Simple,
 }
 
@@ -812,8 +854,11 @@ pub struct UseDecl<'arena, 'src> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum UseKind {
+    /// `use Foo\Bar` — imports a class, interface, trait, or enum.
     Normal,
+    /// `use function Foo\bar` — imports a function.
     Function,
+    /// `use const Foo\BAR` — imports a constant.
     Const,
 }
 
@@ -1089,34 +1134,55 @@ impl<'arena, 'src> Expr<'arena, 'src> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum CastKind {
+    /// `(int)` or `(integer)` cast.
     Int,
+    /// `(float)`, `(double)`, or `(real)` cast.
     Float,
+    /// `(string)` cast.
     String,
+    /// `(bool)` or `(boolean)` cast.
     Bool,
+    /// `(array)` cast.
     Array,
+    /// `(object)` cast.
     Object,
+    /// `(unset)` cast — deprecated; casts to `null`.
     Unset,
+    /// `(void)` cast — non-standard; treated as discarding the value.
     Void,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum IncludeKind {
+    /// `include 'file.php'` — emits a warning if the file is not found.
     Include,
+    /// `include_once 'file.php'` — like `include`, but skipped if the file has already been included.
     IncludeOnce,
+    /// `require 'file.php'` — fatal error if the file is not found.
     Require,
+    /// `require_once 'file.php'` — like `require`, but skipped if the file has already been included.
     RequireOnce,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum MagicConstKind {
+    /// `__CLASS__` — name of the current class, or empty string outside a class.
     Class,
+    /// `__DIR__` — directory of the current file.
     Dir,
+    /// `__FILE__` — absolute path of the current file.
     File,
+    /// `__FUNCTION__` — name of the current function or closure.
     Function,
+    /// `__LINE__` — current line number in the source file.
     Line,
+    /// `__METHOD__` — name of the current method including its class: `ClassName::methodName`.
     Method,
+    /// `__NAMESPACE__` — name of the current namespace, or empty string in the global namespace.
     Namespace,
+    /// `__TRAIT__` — name of the current trait, or empty string outside a trait.
     Trait,
+    /// `__PROPERTY__` — name of the current property inside a property hook (PHP 8.4+).
     Property,
 }
 
@@ -1133,19 +1199,33 @@ pub struct AssignExpr<'arena, 'src> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum AssignOp {
+    /// `=`
     Assign,
+    /// `+=`
     Plus,
+    /// `-=`
     Minus,
+    /// `*=`
     Mul,
+    /// `/=`
     Div,
+    /// `%=`
     Mod,
+    /// `**=`
     Pow,
+    /// `.=`
     Concat,
+    /// `&=`
     BitwiseAnd,
+    /// `|=`
     BitwiseOr,
+    /// `^=`
     BitwiseXor,
+    /// `<<=`
     ShiftLeft,
+    /// `>>=`
     ShiftRight,
+    /// `??=`
     Coalesce,
 }
 
@@ -1158,33 +1238,61 @@ pub struct BinaryExpr<'arena, 'src> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum BinaryOp {
+    /// `+`
     Add,
+    /// `-`
     Sub,
+    /// `*`
     Mul,
+    /// `/`
     Div,
+    /// `%`
     Mod,
+    /// `**`
     Pow,
+    /// `.` — string concatenation.
     Concat,
+    /// `==` — loose equality (type-coercing).
     Equal,
+    /// `!=` or `<>` — loose inequality.
     NotEqual,
+    /// `===` — strict equality (type and value).
     Identical,
+    /// `!==` — strict inequality.
     NotIdentical,
+    /// `<`
     Less,
+    /// `>`
     Greater,
+    /// `<=`
     LessOrEqual,
+    /// `>=`
     GreaterOrEqual,
+    /// `<=>` — spaceship / three-way comparison; returns -1, 0, or 1.
     Spaceship,
+    /// `&&` — short-circuit boolean AND (higher precedence than `and`).
     BooleanAnd,
+    /// `||` — short-circuit boolean OR (higher precedence than `or`).
     BooleanOr,
+    /// `&` — bitwise AND.
     BitwiseAnd,
+    /// `|` — bitwise OR.
     BitwiseOr,
+    /// `^` — bitwise XOR.
     BitwiseXor,
+    /// `<<` — left bit-shift.
     ShiftLeft,
+    /// `>>` — right bit-shift.
     ShiftRight,
+    /// `and` — boolean AND (lower precedence than `&&`).
     LogicalAnd,
+    /// `or` — boolean OR (lower precedence than `||`).
     LogicalOr,
+    /// `xor` — boolean XOR.
     LogicalXor,
+    /// `instanceof` — type-check operator; `$x instanceof Foo`.
     Instanceof,
+    /// `|>` — pipe operator (PHP 8.5+); passes the left operand as the first argument of the right callable.
     Pipe,
 }
 
@@ -1196,11 +1304,17 @@ pub struct UnaryPrefixExpr<'arena, 'src> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum UnaryPrefixOp {
+    /// `-expr` — arithmetic negation.
     Negate,
+    /// `+expr` — unary plus (no-op for numbers, promotes to numeric).
     Plus,
+    /// `!expr` — boolean NOT.
     BooleanNot,
+    /// `~expr` — bitwise NOT.
     BitwiseNot,
+    /// `++$x` — pre-increment; increments then returns the new value.
     PreIncrement,
+    /// `--$x` — pre-decrement; decrements then returns the new value.
     PreDecrement,
 }
 
@@ -1212,7 +1326,9 @@ pub struct UnaryPostfixExpr<'arena, 'src> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum UnaryPostfixOp {
+    /// `$x++` — post-increment; returns the current value then increments.
     PostIncrement,
+    /// `$x--` — post-decrement; returns the current value then decrements.
     PostDecrement,
 }
 
@@ -1375,6 +1491,8 @@ pub enum CallableCreateKind<'arena, 'src> {
 
 #[derive(Debug, Serialize)]
 pub enum StringPart<'arena, 'src> {
+    /// A plain text segment of an interpolated string or heredoc.
     Literal(&'arena str),
+    /// An embedded expression: `$var`, `{$expr}`, or `${var}`.
     Expr(Expr<'arena, 'src>),
 }

--- a/crates/php-ast/src/lib.rs
+++ b/crates/php-ast/src/lib.rs
@@ -1,3 +1,33 @@
+//! AST type definitions and visitor infrastructure for the PHP parser.
+//!
+//! This crate provides:
+//! - The complete set of AST node types ([`ast`] module) — statements, expressions, declarations,
+//!   type hints, operators, and all other syntactic constructs for PHP 8.0–8.5.
+//! - A [`Span`] type for tracking byte-offset ranges back to the source text.
+//! - A [`visitor`] module with the [`visitor::Visitor`] and [`visitor::ScopeVisitor`] traits for
+//!   depth-first AST traversal, plus free `walk_*` functions that drive the default recursion.
+//!
+//! # Quick start
+//!
+//! Parse a PHP file with `php-rs-parser` and then walk the AST with a custom visitor:
+//!
+//! ```
+//! use php_ast::visitor::{Visitor, walk_expr};
+//! use php_ast::ast::{Expr, ExprKind};
+//! use std::ops::ControlFlow;
+//!
+//! struct FunctionCallCounter(usize);
+//!
+//! impl<'arena, 'src> Visitor<'arena, 'src> for FunctionCallCounter {
+//!     fn visit_expr(&mut self, expr: &Expr<'arena, 'src>) -> ControlFlow<()> {
+//!         if matches!(expr.kind, ExprKind::FunctionCall(_)) {
+//!             self.0 += 1;
+//!         }
+//!         walk_expr(self, expr)
+//!     }
+//! }
+//! ```
+
 pub mod ast;
 pub mod span;
 pub mod visitor;

--- a/crates/php-ast/src/visitor.rs
+++ b/crates/php-ast/src/visitor.rs
@@ -105,6 +105,10 @@ pub trait Visitor<'arena, 'src> {
 // Walk functions
 // =============================================================================
 
+/// Calls [`Visitor::visit_name`] on `name`.
+///
+/// The default [`Visitor::visit_name`] is a leaf — it does nothing and returns
+/// `Continue(())`. Override it if you need to inspect name nodes.
 pub fn walk_name<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     name: &Name<'arena, 'src>,
@@ -112,6 +116,21 @@ pub fn walk_name<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor.visit_name(name)
 }
 
+/// Visits every top-level statement in `program` by calling [`Visitor::visit_stmt`].
+///
+/// This is the entry point for a full-file traversal. Call it from
+/// [`Visitor::visit_program`] (which is the default) or drive it directly:
+///
+/// ```
+/// # use php_ast::visitor::{Visitor, walk_program};
+/// # use php_ast::ast::*;
+/// # use std::ops::ControlFlow;
+/// # struct V;
+/// # impl<'a, 'b> Visitor<'a, 'b> for V {}
+/// # fn example<'a, 'b>(v: &mut V, program: &Program<'a, 'b>) {
+/// walk_program(v, program);
+/// # }
+/// ```
 pub fn walk_program<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     program: &Program<'arena, 'src>,
@@ -122,6 +141,10 @@ pub fn walk_program<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     ControlFlow::Continue(())
 }
 
+/// Dispatches `stmt` to the appropriate child visitors based on its [`StmtKind`].
+///
+/// Call this from [`Visitor::visit_stmt`] to recurse into a statement's children.
+/// Omit the call to skip the subtree entirely.
 pub fn walk_stmt<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     stmt: &Stmt<'arena, 'src>,
@@ -309,6 +332,10 @@ pub fn walk_stmt<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     ControlFlow::Continue(())
 }
 
+/// Dispatches `expr` to the appropriate child visitors based on its [`ExprKind`].
+///
+/// Call this from [`Visitor::visit_expr`] to recurse into an expression's children.
+/// Omit the call to skip the subtree entirely.
 pub fn walk_expr<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     expr: &Expr<'arena, 'src>,
@@ -522,6 +549,7 @@ pub fn walk_expr<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     ControlFlow::Continue(())
 }
 
+/// Visits a function/method parameter's attributes, type hint, default expression, and property hooks.
 pub fn walk_param<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     param: &Param<'arena, 'src>,
@@ -539,6 +567,7 @@ pub fn walk_param<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     ControlFlow::Continue(())
 }
 
+/// Visits the value expression of a call argument.
 pub fn walk_arg<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     arg: &Arg<'arena, 'src>,
@@ -546,6 +575,7 @@ pub fn walk_arg<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor.visit_expr(&arg.value)
 }
 
+/// Dispatches a class member (property, method, constant, or trait use) to its child visitors.
 pub fn walk_class_member<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     member: &ClassMember<'arena, 'src>,
@@ -567,6 +597,7 @@ pub fn walk_class_member<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     ControlFlow::Continue(())
 }
 
+/// Visits a property hook's attributes, parameters, and body statements or expression.
 pub fn walk_property_hook<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     hook: &PropertyHook<'arena, 'src>,
@@ -589,6 +620,7 @@ pub fn walk_property_hook<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     ControlFlow::Continue(())
 }
 
+/// Dispatches an enum member (case, method, constant, or trait use) to its child visitors.
 pub fn walk_enum_member<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     member: &EnumMember<'arena, 'src>,
@@ -613,6 +645,7 @@ pub fn walk_enum_member<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     ControlFlow::Continue(())
 }
 
+/// Visits the inner types of a type hint (recursing into nullable, union, and intersection).
 pub fn walk_type_hint<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     type_hint: &TypeHint<'arena, 'src>,
@@ -634,6 +667,7 @@ pub fn walk_type_hint<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     ControlFlow::Continue(())
 }
 
+/// Visits an attribute's name and argument expressions.
 pub fn walk_attribute<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     attribute: &Attribute<'arena, 'src>,
@@ -645,6 +679,7 @@ pub fn walk_attribute<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     ControlFlow::Continue(())
 }
 
+/// Visits a catch clause's caught type names and body statements.
 pub fn walk_catch_clause<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     catch: &CatchClause<'arena, 'src>,
@@ -658,6 +693,7 @@ pub fn walk_catch_clause<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     ControlFlow::Continue(())
 }
 
+/// Visits a match arm's condition expressions (if any) and body expression.
 pub fn walk_match_arm<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     arm: &MatchArm<'arena, 'src>,
@@ -670,6 +706,7 @@ pub fn walk_match_arm<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor.visit_expr(&arm.body)
 }
 
+/// Visits a trait use declaration's trait names and adaptations (`insteadof`, `as`).
 pub fn walk_trait_use<'arena, 'src, V: Visitor<'arena, 'src> + ?Sized>(
     visitor: &mut V,
     trait_use: &TraitUseDecl<'arena, 'src>,

--- a/crates/php-lexer/src/lexer.rs
+++ b/crates/php-lexer/src/lexer.rs
@@ -50,10 +50,14 @@ static IS_PHP_WHITESPACE: [bool; 256] = make_whitespace_table();
 static IS_IDENT_START: [bool; 256] = make_ident_start_table();
 static IS_IDENT_CONTINUE: [bool; 256] = make_ident_continue_table();
 
+/// Discriminant for [`LexerError`] — describes what kind of lexer failure occurred.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LexerErrorKind {
+    /// The lexer reached end-of-file inside a string literal without finding the closing delimiter.
     UnterminatedString,
+    /// The source file exceeds the maximum supported size (2^32 bytes).
     FileTooLarge,
+    /// Any other lexer-level error (e.g. unterminated block comment, invalid numeric literal).
     Other,
 }
 

--- a/crates/php-lexer/src/lib.rs
+++ b/crates/php-lexer/src/lib.rs
@@ -1,3 +1,24 @@
+//! Hand-written PHP lexer with support for PHP 8.0–8.5 syntax.
+//!
+//! This crate provides:
+//! - [`Lexer`] — a lazy, streaming tokenizer. Call [`Lexer::next_token`] to advance one token at
+//!   a time, or use [`Lexer::peek`]/[`Lexer::peek2`] for lookahead without consuming.
+//! - [`TokenKind`] — the complete set of token types produced by the lexer.
+//! - [`lex_all`] — convenience function that tokenizes an entire source string at once.
+//!
+//! # Quick start
+//!
+//! ```
+//! use php_lexer::{Lexer, TokenKind};
+//!
+//! let mut lexer = Lexer::new("<?php echo 'hello';");
+//! loop {
+//!     let token = lexer.next_token();
+//!     if token.kind == TokenKind::Eof { break; }
+//!     println!("{:?} {:?}", token.kind, token.span);
+//! }
+//! ```
+
 pub mod lexer;
 pub mod token;
 

--- a/crates/php-lexer/src/token.rs
+++ b/crates/php-lexer/src/token.rs
@@ -1,233 +1,442 @@
+/// All token types produced by the PHP lexer.
+///
+/// The variants are grouped by category in source order; the `#[repr(u8)]`
+/// guarantees a compact discriminant layout used by [`TokenKind::is_assignment_op`].
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TokenKind {
-    // --- Literals ---
-    // Float: scientific notation (with or without decimal)
+    // -------------------------------------------------------------------------
+    // Literals
+    // -------------------------------------------------------------------------
+    /// Float in scientific notation: `1e10`, `1.5e-3`, `1E+10`.
     FloatLiteral,
 
-    // Float: decimal with digits on both sides
+    /// Float with digits on both sides of the decimal point: `1.5`, `0.0`.
     FloatLiteralSimple,
 
-    // Float: decimal starting with dot (.0)
+    /// Float starting with a leading dot: `.5`, `.001`.
     FloatLiteralLeadingDot,
 
+    /// Hexadecimal integer literal: `0x1A`, `0xFF`.
     HexIntLiteral,
 
+    /// Binary integer literal: `0b1010`, `0B0011`.
     BinIntLiteral,
 
+    /// Octal integer literal in the new `0o` prefix form: `0o17` (PHP 8.1+).
     OctIntLiteralNew,
 
+    /// Octal integer literal in the legacy leading-zero form: `017`.
     OctIntLiteral,
 
+    /// Decimal integer literal: `0`, `42`, `1_000_000`.
     IntLiteral,
 
-    // String literals (with optional binary prefix b/B)
+    /// Single-quoted string literal: `'hello'`. Optional `b`/`B` prefix allowed.
     SingleQuotedString,
 
+    /// Double-quoted string literal: `"hello $name"`. Triggers interpolation processing.
     DoubleQuotedString,
 
+    /// Backtick string (shell execution): `` `ls -la` ``.
     BacktickString,
 
-    // --- Variables ---
+    // -------------------------------------------------------------------------
+    // Variables
+    // -------------------------------------------------------------------------
+    /// A `$`-prefixed variable name: `$foo`, `$myVar`.
     Variable,
+
+    /// A bare `$` not followed by a valid identifier start (variable-variable prefix).
     Dollar,
 
-    // --- Identifiers (keywords resolved from these) ---
+    // -------------------------------------------------------------------------
+    // Identifiers
+    // -------------------------------------------------------------------------
+    /// A bare identifier or keyword that has not yet been resolved.
+    /// PHP keywords are case-insensitive and are resolved from this token.
     Identifier,
 
-    // --- Operators ---
+    // -------------------------------------------------------------------------
+    // Arithmetic operators
+    // -------------------------------------------------------------------------
+    /// `+`
     Plus,
+    /// `-`
     Minus,
+    /// `*`
     Star,
+    /// `/`
     Slash,
+    /// `%`
     Percent,
+    /// `**` — exponentiation.
     StarStar,
+    /// `.` — string concatenation.
     Dot,
 
+    // -------------------------------------------------------------------------
+    // Assignment operators
+    // -------------------------------------------------------------------------
+    // NOTE: Equals..=CoalesceEquals must remain contiguous; is_assignment_op relies on this.
+    /// `=`
     Equals,
+    /// `+=`
     PlusEquals,
+    /// `-=`
     MinusEquals,
+    /// `*=`
     StarEquals,
+    /// `/=`
     SlashEquals,
+    /// `%=`
     PercentEquals,
+    /// `**=`
     StarStarEquals,
+    /// `.=`
     DotEquals,
+    /// `&=`
     AmpersandEquals,
+    /// `|=`
     PipeEquals,
+    /// `^=`
     CaretEquals,
+    /// `<<=`
     ShiftLeftEquals,
+    /// `>>=`
     ShiftRightEquals,
+    /// `??=`
     CoalesceEquals,
 
+    // -------------------------------------------------------------------------
+    // Comparison operators
+    // -------------------------------------------------------------------------
+    /// `==` — loose equality.
     EqualsEquals,
+    /// `!=` or `<>` — loose inequality.
     BangEquals,
+    /// `===` — strict equality.
     EqualsEqualsEquals,
+    /// `!==` — strict inequality.
     BangEqualsEquals,
+    /// `<`
     LessThan,
+    /// `>`
     GreaterThan,
+    /// `<=`
     LessThanEquals,
+    /// `>=`
     GreaterThanEquals,
+    /// `<=>` — spaceship / three-way comparison.
     Spaceship,
 
+    // -------------------------------------------------------------------------
+    // Logical / bitwise operators
+    // -------------------------------------------------------------------------
+    /// `&&` — short-circuit boolean AND.
     AmpersandAmpersand,
+    /// `||` — short-circuit boolean OR.
     PipePipe,
+    /// `!` — boolean NOT.
     Bang,
 
+    /// `&` — bitwise AND (also reference marker in declarations).
     Ampersand,
+    /// `|` — bitwise OR.
     Pipe,
+    /// `^` — bitwise XOR.
     Caret,
+    /// `~` — bitwise NOT.
     Tilde,
+    /// `<<` — left bit-shift.
     ShiftLeft,
+    /// `>>` — right bit-shift.
     ShiftRight,
 
+    // -------------------------------------------------------------------------
+    // Increment / decrement
+    // -------------------------------------------------------------------------
+    /// `++`
     PlusPlus,
+    /// `--`
     MinusMinus,
 
+    // -------------------------------------------------------------------------
+    // Other operators
+    // -------------------------------------------------------------------------
+    /// `?` — ternary operator or nullable type-hint prefix.
     Question,
+    /// `??` — null coalescing.
     QuestionQuestion,
+    /// `:` — ternary separator, named argument separator, or return type separator.
     Colon,
 
+    /// `=>` — key-value separator in arrays and `match` arms.
     FatArrow,
 
+    /// `|>` — pipe operator (PHP 8.5+).
     PipeArrow,
 
-    // --- Delimiters ---
+    // -------------------------------------------------------------------------
+    // Delimiters & punctuation
+    // -------------------------------------------------------------------------
+    /// `(`
     LeftParen,
+    /// `)`
     RightParen,
+    /// `[`
     LeftBracket,
+    /// `]`
     RightBracket,
+    /// `{`
     LeftBrace,
+    /// `}`
     RightBrace,
+    /// `;`
     Semicolon,
+    /// `,`
     Comma,
 
+    /// `::` — static access separator.
     DoubleColon,
 
+    /// `->` — object property / method access.
     Arrow,
 
+    /// `?->` — nullsafe property / method access.
     NullsafeArrow,
 
+    /// `\` — namespace separator.
     Backslash,
 
+    /// `@` — error-suppression operator.
     At,
 
+    /// `#[` — attribute syntax opener.
     HashBracket,
 
+    /// `...` — splat / variadic operator.
     Ellipsis,
 
-    // --- Keywords (resolved from Identifier) ---
+    // -------------------------------------------------------------------------
+    // Keywords (resolved from Identifier at lex time)
+    // -------------------------------------------------------------------------
+    /// `if`
     If,
+    /// `else`
     Else,
+    /// `elseif`
     ElseIf,
+    /// `while`
     While,
+    /// `do`
     Do,
+    /// `for`
     For,
+    /// `foreach`
     Foreach,
+    /// `as`
     As,
+    /// `function`
     Function,
+    /// `return`
     Return,
+    /// `echo`
     Echo,
+    /// `print`
     Print,
+    /// `true`
     True,
+    /// `false`
     False,
+    /// `null`
     Null,
+    /// `and` — low-precedence boolean AND.
     And,
+    /// `or` — low-precedence boolean OR.
     Or,
+    /// `xor` — low-precedence boolean XOR.
     Xor,
+    /// `break`
     Break,
+    /// `continue`
     Continue,
+    /// `switch`
     Switch,
+    /// `case`
     Case,
+    /// `default`
     Default,
+    /// `endif` — alternative `if` syntax terminator.
     EndIf,
+    /// `endwhile` — alternative `while` syntax terminator.
     EndWhile,
+    /// `endfor` — alternative `for` syntax terminator.
     EndFor,
+    /// `endforeach` — alternative `foreach` syntax terminator.
     EndForeach,
+    /// `throw`
     Throw,
+    /// `try`
     Try,
+    /// `catch`
     Catch,
+    /// `finally`
     Finally,
+    /// `instanceof`
     Instanceof,
+    /// `array` — as a keyword (e.g. `array(1, 2)` or `array` type hint).
     Array,
+    /// `list` — destructuring construct: `list($a, $b) = ...`.
     List,
+    /// `goto`
     Goto,
+    /// `declare`
     Declare,
+    /// `unset`
     Unset,
+    /// `global`
     Global,
+    /// `enddeclare` — alternative `declare` syntax terminator.
     EndDeclare,
+    /// `endswitch` — alternative `switch` syntax terminator.
     EndSwitch,
+    /// `isset`
     Isset,
+    /// `empty`
     Empty,
+    /// `include`
     Include,
+    /// `include_once`
     IncludeOnce,
+    /// `require`
     Require,
+    /// `require_once`
     RequireOnce,
+    /// `eval`
     Eval,
+    /// `exit`
     Exit,
+    /// `die` — alias for `exit`.
     Die,
+    /// `clone`
     Clone,
+
     // OOP keywords
+    /// `new`
     New,
+    /// `class`
     Class,
+    /// `abstract`
     Abstract,
+    /// `final`
     Final,
+    /// `interface`
     Interface,
+    /// `trait`
     Trait,
+    /// `extends`
     Extends,
+    /// `implements`
     Implements,
+    /// `public`
     Public,
+    /// `protected`
     Protected,
+    /// `private`
     Private,
+    /// `static`
     Static,
+    /// `const`
     Const,
+    /// `fn` — arrow function keyword.
     Fn_,
+    /// `match` — match expression keyword (PHP 8.0+).
     Match_,
+    /// `namespace`
     Namespace,
+    /// `use`
     Use,
+    /// `readonly` (PHP 8.1+).
     Readonly,
+    /// `enum` (PHP 8.1+).
     Enum_,
+    /// `yield`
     Yield_,
+    /// `from` — used in `yield from`.
     From,
+    /// `self`
     Self_,
+    /// `parent`
     Parent_,
-    // Magic constants
+
+    // -------------------------------------------------------------------------
+    // Magic constants (resolved from Identifier at lex time)
+    // -------------------------------------------------------------------------
+    /// `__CLASS__`
     MagicClass,
+    /// `__DIR__`
     MagicDir,
+    /// `__FILE__`
     MagicFile,
+    /// `__FUNCTION__`
     MagicFunction,
+    /// `__LINE__`
     MagicLine,
+    /// `__METHOD__`
     MagicMethod,
+    /// `__NAMESPACE__`
     MagicNamespace,
+    /// `__TRAIT__`
     MagicTrait,
+    /// `__PROPERTY__` (PHP 8.4+)
     MagicProperty,
+    /// `__halt_compiler` — stops the parser; remaining bytes are raw data.
     HaltCompiler,
 
-    // --- PHP tags ---
+    // -------------------------------------------------------------------------
+    // PHP tags & template output
+    // -------------------------------------------------------------------------
+    /// `<?php` or `<?=` opening tag.
     OpenTag,
 
+    /// `?>` closing tag; switches the lexer back to inline-HTML mode.
     CloseTag,
 
-    // Inline HTML (produced by Lexer wrapper)
+    /// Raw HTML text between PHP tags (produced by the `Lexer` wrapper, not the inner scanner).
     InlineHtml,
 
-    // Heredoc/Nowdoc (produced by Lexer wrapper)
+    // -------------------------------------------------------------------------
+    // Heredoc / Nowdoc (produced by Lexer wrapper)
+    // -------------------------------------------------------------------------
+    /// `<<<LABEL … LABEL;` — heredoc string (supports interpolation).
     Heredoc,
+    /// `<<<'LABEL' … LABEL;` — nowdoc string (no interpolation).
     Nowdoc,
 
-    // Invalid numeric literal (e.g. 1_0_0_ with trailing underscore)
+    // -------------------------------------------------------------------------
+    // Error tokens
+    // -------------------------------------------------------------------------
+    /// An invalid numeric literal, e.g. `1_000_` (trailing underscore).
+    /// The lexer emits this token and records a [`LexerError`](crate::LexerError) for it.
     InvalidNumericLiteral,
 
-    // Comments (yielded by the lexer; filtered out by the parser into a side-table)
-    /// `// …` single-line slash comment
+    // -------------------------------------------------------------------------
+    // Comments (filtered into a side-table by the parser)
+    // -------------------------------------------------------------------------
+    /// `// …` single-line slash comment.
     LineComment,
-    /// `# …` single-line hash comment
+    /// `# …` single-line hash comment.
     HashComment,
-    /// `/* … */` block comment
+    /// `/* … */` block comment.
     BlockComment,
-    /// `/** … */` doc-block comment
+    /// `/** … */` doc-block comment (first non-whitespace char after `/*` is `*`).
     DocComment,
 
-    // End of file
+    // -------------------------------------------------------------------------
+    // End of input
+    // -------------------------------------------------------------------------
+    /// Sentinel token emitted once all source bytes have been consumed.
     Eof,
 }
 


### PR DESCRIPTION
## Summary

- **php-ast**: adds crate-level `//!` doc with quick-start example; documents all previously undocumented enum variants across `ast.rs` (~50 variants in `NameKind`, `BuiltinType`, `TypeHintKind`, `Visibility`, `PropertyHookKind/Body`, `NamespaceBody`, `UseKind`, `CastKind`, `IncludeKind`, `MagicConstKind`, `AssignOp`, `BinaryOp`, `UnaryPrefixOp/PostfixOp`, `EnumMemberKind`, `StringPart`); adds `///` doc comments to all 16 `walk_*` functions in `visitor.rs`
- **php-lexer**: adds crate-level `//!` doc with quick-start example; documents all 3 `LexerErrorKind` variants; converts all ~232 `TokenKind` variants from `//` inline comments to `///` doc comments, organized into clearly labeled sections (literals, operators, delimiters, keywords, magic constants, tags, comments)

Closes #234