### PR TITLE
docs: add Acknowledgements section for nikic/PHP-Parser and PHP community

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contributor and performance researche
 
 ## Acknowledgements
 
-Test corpus fixtures were adapted from [nikic/PHP-Parser](https://github.com/nikic/PHP-Parser). Thanks to Nikita Popov and contributors.
+Inspired by and indebted to [nikic/PHP-Parser](https://github.com/nikic/PHP-Parser) — test corpus fixtures were adapted from its test suite. Thanks to Nikita Popov and contributors.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contributor and performance researche
 
 ## Acknowledgements
 
-Inspired by and indebted to [nikic/PHP-Parser](https://github.com/nikic/PHP-Parser) — test corpus fixtures were adapted from its test suite. Thanks to Nikita Popov and contributors.
+Inspired by and indebted to [nikic/PHP-Parser](https://github.com/nikic/PHP-Parser) — test corpus fixtures were adapted from its test suite.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contributor and performance researche
 
 ## Acknowledgements
 
-Inspired by and indebted to [nikic/PHP-Parser](https://github.com/nikic/PHP-Parser) — test corpus fixtures were adapted from its test suite.
+Inspired by and indebted to [nikic/PHP-Parser](https://github.com/nikic/PHP-Parser) — test corpus fixtures were adapted from its test suite. Thanks to the PHP community contributors.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contributor and performance researche
 
 ## Acknowledgements
 
-The test corpus includes fixtures adapted from the [nikic/PHP-Parser](https://github.com/nikic/PHP-Parser) test suite, used under the BSD 3-Clause License.
+Test corpus fixtures were adapted from [nikic/PHP-Parser](https://github.com/nikic/PHP-Parser). Thanks to Nikita Popov and contributors.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ Fixture files live in `crates/php-parser/tests/fixtures/`. All fixtures are vali
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contributor and performance researcher guides. Full documentation is in the [docs/](docs/) directory.
 
+## Acknowledgements
+
+The test corpus includes fixtures adapted from the [nikic/PHP-Parser](https://github.com/nikic/PHP-Parser) test suite, used under the BSD 3-Clause License.
+
 ## License
 
 BSD 3-Clause


### PR DESCRIPTION
Adds an Acknowledgements section crediting nikic/PHP-Parser and the PHP community contributors.