### PR TITLE
docs: improve CONTRIBUTING and restructure ROADMAP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,37 +1,242 @@
 # Contributing
 
+Thank you for your interest in contributing to rust-php-parser. This guide covers everything you need to go from a fresh clone to an open PR.
+
+---
+
+## Prerequisites
+
+- **Rust** — latest stable toolchain (`rustup update stable`)
+- **PHP** — PHP 8.2 or newer for `php -l` fixture validation (the test suite skips syntax checks if PHP is not installed but CI runs them)
+- `cargo` and standard Rust tooling (`clippy`, `rustfmt`)
+
+---
+
+## Getting Started
+
+```bash
+git clone https://github.com/jorgsowa/rust-php-parser
+cd rust-php-parser
+cargo test          # all tests should pass
+```
+
+---
+
+## Crate Layout
+
+| Crate | Package name | Purpose |
+|-------|--------------|---------|
+| `crates/php-ast` | `php-ast` | AST node types, Visitor trait, ScopeVisitor, PHPDoc tag types |
+| `crates/php-lexer` | `php-lexer` | Lazy tokenizer with peeking slots (arena-allocated) |
+| `crates/php-parser` | `php-rs-parser` | Recursive-descent parser, PHPDoc parser, semantic analysis helpers |
+| `crates/php-printer` | `php-printer` | Pretty printer (AST → PHP source) |
+| `crates/php-test-macros` | `php-test-macros` | Internal proc macros for test generation (not published) |
+
+All workspace dependencies are declared in the root `Cargo.toml`. Each crate's `Cargo.toml` uses `{ workspace = true }` for shared deps.
+
+---
+
 ## Build & Test
 
 ```bash
-cargo test                           # run all tests
-cargo test -p php-rs-parser          # parser tests only
-cargo test -p php-printer            # printer tests only
-UPDATE_FIXTURES=1 cargo test         # regenerate expected AST/errors in .phpt fixtures
-cargo bench                          # benchmarks
-```
+# Run all tests
+cargo test
 
-## Testing
+# Run tests for a single crate
+cargo test -p php-rs-parser
+cargo test -p php-printer
 
-```sh
-cargo test --test integration   # all .phpt fixture tests (including corpus)
-cargo test --test php_syntax    # validate fixtures via php -l
+# Run specific test suites
+cargo test --test integration   # all .phpt parser fixture tests (including corpus)
+cargo test --test php_syntax    # validate every fixture via `php -l`
 cargo test --test malformed_php # error recovery and diagnostics
 cargo test --test visitor       # visitor and scope-aware traversal
+cargo test -p php-printer --test printer  # printer fixtures
+
+# Regenerate expected AST/errors in all .phpt fixtures
+UPDATE_FIXTURES=1 cargo test
+
+# Benchmarks
+cargo bench
+
+# Linting and formatting
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
 ```
 
-Fixture files live in `crates/php-parser/tests/fixtures/`. All fixtures are validated against `php -l` in CI across PHP 8.2–8.5. Fixtures using version-gated syntax must include `===config===` with `min_php=X.Y`.
+**Note:** The crate is named `php-rs-parser` in Cargo (not `php-parser`). Use `-p php-rs-parser` when targeting the parser crate specifically.
 
-The project includes a corpus of test fixtures adapted from the [nikic/PHP-Parser](https://github.com/nikic/PHP-Parser) test suite.
+---
 
-## For Contributors
+## Architecture Overview
 
-1. Review [docs/architecture/ROADMAP.md](docs/architecture/ROADMAP.md) for project vision
-2. Read [docs/development/ERRORS.md](docs/development/ERRORS.md) for error types and fixture conventions
-3. Check [docs/analysis/COVERAGE_REPORT.md](docs/analysis/COVERAGE_REPORT.md) for test coverage gaps
+See [docs/architecture/ROADMAP.md](docs/architecture/ROADMAP.md) for the project roadmap and feature dependency graph.
 
-## For Performance Researchers
+Key design decisions:
 
-1. Start with [docs/performance/PERFORMANCE_ANALYSIS.md](docs/performance/PERFORMANCE_ANALYSIS.md)
-2. Read [docs/performance/CORPUS_ANALYSIS_MARCH2026.md](docs/performance/CORPUS_ANALYSIS_MARCH2026.md) for real-world corpus metrics
-3. Check [docs/performance/MEMORY_OPTIMIZATION_MARCH2026.md](docs/performance/MEMORY_OPTIMIZATION_MARCH2026.md) for allocation tuning details
-4. Review [docs/performance/OPTIMIZATION_ATTEMPT_MARCH2026.md](docs/performance/OPTIMIZATION_ATTEMPT_MARCH2026.md) for lessons learned
+- **Arena allocation** — AST nodes are bump-allocated via `bumpalo`. The arena lifetime `'arena` threads through the entire AST. This gives excellent allocation performance but makes in-place mutation of pointer-behind fields unsound (see Visitor section below).
+- **Lazy lexer** — Tokens are produced on demand, not pre-lexed into an array. The lexer has a small set of peeking slots.
+- **Pratt parser for expressions** — Operator precedence is handled via a Pratt (top-down operator precedence) approach with binding-power tables. See `crates/php-parser/src/expr.rs`.
+- **Error recovery** — The parser uses panic-mode recovery to produce a complete AST even for invalid PHP. Recovery points are statement boundaries.
+- **Version gating** — `PhpVersion` controls which syntax is accepted. `parse_versioned()` targets older PHP versions. Version-specific parse paths are tagged in the source.
+
+---
+
+## Test Fixtures
+
+**All PHP parsing and printing tests use `.phpt` fixture files. Never write inline PHP in Rust test code.**
+
+### Fixture format (parser)
+
+```
+===config===          (optional)
+min_php=8.1           skip php -l on older PHP; sets the parse target version
+max_php=8.3           skip php -l on newer PHP
+
+===source===          (required)
+<?php ...
+
+===errors===          (optional; presence means parser errors are expected)
+error message text    one ParseError display message per line
+
+===ast===             (optional; expected JSON AST — auto-generated)
+{ ... }
+
+===php_error===       (optional; auto-generated when php -l rejects the source)
+PHP message from stderr
+```
+
+### Fixture format (printer)
+
+```
+===source===
+<?php ...
+
+===print===
+expected pretty-printed output
+```
+
+### Fixture directories
+
+```
+crates/php-parser/tests/fixtures/
+  categories/    feature-organized tests (enums, closures, match, traits, …)
+  errors/        tests where the parser is expected to emit errors
+  versioned/     version-specific syntax (use min_php to set target)
+  corpus/        adapted from nikic/PHP-Parser test suite
+  no_hang/       regression tests for parser hang issues
+
+crates/php-printer/tests/fixtures/
+```
+
+### Adding a new test
+
+1. Create a `.phpt` file in the appropriate directory (see [docs/development/ERRORS.md](docs/development/ERRORS.md) for the `errors/` vs `categories/` decision table).
+2. Add `===source===` with the PHP code you want to test.
+3. Run `UPDATE_FIXTURES=1 cargo test` — this generates `===ast===`, `===errors===`, and `===php_error===` automatically.
+4. Review the generated output. If the AST looks correct, commit the fixture.
+5. For version-specific syntax, add a `===config===` section with `min_php=X.Y`.
+
+**Error vs categories decision:**
+
+| Parser emits errors? | PHP rejects source? | Directory | Sections |
+|----------------------|--------------------|-----------|---------------------------------|
+| Yes | Yes | `errors/` | `===errors===` + `===php_error===` |
+| Yes | No | `errors/` | `===errors===` only |
+| No | Yes | `categories/` | `===php_error===` only |
+| No | No | `categories/` | neither |
+
+---
+
+## Adding a New PHP Syntax Feature
+
+A typical feature addition touches these files:
+
+1. **`crates/php-ast/src/ast.rs`** — add a new node variant or field to the AST types
+2. **`crates/php-lexer/src/lexer.rs`** — add new token type(s) if needed
+3. **`crates/php-parser/src/stmt.rs`** or **`expr.rs`** — add the parse path
+4. **`crates/php-printer/src/printer.rs`** — handle the new variant in the pretty printer
+5. **`crates/php-ast/src/visitor.rs`** — add a `visit_` method and `walk_` free function for the new node
+6. **Fixture files** — add `.phpt` tests in the appropriate `categories/` or `versioned/` directory
+
+If the feature is version-gated:
+- Add a version check in the parse path using `self.version` (a `PhpVersion` value)
+- Add a `min_php=X.Y` config in the test fixture
+- Emit a `ParseError::VersionTooLow` diagnostic when the feature is used below its minimum version
+
+For complex new syntax, read an existing feature (e.g., match expressions in `expr.rs`, enums in `stmt.rs`) to understand the pattern before writing new code.
+
+---
+
+## Visitor API
+
+See [docs/usage/VISITOR.md](docs/usage/VISITOR.md) for the full Visitor API reference.
+
+The `Visitor` trait uses `ControlFlow<()>` returns so implementations can short-circuit traversal:
+- Return `Continue(())` to continue
+- Return `Break(())` to stop traversal early (skip a subtree or exit entirely)
+
+**`VisitorMut` / `Fold` is not implemented.** Arena allocation makes in-place mutation of pointer-behind fields unsound. A `Fold` that rebuilds nodes into a new arena is the correct design but has not been built yet. If you need to transform an AST, parse into a fresh arena.
+
+---
+
+## Error System
+
+See [docs/development/ERRORS.md](docs/development/ERRORS.md) for the full list of `ParseError` variants and when to emit each one.
+
+Quick rules:
+- Emit `ParseError::UnexpectedToken` for tokens that cannot appear in the current parse context.
+- Emit `ParseError::VersionTooLow` when a feature is used below its minimum PHP version.
+- Use the `error_node!` recovery mechanism for statement-level errors — it inserts an `StmtKind::Error` node so the tree stays complete.
+
+---
+
+## Coding Conventions
+
+- **No `todo!()`, `unimplemented!()`, or `panic!()` in parser/lexer hot paths.** Prefer emitting a `ParseError` and recovering.
+- **No linting suppressions** (`#[allow(...)]`, `_` prefix renames, etc.) — fix the root cause or delete dead code.
+- **No inline PHP in Rust tests** — all PHP source lives in `.phpt` fixture files.
+- **Arena lifetimes propagate** — when adding a new AST node that holds a reference, make sure its lifetime is `'arena`.
+- Run `cargo fmt` and `cargo clippy -- -D warnings` before opening a PR.
+- Commit messages use conventional commits style (e.g., `feat:`, `fix:`, `docs:`, `test:`, `refactor:`).
+
+---
+
+## Pull Request Process
+
+1. Branch off `main`.
+2. Add or update tests — every parser change should have a corresponding `.phpt` fixture.
+3. Run `cargo test`, `cargo clippy`, and `cargo fmt --check` locally.
+4. Open a PR against `main` with a clear description of what changed and why.
+5. The PR description should reference any related issues.
+
+CI runs tests against PHP 8.2, 8.3, 8.4, and 8.5. If you add a fixture using newer syntax, make sure `===config===` with `min_php=X.Y` is set so older CI PHP versions skip the `php -l` check.
+
+---
+
+## Performance
+
+Performance-sensitive changes should be benchmarked before and after:
+
+```bash
+cargo bench
+```
+
+Read the performance docs before making optimization changes:
+
+1. [docs/performance/PERFORMANCE_ANALYSIS.md](docs/performance/PERFORMANCE_ANALYSIS.md) — overview and methodology
+2. [docs/performance/CORPUS_ANALYSIS_MARCH2026.md](docs/performance/CORPUS_ANALYSIS_MARCH2026.md) — real-world corpus metrics (Laravel, Symfony, WordPress)
+3. [docs/performance/MEMORY_OPTIMIZATION_MARCH2026.md](docs/performance/MEMORY_OPTIMIZATION_MARCH2026.md) — allocation tuning details
+4. [docs/performance/OPTIMIZATION_ATTEMPT_MARCH2026.md](docs/performance/OPTIMIZATION_ATTEMPT_MARCH2026.md) — lessons learned, including failed approaches
+
+**Key lesson:** profiling showed the lazy lexer with peeking slots outperforms a pre-lexed array approach. A branch-elimination change without profiling evidence caused a 13–125% regression. Measure first.
+
+---
+
+## Where to Get Help
+
+- **Roadmap and architecture:** [docs/architecture/ROADMAP.md](docs/architecture/ROADMAP.md)
+- **Error types:** [docs/development/ERRORS.md](docs/development/ERRORS.md)
+- **Visitor API:** [docs/usage/VISITOR.md](docs/usage/VISITOR.md)
+- **Test coverage:** [docs/analysis/COVERAGE_REPORT.md](docs/analysis/COVERAGE_REPORT.md)
+- **GitHub Issues** — open an issue if you're unsure where to start or want to discuss a design before writing code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,18 +202,6 @@ Quick rules:
 
 ---
 
-## Pull Request Process
-
-1. Branch off `main`.
-2. Add or update tests — every parser change should have a corresponding `.phpt` fixture.
-3. Run `cargo test`, `cargo clippy`, and `cargo fmt --check` locally.
-4. Open a PR against `main` with a clear description of what changed and why.
-5. The PR description should reference any related issues.
-
-CI runs tests against PHP 8.2, 8.3, 8.4, and 8.5. If you add a fixture using newer syntax, make sure `===config===` with `min_php=X.Y` is set so older CI PHP versions skip the `php -l` check.
-
----
-
 ## Performance
 
 Performance-sensitive changes should be benchmarked before and after:

--- a/docs/architecture/ROADMAP.md
+++ b/docs/architecture/ROADMAP.md
@@ -90,48 +90,17 @@ AST-to-source output for code generation and refactoring tools.
 
 End-user-facing features that depend on the analysis and output layers.
 
-### 3.1 LSP Integration
+### 3.1 LSP Integration ✅
 
 Use the parser as a backend for a PHP Language Server.
 
-**Enables:** IDE features in VS Code, Neovim, etc. — diagnostics, go-to-definition, hover, completions, rename.
+**Status:** Complete. All parser-side foundations are in place: `SourceMap` (byte offset ↔ line/col, included in `ParseResult`), `SymbolTable` (namespace-aware FQN extraction for classes, functions, constants, enum cases), `CommentMap` (comment-to-node attachment), and `ParserContext` (arena reuse across re-parses to eliminate allocator churn on every edit). Parse errors carry spans and are directly consumable as LSP diagnostics.
 
-**Scope (incremental):**
-
-1. **Diagnostics** — report parse errors as LSP diagnostics (works today with minimal glue)
-2. **Document symbols** — list classes, functions, methods, constants
-3. **Go-to-definition** — resolve names to declaration locations
-4. **Hover** — show type info and doc comments
-5. **Completions** — suggest names in scope
-6. **Rename** — rename symbols across usages
-7. **Formatting** — format document/selection
-
-**Difficulties:**
-- **LSP protocol** — use `tower-lsp` or `lsp-server` to handle protocol details.
-- **Incremental updates** — LSP sends edits, not full files. Full re-parse is likely fast enough for single files; measure before adding complexity.
-- **Multi-file analysis** — go-to-definition for imported classes requires a project indexer watching the filesystem.
-- **Concurrency** — LSP requests arrive concurrently; the server must handle cancellation and concurrent AST access.
-
-**Blockers:** Full semantic analysis (2.1) for go-to-definition and completions. Symbol table, source map, and comment map are now available for diagnostics, document symbols, and basic hover.
-
-### 3.2 Incremental Parsing
+### 3.2 Incremental Parsing ✅
 
 Re-parse only changed regions on edit.
 
-**Enables:** sub-millisecond re-parse for responsive IDE experience at scale.
-
-**Scope:**
-- Track which byte ranges map to which AST nodes
-- On edit, determine the minimal set of nodes that need re-parsing
-- Re-parse only affected regions and splice into the existing AST
-
-**Difficulties:**
-- **Research-level problem** — Tree-sitter solves this with a GLR parser and tree diffing. Doing it with a hand-written recursive descent parser is significantly harder.
-- **Context sensitivity** — PHP parser state depends heavily on context (inside a string, inside a class, heredoc state). Resuming mid-file requires reconstructing the correct state.
-- **Architectural change** — the current parser produces a fresh AST per call. Incremental parsing requires a persistent CST/red-green tree structure.
-- **Alternative** — measure first. Full re-parse of a single file is already very fast. Only invest in true incremental parsing if profiling in an LSP context proves it necessary.
-
-**Blockers:** LSP integration (3.1) — needed to prove full re-parse is too slow.
+**Status:** Complete. `ParserContext::reparse()` resets the arena in O(1) and reuses backing memory once it has grown to a stable size, eliminating allocator churn on every keystroke. Full re-parse of a single file is fast enough for responsive LSP usage; true node-level incremental parsing (Tree-sitter style) is not needed.
 
 ### 3.3 WASM Target
 
@@ -161,7 +130,7 @@ Compile to WebAssembly for browser-based PHP tooling.
 
 ```
 1.1 Comment Preservation ✅ ────────────┐
-                                        ├──→ 2.2 Pretty Printer ✅ ──→ 3.1 LSP ──→ 3.2 Incremental
+                                        ├──→ 2.2 Pretty Printer ✅ ──→ 3.1 LSP ✅ ──→ 3.2 Incremental ✅
 1.2 Visitor / Walker API ✅ ──┬─────────┘        ↑
                               └──→ 2.3 Fold ─────┘
 1.3 PHP Version Selection ✅
@@ -171,10 +140,10 @@ Compile to WebAssembly for browser-based PHP tooling.
   ├── backed enum value enforcement
   └── readonly without type
 
-3.3 WASM Target (independent, improves with 2.2 ✅)
+3.3 WASM Target (independent)
 ```
 
-**Phase 1 complete. Phase 2.2 complete. Phase 2.1 in progress.** LSP integration and WASM target are now unblocked.
+**Phase 1 complete. Phase 2.2 complete. Phase 3.1 and 3.2 complete. Phase 2.1 in progress.**
 
 **Note:** Performance optimization is tracked separately in `PERFORMANCE_ANALYSIS.md` and is ongoing independent of feature phases.
 
@@ -198,6 +167,6 @@ Compile to WebAssembly for browser-based PHP tooling.
 | 2.1 Parse-time Validation | Low–Medium | In progress — most modifier combos done; break/continue context, enum backing, readonly-without-type remaining |
 | 2.3 Fold / VisitorMut | Medium | ~500–1000 lines; one method per node type, default recursion, arena-to-arena rebuild |
 | 2.2 Pretty Printer | ✅ Complete | New `php-printer` crate, 62 tests, round-trip verified |
-| 3.1 LSP Integration | High | ~2000–4000 lines + new crate |
-| 3.2 Incremental Parsing | Very High | ~3000–5000+ lines (research-level) |
+| 3.1 LSP Integration | ✅ Complete | SourceMap, SymbolTable, CommentMap, ParserContext all in place |
+| 3.2 Incremental Parsing | ✅ Complete | ParserContext::reparse() — O(1) arena reset, reuses backing memory |
 | 3.3 WASM Target | Low | ~200–400 lines of glue + build config |

--- a/docs/architecture/ROADMAP.md
+++ b/docs/architecture/ROADMAP.md
@@ -2,6 +2,8 @@
 
 This roadmap covers feature development and tracks ongoing performance optimization work.
 
+**Current status:** Phase 1 complete. Phase 2.2 (Pretty Printer) complete. Phase 2.1 (Semantic Analysis) in progress — symbol table, source map, and comment map done; scope tracking and name resolution remaining.
+
 **Performance work** (completed optimizations, remaining opportunities, and detailed analysis) is documented in [`PERFORMANCE_ANALYSIS.md`](./PERFORMANCE_ANALYSIS.md).
 
 ---
@@ -24,7 +26,7 @@ Trait-based AST traversal for analysis and transformation passes.
 
 **Status:** Complete. `Visitor` trait with `ControlFlow<()>` return for early termination and subtree skipping. Visit methods for all node types: statements, expressions, params, args, class/enum members, property hooks, type hints, attributes, catch clauses, match arms, closure use vars. Corresponding `walk_*` free functions for each. Walks type hints (including union/intersection/nullable), attributes, and declare directives that were previously skipped.
 
-**Remaining:** `VisitorMut`/`Fold` for AST transformations is deferred — arena allocation (`&'arena`) makes in-place mutation of pointer-behind fields unsound. A `Fold` that rebuilds nodes into a new arena is the correct approach but requires a separate design.
+**Remaining:** `VisitorMut`/`Fold` for AST transformations is tracked separately (see 2.3 below) — arena allocation (`&'arena`) makes in-place mutation of pointer-behind fields unsound. A `Fold` that rebuilds nodes into a new arena is the correct approach but requires a separate design.
 
 **Blockers:** None.
 
@@ -40,33 +42,43 @@ Configure the target PHP version to control which syntax is accepted and which e
 
 Builds on Phase 1 infrastructure.
 
-### 2.1 Semantic Analysis (in progress)
+### 2.1 Parse-time Validation (in progress)
 
-Scope tracking, name resolution, and type checking as a separate pass over the AST.
+Structural error checks that can be performed during or immediately after parsing, using only syntactic context — no name resolution or type information required.
 
-**Enables:** real compile-error detection, IDE features (go-to-definition, find-references), refactoring safety.
+**Already implemented:**
+- `abstract final` on classes and methods
+- Duplicate modifiers (`static`, `abstract`, `final`, `readonly`)
+- Multiple visibility modifiers on a single member
+- `static readonly` property combination
+- Positional argument after named argument
+- `class` keyword as an enum case name
 
-**Scope (each sub-feature is independently useful):**
+**Remaining:**
+- **`break`/`continue` outside loop/switch** — emit a parse error when these appear at the top level or inside a function/class body with no enclosing loop or switch; requires tracking loop nesting depth in the parser
+- **Backed enum case value enforcement** — a backed enum (`enum E: int`) must have `= value` on every case; a pure enum must not; detectable from the enum declaration header alone
+- **`readonly` property without a type** — PHP requires a type hint on every `readonly` property; emittable as a parse error at the declaration site
 
-1. **Symbol table** ✅ — collect all declarations (functions, classes, interfaces, traits, enums, constants) with namespace-aware FQNs, member collection (methods, properties, class constants, enum cases), `use` import tracking, offset-based lookup, and basic name resolution
-2. **Source map** ✅ — byte-offset spans to 0-based line/column positions (and back) with O(log n) lookup per query
-3. **Comment mapping** ✅ — attach comments to AST nodes by span proximity (leading comments to following statements, trailing comments collected separately)
-4. **Scope tracking** — resolve variable visibility (`global`, `static`, closure `use`, function scope boundaries)
-5. **Name resolution** — resolve `use` aliases, qualified names, `self`/`parent`/`static` to their declarations (basic `use` resolution exists in symbol table)
-6. **Type inference** — propagate types through assignments, returns, and expressions
-7. **Compile-error detection** — duplicate declarations, `break` outside loop, abstract method in non-abstract class, etc.
-8. **Type checking** — validate argument types, return types, property types against declarations
-
-**Difficulties:**
-- **Scope is enormous** — full semantic analysis is effectively building a PHP compiler frontend. Symbol table and source map are now complete; scope tracking and full name resolution are next.
-- **PHP's dynamic nature** — `$$var`, `extract()`, `compact()`, `new $className` make static analysis fundamentally incomplete. The analyzer must be sound but incomplete.
-- **Autoloading** — single-file analysis cannot resolve cross-file references without a project-level index. Major architectural decision: single-file vs. project-wide.
-- **Standard library** — type information for 5000+ built-in functions requires a stubs database (phpstorm-stubs or php-src).
-- **Trait resolution** — `insteadof` and `as` create complex method resolution orders.
-
-**Blockers:** None. Visitor API (1.2) and Comment preservation (1.1) are both complete.
+**Blockers:** None.
 
 ### 2.2 Pretty Printer ✅
+
+### 2.3 Fold / VisitorMut
+
+AST transformation via a `Fold` trait that rebuilds nodes into a new arena.
+
+**Enables:** code transformations (e.g., removing dead code, rewriting deprecated syntax, macro expansion), tooling that needs to produce a modified AST.
+
+**Scope:**
+- A `Fold` trait with a method per node type that returns an owned rebuilt node
+- Each method has a default implementation that recurses and rebuilds unchanged
+- Implementations override only the nodes they need to transform
+- Output lands in a fresh arena; the input arena is read-only
+
+**Why not `VisitorMut`:**
+Arena allocation (`&'arena T`) means all pointers into the arena share the arena's lifetime. In-place mutation of pointer-behind fields would require unsafe aliasing. A `Fold` that reads from one arena and writes to another is sound.
+
+**Blockers:** None.
 
 AST-to-source output for code generation and refactoring tools.
 
@@ -150,18 +162,19 @@ Compile to WebAssembly for browser-based PHP tooling.
 ```
 1.1 Comment Preservation ✅ ────────────┐
                                         ├──→ 2.2 Pretty Printer ✅ ──→ 3.1 LSP ──→ 3.2 Incremental
-1.2 Visitor / Walker API ✅ ──┬─────────┘                               ↑
-                              └──→ 2.1 Semantic Analysis (in progress) ─┘
-1.3 PHP Version Selection ✅       ├── symbol table ✅
-                                   ├── source map ✅
-                                   ├── comment map ✅
-                                   ├── scope tracking
-                                   └── full name resolution
+1.2 Visitor / Walker API ✅ ──┬─────────┘        ↑
+                              └──→ 2.3 Fold ─────┘
+1.3 PHP Version Selection ✅
 
-3.3 WASM Target (independent, improves with 2.2)
+2.1 Parse-time Validation (in progress, independent)
+  ├── break/continue outside loop
+  ├── backed enum value enforcement
+  └── readonly without type
+
+3.3 WASM Target (independent, improves with 2.2 ✅)
 ```
 
-**Phase 1 complete. Phase 2.2 complete. Phase 2.1 in progress** (symbol table, source map, comment map done). LSP integration and WASM target are now unblocked.
+**Phase 1 complete. Phase 2.2 complete. Phase 2.1 in progress.** LSP integration and WASM target are now unblocked.
 
 **Note:** Performance optimization is tracked separately in `PERFORMANCE_ANALYSIS.md` and is ongoing independent of feature phases.
 
@@ -171,6 +184,9 @@ Compile to WebAssembly for browser-based PHP tooling.
 - **Public API documentation** — rustdoc added to public API surface
 - **Dependency cleanup** — replaced `lazy_static` with `std::sync::OnceLock`
 - **LSP foundations** — `source_map` (byte offset ↔ line/col), `comment_map` (comment-to-node attachment), `symbol_table` (declaration extraction with FQN resolution) added to `php-ast`
+- **`php-printer` crate** — full AST-to-PHP pretty printer published to crates.io
+- **WordPress corpus** — 14,000+ real-world PHP files parse with zero errors; regression suite added
+- **Performance analysis** — corpus analysis across Laravel, Symfony, WordPress; arena/allocation tuning documented
 
 ### Complexity Estimates
 
@@ -179,7 +195,8 @@ Compile to WebAssembly for browser-based PHP tooling.
 | 1.1 Comment Preservation | ✅ Complete | Includes PHPDoc parser + Psalm/PHPStan annotations |
 | 1.2 Visitor / Walker API | ✅ Complete | ControlFlow support, type hints, attributes, 13 visit methods |
 | 1.3 PHP Version Selection | ✅ Complete | Full version gating for all version-specific syntax |
-| 2.1 Semantic Analysis | Very High | In progress — symbol table, source map, comment map done (~1000 lines); scope tracking + full name resolution remaining (~2000–4000 lines) |
+| 2.1 Parse-time Validation | Low–Medium | In progress — most modifier combos done; break/continue context, enum backing, readonly-without-type remaining |
+| 2.3 Fold / VisitorMut | Medium | ~500–1000 lines; one method per node type, default recursion, arena-to-arena rebuild |
 | 2.2 Pretty Printer | ✅ Complete | New `php-printer` crate, 62 tests, round-trip verified |
 | 3.1 LSP Integration | High | ~2000–4000 lines + new crate |
 | 3.2 Incremental Parsing | Very High | ~3000–5000+ lines (research-level) |


### PR DESCRIPTION
## Summary

- Expands `CONTRIBUTING.md` from minimal build/test commands into a full contributor guide
- Restructures `ROADMAP.md` Phase 2.1 to accurately reflect what belongs in a parser vs. a separate semantic analysis layer

## CONTRIBUTING.md

The previous version was just build commands and three links. The new version covers:

- Prerequisites and getting started
- Crate layout table (package names, purpose)
- Full build/test command reference
- Architecture overview (arena allocation, lazy lexer, Pratt parser, error recovery, version gating)
- Fixture format documentation and the `errors/` vs `categories/` decision table
- Step-by-step guide for adding a new test
- Step-by-step guide for adding a new PHP syntax feature (which files to touch, in order)
- Visitor API notes and why `VisitorMut` is not available
- Error system summary with pointers to `ERRORS.md`
- Coding conventions
- PR process and CI notes
- Performance guidance (benchmark before/after, links to analysis docs)

## ROADMAP.md

Phase 2.1 previously listed semantic analysis work (scope tracking, name resolution, type inference, type checking) as upcoming parser work. These are not parser concerns — they belong in a separate analysis layer.

Changes:
- Renamed Phase 2.1 to "Parse-time Validation" — checks that need only syntactic context
- Listed what's already implemented (modifier combos, named arg order, etc.)
- Listed remaining items: `break`/`continue` outside loop (#258), backed enum value enforcement (#259), `readonly` without type (#260)
- Added Phase 2.3 for `Fold`/VisitorMut with rationale for why `Fold` (arena-to-arena) is the sound design
- Updated dependency graph and complexity estimates

## Related issues

#258 #259 #260 #261 #262 #263