### PR TITLE
feat(parser): emit error for readonly property declared without a type

### DIFF
--- a/crates/php-parser/src/stmt.rs
+++ b/crates/php-parser/src/stmt.rs
@@ -1157,6 +1157,14 @@ pub fn parse_param_list<'arena, 'src>(
             None
         };
 
+        // Readonly promoted property must have a type
+        if is_readonly && visibility.is_some() && type_hint.is_none() {
+            parser.error(ParseError::Forbidden {
+                message: "readonly promoted property must have type".into(),
+                span: Span::new(param_start, parser.previous_end()),
+            });
+        }
+
         // by-ref
         let by_ref = parser.eat(TokenKind::Ampersand).is_some();
 
@@ -2544,6 +2552,12 @@ pub fn parse_class_members<'arena, 'src>(
                 parser.alloc_vec()
             };
             if is_readonly {
+                if type_hint.is_none() {
+                    parser.error(ParseError::Forbidden {
+                        message: "readonly property must have type".into(),
+                        span: Span::new(member_start, parser.previous_end()),
+                    });
+                }
                 if let Some(hook) = hooks.first() {
                     parser.error(ParseError::Forbidden {
                         message: "A readonly property cannot declare hooks".into(),

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_modifiers.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_modifiers.phpt
@@ -4,7 +4,7 @@ min_php=8.4
 <?php
 class Test {
     final public $prop;
-    readonly $prop;
+    readonly int $prop;
     private static $prop;
 }
 ===ast===
@@ -48,14 +48,31 @@ class Test {
                   "set_visibility": null,
                   "is_static": false,
                   "is_readonly": true,
-                  "type_hint": null,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "int"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 56,
+                          "end": 59
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 56,
+                      "end": 59
+                    }
+                  },
                   "default": null,
                   "attributes": []
                 }
               },
               "span": {
                 "start": 47,
-                "end": 61
+                "end": 65
               }
             },
             {
@@ -72,8 +89,8 @@ class Test {
                 }
               },
               "span": {
-                "start": 67,
-                "end": 87
+                "start": 71,
+                "end": 91
               }
             }
           ],
@@ -82,13 +99,13 @@ class Test {
       },
       "span": {
         "start": 6,
-        "end": 90
+        "end": 94
       }
     }
   ],
   "span": {
     "start": 0,
-    "end": 90
+    "end": 94
   }
 }
 ===php_error===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_modifiers_php82.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_modifiers_php82.phpt
@@ -4,7 +4,7 @@ max_php=8.2
 <?php
 class Test {
     final public $prop;
-    readonly $prop;
+    readonly int $prop;
     private static $prop;
 }
 ===ast===
@@ -48,14 +48,31 @@ class Test {
                   "set_visibility": null,
                   "is_static": false,
                   "is_readonly": true,
-                  "type_hint": null,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "int"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 56,
+                          "end": 59
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 56,
+                      "end": 59
+                    }
+                  },
                   "default": null,
                   "attributes": []
                 }
               },
               "span": {
                 "start": 47,
-                "end": 61
+                "end": 65
               }
             },
             {
@@ -72,8 +89,8 @@ class Test {
                 }
               },
               "span": {
-                "start": 67,
-                "end": 87
+                "start": 71,
+                "end": 91
               }
             }
           ],
@@ -82,13 +99,13 @@ class Test {
       },
       "span": {
         "start": 6,
-        "end": 90
+        "end": 94
       }
     }
   ],
   "span": {
     "start": 0,
-    "end": 90
+    "end": 94
   }
 }
 ===php_error===

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/property_modifiers_php83.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/property_modifiers_php83.phpt
@@ -5,7 +5,7 @@ max_php=8.3
 <?php
 class Test {
     final public $prop;
-    readonly $prop;
+    readonly int $prop;
     private static $prop;
 }
 ===ast===
@@ -49,14 +49,31 @@ class Test {
                   "set_visibility": null,
                   "is_static": false,
                   "is_readonly": true,
-                  "type_hint": null,
+                  "type_hint": {
+                    "kind": {
+                      "Named": {
+                        "parts": [
+                          "int"
+                        ],
+                        "kind": "Unqualified",
+                        "span": {
+                          "start": 56,
+                          "end": 59
+                        }
+                      }
+                    },
+                    "span": {
+                      "start": 56,
+                      "end": 59
+                    }
+                  },
                   "default": null,
                   "attributes": []
                 }
               },
               "span": {
                 "start": 47,
-                "end": 61
+                "end": 65
               }
             },
             {
@@ -73,8 +90,8 @@ class Test {
                 }
               },
               "span": {
-                "start": 67,
-                "end": 87
+                "start": 71,
+                "end": 91
               }
             }
           ],
@@ -83,13 +100,13 @@ class Test {
       },
       "span": {
         "start": 6,
-        "end": 90
+        "end": 94
       }
     }
   ],
   "span": {
     "start": 0,
-    "end": 90
+    "end": 94
   }
 }
 ===php_error===

--- a/crates/php-parser/tests/fixtures/errors/duplicate_modifier_readonly_readonly.phpt
+++ b/crates/php-parser/tests/fixtures/errors/duplicate_modifier_readonly_readonly.phpt
@@ -2,6 +2,7 @@
 <?php class A { readonly readonly $x; }
 ===errors===
 duplicate modifier 'readonly'
+readonly property must have type
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/errors/readonly_promoted_param_without_type.phpt
+++ b/crates/php-parser/tests/fixtures/errors/readonly_promoted_param_without_type.phpt
@@ -1,0 +1,78 @@
+===source===
+<?php
+class Foo {
+    public function __construct(
+        public readonly $x,
+    ) {}
+}
+===errors===
+readonly promoted property must have type
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Class": {
+          "name": "Foo",
+          "modifiers": {
+            "is_abstract": false,
+            "is_final": false,
+            "is_readonly": false
+          },
+          "extends": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Method": {
+                  "name": "__construct",
+                  "visibility": "Public",
+                  "is_static": false,
+                  "is_abstract": false,
+                  "is_final": false,
+                  "by_ref": false,
+                  "params": [
+                    {
+                      "name": "x",
+                      "type_hint": null,
+                      "default": null,
+                      "by_ref": false,
+                      "variadic": false,
+                      "is_readonly": true,
+                      "is_final": false,
+                      "visibility": "Public",
+                      "set_visibility": null,
+                      "attributes": [],
+                      "span": {
+                        "start": 59,
+                        "end": 77
+                      }
+                    }
+                  ],
+                  "return_type": null,
+                  "body": [],
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 22,
+                "end": 87
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 89
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 89
+  }
+}
+===php_error===
+PHP Fatal error:  Readonly property Foo::$x must have type in Standard input code on line 4

--- a/crates/php-parser/tests/fixtures/errors/readonly_promoted_param_without_type_legacy.phpt
+++ b/crates/php-parser/tests/fixtures/errors/readonly_promoted_param_without_type_legacy.phpt
@@ -1,5 +1,5 @@
 ===config===
-min_php=8.5
+max_php=8.4
 ===source===
 <?php
 class Foo {
@@ -77,4 +77,4 @@ readonly promoted property must have type
   }
 }
 ===php_error===
-PHP Fatal error:  Readonly property Foo::$x must have type in Standard input code on line 4
+PHP Fatal error:  Readonly property Foo::$x must have type in Standard input code on line 3

--- a/crates/php-parser/tests/fixtures/errors/readonly_property_without_type.phpt
+++ b/crates/php-parser/tests/fixtures/errors/readonly_property_without_type.phpt
@@ -1,7 +1,9 @@
 ===source===
-<?php class C { readonly readonly $a; }
+<?php
+class Foo {
+    public readonly $bar;
+}
 ===errors===
-duplicate modifier 'readonly'
 readonly property must have type
 ===ast===
 {
@@ -9,7 +11,7 @@ readonly property must have type
     {
       "kind": {
         "Class": {
-          "name": "C",
+          "name": "Foo",
           "modifiers": {
             "is_abstract": false,
             "is_final": false,
@@ -21,8 +23,8 @@ readonly property must have type
             {
               "kind": {
                 "Property": {
-                  "name": "a",
-                  "visibility": null,
+                  "name": "bar",
+                  "visibility": "Public",
                   "set_visibility": null,
                   "is_static": false,
                   "is_readonly": true,
@@ -32,8 +34,8 @@ readonly property must have type
                 }
               },
               "span": {
-                "start": 16,
-                "end": 36
+                "start": 22,
+                "end": 42
               }
             }
           ],
@@ -42,14 +44,14 @@ readonly property must have type
       },
       "span": {
         "start": 6,
-        "end": 39
+        "end": 45
       }
     }
   ],
   "span": {
     "start": 0,
-    "end": 39
+    "end": 45
   }
 }
 ===php_error===
-PHP Fatal error:  Multiple readonly modifiers are not allowed in Standard input code on line 1
+PHP Fatal error:  Readonly property Foo::$bar must have type in Standard input code on line 3


### PR DESCRIPTION
## Summary

- Emit `ParseError::Forbidden` when a `readonly` property has no type hint
- Same check for constructor-promoted parameters with `readonly`
- Update existing corpus fixtures that had untyped `readonly` properties

## Test plan

- [ ] `readonly_property_without_type.phpt` — new fixture covering the property case
- [ ] `readonly_promoted_param_without_type.phpt` — new fixture covering the constructor promotion case
- [ ] All existing tests pass (`cargo test -p php-rs-parser`)

Closes #260