### PR TITLE
docs: reorganize README for clarity and audience separation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,19 @@ UPDATE_FIXTURES=1 cargo test         # regenerate expected AST/errors in .phpt f
 cargo bench                          # benchmarks
 ```
 
+## Testing
+
+```sh
+cargo test --test integration   # all .phpt fixture tests (including corpus)
+cargo test --test php_syntax    # validate fixtures via php -l
+cargo test --test malformed_php # error recovery and diagnostics
+cargo test --test visitor       # visitor and scope-aware traversal
+```
+
+Fixture files live in `crates/php-parser/tests/fixtures/`. All fixtures are validated against `php -l` in CI across PHP 8.2–8.5. Fixtures using version-gated syntax must include `===config===` with `min_php=X.Y`.
+
+The project includes a corpus of test fixtures adapted from the [nikic/PHP-Parser](https://github.com/nikic/PHP-Parser) test suite.
+
 ## For Contributors
 
 1. Review [docs/architecture/ROADMAP.md](docs/architecture/ROADMAP.md) for project vision

--- a/README.md
+++ b/README.md
@@ -2,22 +2,7 @@
 
 A fast, fault-tolerant PHP parser written in Rust. Produces a full typed AST with source spans, recovers from syntax errors, and covers PHP 8.0–8.5 syntax.
 
-Includes a corpus of test fixtures adapted from the [nikic/PHP-Parser](https://github.com/nikic/PHP-Parser) test suite.
-
-> **Note:** The parser targets **PHP 8.5** by default. Use `parse_versioned()` to target an earlier version.
-
-## Architecture
-
-Cargo workspace with four crates:
-
-| Crate | crates.io | Purpose |
-|-------|-----------|---------|
-| **php-lexer** | [![crates.io](https://img.shields.io/crates/v/php-lexer)](https://crates.io/crates/php-lexer) | Hand-written tokenizer with handling for strings, heredoc/nowdoc, and inline HTML |
-| **php-ast** | [![crates.io](https://img.shields.io/crates/v/php-ast)](https://crates.io/crates/php-ast) | AST type definitions, `Visitor` trait, `ScopeVisitor` trait |
-| **php-rs-parser** | [![crates.io](https://img.shields.io/crates/v/php-rs-parser)](https://crates.io/crates/php-rs-parser) | Pratt-based recursive descent parser with panic-mode error recovery, PHPDoc parser, source map |
-| **php-printer** | [![crates.io](https://img.shields.io/crates/v/php-printer)](https://crates.io/crates/php-printer) | Pretty printer — converts an AST back to PHP source |
-
-## Usage
+## Quick Start
 
 ```rust
 use php_rs_parser::parse;
@@ -35,9 +20,19 @@ for err in &result.errors {
 let pos = result.source_map.offset_to_line_col(6);
 ```
 
+## API Reference
+
+The three entry points you need for integration:
+
+- **`parse()` / `parse_versioned()`** — main parser entry points in `php-rs-parser`; see [`crates/php-parser/src/lib.rs`](crates/php-parser/src/lib.rs)
+- **`Visitor` / `ScopeVisitor`** — AST traversal traits in `php-ast`; see [`crates/php-ast/src/visitor.rs`](crates/php-ast/src/visitor.rs) for the distinction between the two
+- **`ParseError` variants** — see [`crates/php-parser/src/diagnostics.rs`](crates/php-parser/src/diagnostics.rs) and [docs/development/ERRORS.md](docs/development/ERRORS.md) for recovery behavior
+
+## Usage
+
 ### Version-aware parsing
 
-Target a specific PHP version to catch version-gated syntax:
+The parser targets PHP 8.5 by default. Use `parse_versioned()` to target an earlier version:
 
 ```rust
 use php_rs_parser::{parse_versioned, PhpVersion};
@@ -77,45 +72,7 @@ impl<'arena, 'src> Visitor<'arena, 'src> for VarCounter {
 
 Return `ControlFlow::Break(())` to stop traversal early. Return `ControlFlow::Continue(())` without calling `walk_*` to skip a subtree.
 
-### Scope-aware traversal
-
-`ScopeVisitor` and `ScopeWalker` provide zero-allocation lexical scope context — namespace, class name, and function/method name — at every node:
-
-```rust
-use php_ast::visitor::{ScopeVisitor, ScopeWalker, Scope};
-use php_ast::ast::*;
-use std::ops::ControlFlow;
-
-struct MethodCollector { methods: Vec<String> }
-
-impl<'arena, 'src> ScopeVisitor<'arena, 'src> for MethodCollector {
-    fn visit_class_member(
-        &mut self,
-        member: &ClassMember<'arena, 'src>,
-        scope: &Scope<'src>,
-    ) -> ControlFlow<()> {
-        if let ClassMemberKind::Method(m) = &member.kind {
-            self.methods.push(format!(
-                "{}::{}",
-                scope.class_name.unwrap_or("<anon>"),
-                m.name
-            ));
-        }
-        ControlFlow::Continue(())
-    }
-}
-
-let arena = bumpalo::Bump::new();
-let result = php_rs_parser::parse(&arena, "<?php class Foo { public function bar() {} }");
-let mut walker = ScopeWalker::new(MethodCollector { methods: vec![] });
-let _ = walker.walk(&result.program);
-// walker.into_inner().methods == ["Foo::bar"]
-```
-
-`Scope` fields:
-- `namespace: Option<Cow<'src, str>>` — current namespace, `None` in the global namespace
-- `class_name: Option<&'src str>` — enclosing class/interface/trait/enum name, `None` outside or in anonymous classes
-- `function_name: Option<&'src str>` — enclosing named function/method name, `None` in closures/arrow functions
+For scope-aware traversal (`ScopeVisitor`, `ScopeWalker`) and the PHPDoc parser, see [docs/usage/VISITOR.md](docs/usage/VISITOR.md).
 
 ### Pretty printer
 
@@ -126,15 +83,20 @@ let output = php_printer::pretty_print(&result.program);
 // output == "echo 1 + 2;"
 ```
 
-`pretty_print_file` prepends `<?php\n\n` and appends a trailing newline.
+Use `pretty_print_file` to produce a complete file with a `<?php\n\n` prefix and trailing newline.
 
-### PHPDoc parser
+## Architecture
 
-```rust
-let tags = php_rs_parser::phpdoc::parse("/** @param int $id The user ID\n * @return User */");
-```
+Four crates, one workspace:
 
-Produces typed `PhpDocTag` variants for `@param`, `@return`, `@var`, `@throws`, `@template`, `@property`, `@method`, `@deprecated`, and Psalm/PHPStan annotations. Doc comments are attached to function, class, method, property, and constant AST nodes.
+| Crate | crates.io | Purpose |
+|-------|-----------|---------|
+| **php-lexer** | [![crates.io](https://img.shields.io/crates/v/php-lexer)](https://crates.io/crates/php-lexer) | Hand-written tokenizer with handling for strings, heredoc/nowdoc, and inline HTML |
+| **php-ast** | [![crates.io](https://img.shields.io/crates/v/php-ast)](https://crates.io/crates/php-ast) | AST type definitions, `Visitor` trait, `ScopeVisitor` trait |
+| **php-rs-parser** | [![crates.io](https://img.shields.io/crates/v/php-rs-parser)](https://crates.io/crates/php-rs-parser) | Pratt-based recursive descent parser with panic-mode error recovery, PHPDoc parser, source map |
+| **php-printer** | [![crates.io](https://img.shields.io/crates/v/php-printer)](https://crates.io/crates/php-printer) | Pretty printer — converts an AST back to PHP source |
+
+Source flows through `Lexer → Parser → arena-allocated AST nodes`. The lexer is lazy (tokens produced on demand with peeking slots); the parser is Pratt-based recursive descent with panic-mode error recovery.
 
 ## Performance
 
@@ -142,26 +104,9 @@ This parser is optimised for **modern PHP applications with full typing** (PHP 7
 
 **The fastest full-featured PHP parser.** For detailed analysis see [docs/performance/](docs/performance/). For comparative benchmarks against other PHP parsers see [php-parser-benchmark](https://github.com/jorgsowa/php-parser-benchmark).
 
-## Testing
+## Contributing
 
-```sh
-cargo test --test integration   # all .phpt fixture tests (including corpus)
-cargo test --test php_syntax    # validate fixtures via php -l
-cargo test --test malformed_php # error recovery and diagnostics
-cargo test --test visitor       # visitor and scope-aware traversal
-```
-
-Fixture files live in `crates/php-parser/tests/fixtures/`. All fixtures are validated against `php -l` in CI across PHP 8.2–8.5. Fixtures using version-gated syntax must include `===config===` with `min_php=X.Y`.
-
-## Documentation
-
-### For external tool consumers (LSPs, linters, static analyzers)
-1. This file — public API entry points (`parse`, `parse_versioned`, `ParserContext`)
-2. `php-ast/src/visitor.rs` module doc — `Visitor` vs `ScopeVisitor` distinction
-3. [`crates/php-parser/src/diagnostics.rs`](crates/php-parser/src/diagnostics.rs) — `ParseError` variants
-4. [docs/development/ERRORS.md](docs/development/ERRORS.md) — error recovery behavior
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for contributor and performance researcher guides. Full documentation is in the [docs/](docs/) directory.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions, testing, and contributor guides. Full documentation is in the [docs/](docs/) directory.
 
 ## License
 

--- a/docs/usage/VISITOR.md
+++ b/docs/usage/VISITOR.md
@@ -1,0 +1,60 @@
+# Visitor API
+
+## `Visitor` vs `ScopeVisitor`
+
+| Trait | Use when |
+|-------|----------|
+| `Visitor` | You only need the AST node itself |
+| `ScopeVisitor` | You also need the enclosing namespace, class, or function name |
+
+---
+
+## Scope-aware traversal
+
+`ScopeVisitor` and `ScopeWalker` provide zero-allocation lexical scope context — namespace, class name, and function/method name — at every node:
+
+```rust
+use php_ast::visitor::{ScopeVisitor, ScopeWalker, Scope};
+use php_ast::ast::*;
+use std::ops::ControlFlow;
+
+struct MethodCollector { methods: Vec<String> }
+
+impl<'arena, 'src> ScopeVisitor<'arena, 'src> for MethodCollector {
+    fn visit_class_member(
+        &mut self,
+        member: &ClassMember<'arena, 'src>,
+        scope: &Scope<'src>,
+    ) -> ControlFlow<()> {
+        if let ClassMemberKind::Method(m) = &member.kind {
+            self.methods.push(format!(
+                "{}::{}",
+                scope.class_name.unwrap_or("<anon>"),
+                m.name
+            ));
+        }
+        ControlFlow::Continue(())
+    }
+}
+
+let arena = bumpalo::Bump::new();
+let result = php_rs_parser::parse(&arena, "<?php class Foo { public function bar() {} }");
+let mut walker = ScopeWalker::new(MethodCollector { methods: vec![] });
+let _ = walker.walk(&result.program);
+// walker.into_inner().methods == ["Foo::bar"]
+```
+
+`Scope` fields:
+- `namespace: Option<Cow<'src, str>>` — current namespace, `None` in the global namespace
+- `class_name: Option<&'src str>` — enclosing class/interface/trait/enum name, `None` outside or in anonymous classes
+- `function_name: Option<&'src str>` — enclosing named function/method name, `None` in closures/arrow functions
+
+---
+
+## PHPDoc parser
+
+```rust
+let tags = php_rs_parser::phpdoc::parse("/** @param int $id The user ID\n * @return User */");
+```
+
+Produces typed `PhpDocTag` variants for `@param`, `@return`, `@var`, `@throws`, `@template`, `@property`, `@method`, `@deprecated`, and Psalm/PHPStan annotations. Doc comments are attached to function, class, method, property, and constant AST nodes.


### PR DESCRIPTION
## Summary

- **Quick Start and API Reference moved above Architecture** — users see how to use the library before reading about its internals
- **Testing section moved to CONTRIBUTING.md** — contributor content removed from the user-facing README
- **PHP 8.5 default note relocated** — moved from the intro paragraph into the version-aware parsing subsection where it answers an actual question
- **ScopeVisitor, ScopeWalker, and PHPDoc examples extracted** to `docs/usage/VISITOR.md` — README keeps the basic Visitor example and links out for depth
- **Architecture section improved** — adds a data flow sentence (`Lexer → Parser → arena-allocated AST nodes`); header updated to "Four crates, one workspace:"
- **API Reference promoted** — "For external tool consumers" list restructured as a top-level section near the top with clearer framing
- **Corpus mention removed from README intro** — moved to CONTRIBUTING.md

## Test plan

- [ ] README renders correctly on GitHub (section order, table, badges, code blocks)
- [ ] All internal links resolve (`docs/usage/VISITOR.md`, `crates/php-parser/src/lib.rs`, `crates/php-ast/src/visitor.rs`, `crates/php-parser/src/diagnostics.rs`)
- [ ] CONTRIBUTING.md Testing section is complete and accurate