### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-04-19
+
+### Fixed
+
+- `readonly` property with a `set` hook now emits a parse error instead of silently accepting it (`php-rs-parser`, #237).
+
+### Changed
+
+- Builtin type hint matching refactored from chained `eq_ignore_ascii_case` to a `match` expression (`php-rs-parser`, #238).
+- Verbose ampersand-eat patterns replaced with `parser.eat()` helper (`php-rs-parser`, #235).
+
+### Documentation
+
+- Complete public API documentation coverage for `php-ast` and `php-lexer` crates (#241).
+- Binding-power convention documented in `precedence.rs` (`php-rs-parser`, #240).
+
+### Tests
+
+- String interpolation edge-case fixtures added (`php-rs-parser`, #239).
+- Error-recovery fixtures for property hooks added (`php-rs-parser`, #236).
+
+---
+
 ## [0.8.0] - 2026-04-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -24,10 +24,10 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.8.0" }
-php-lexer = { path = "crates/php-lexer", version = "0.8.0" }
-php-rs-parser = { path = "crates/php-parser", version = "0.8.0" }
-php-printer = { path = "crates/php-printer", version = "0.8.0" }
+php-ast = { path = "crates/php-ast", version = "0.8.1" }
+php-lexer = { path = "crates/php-lexer", version = "0.8.1" }
+php-rs-parser = { path = "crates/php-parser", version = "0.8.1" }
+php-printer = { path = "crates/php-printer", version = "0.8.1" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Bump workspace version to 0.8.1
- Update `CHANGELOG.md` with entries for all post-0.8.0 commits

## Changes since v0.8.0

**Fixed**
- `readonly` property with a `set` hook now emits a parse error (#237)

**Changed**
- Builtin type hint matching uses `match` instead of chained `eq_ignore_ascii_case` (#238)
- Verbose ampersand-eat patterns replaced with `parser.eat()` (#235)

**Documentation**
- Complete public API docs for `php-ast` and `php-lexer` (#241)
- Binding-power convention documented in `precedence.rs` (#240)

**Tests**
- String interpolation edge-case fixtures (#239)
- Error-recovery fixtures for property hooks (#236)

## Test plan

- [ ] CI passes (clippy, fmt, tests against PHP 8.2–8.5)
- [ ] After merge: tag `v0.8.1` and publish GitHub release