### PR TITLE
feat(parser): enforce backed enum case values and reject values on pure enums

### DIFF
--- a/crates/php-parser/src/stmt.rs
+++ b/crates/php-parser/src/stmt.rs
@@ -2815,21 +2815,43 @@ fn parse_enum<'arena, 'src>(
                     span,
                 });
             }
-            let case_name = if let Some((text, _)) = parser.eat_identifier_or_keyword() {
-                text
-            } else {
-                parser.error(ParseError::Expected {
-                    expected: "case name".into(),
-                    found: parser.current_kind(),
-                    span: parser.current_span(),
-                });
-                "<error>"
-            };
-            let value = if parser.eat(TokenKind::Equals).is_some() {
+            let (case_name, case_name_span) =
+                if let Some((text, span)) = parser.eat_identifier_or_keyword() {
+                    (text, span)
+                } else {
+                    let span = parser.current_span();
+                    parser.error(ParseError::Expected {
+                        expected: "case name".into(),
+                        found: parser.current_kind(),
+                        span,
+                    });
+                    ("<error>", span)
+                };
+            let equals_token = parser.eat(TokenKind::Equals);
+            let value = if equals_token.is_some() {
                 Some(expr::parse_expr(parser))
             } else {
                 None
             };
+            if scalar_type.is_some() && value.is_none() {
+                parser.error(ParseError::Forbidden {
+                    message: format!(
+                        "Case {} of backed enum {} must have a value",
+                        case_name, name
+                    )
+                    .into(),
+                    span: case_name_span,
+                });
+            } else if scalar_type.is_none() && value.is_some() {
+                parser.error(ParseError::Forbidden {
+                    message: format!(
+                        "Case {} of pure enum {} must not have a value",
+                        case_name, name
+                    )
+                    .into(),
+                    span: equals_token.unwrap().span,
+                });
+            }
             parser.expect(TokenKind::Semicolon);
             let span = Span::new(member_start, parser.previous_end());
             members.push(EnumMember {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/enum_with_string.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/enum_with_string.phpt
@@ -8,6 +8,8 @@ enum Suit: string
     case Clubs = 'C';
     case Spades = 'S';
 }
+===errors===
+Case Diamonds of backed enum Suit must have a value
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/errors/enum_backed_case_missing_value.phpt
+++ b/crates/php-parser/tests/fixtures/errors/enum_backed_case_missing_value.phpt
@@ -1,0 +1,78 @@
+===source===
+<?php
+enum Status: string {
+    case Active;
+    case Inactive = 'inactive';
+}
+===errors===
+Case Active of backed enum Status must have a value
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Enum": {
+          "name": "Status",
+          "scalar_type": {
+            "parts": [
+              "string"
+            ],
+            "kind": "Unqualified",
+            "span": {
+              "start": 19,
+              "end": 25
+            }
+          },
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Case": {
+                  "name": "Active",
+                  "value": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 32,
+                "end": 44
+              }
+            },
+            {
+              "kind": {
+                "Case": {
+                  "name": "Inactive",
+                  "value": {
+                    "kind": {
+                      "String": "inactive"
+                    },
+                    "span": {
+                      "start": 65,
+                      "end": 75
+                    }
+                  },
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 49,
+                "end": 76
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 78
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 78
+  }
+}
+===php_error===
+PHP Fatal error:  Case Active of backed enum Status must have a value in Standard input code on line 3

--- a/crates/php-parser/tests/fixtures/errors/enum_error_then_valid_function.phpt
+++ b/crates/php-parser/tests/fixtures/errors/enum_error_then_valid_function.phpt
@@ -2,6 +2,7 @@
 <?php enum Status { case Active = ; } function use_status() { return Status::Active; }
 ===errors===
 expected expression
+Case Active of pure enum Status must not have a value
 ===ast===
 {
   "stmts": [

--- a/crates/php-parser/tests/fixtures/errors/enum_pure_case_with_value.phpt
+++ b/crates/php-parser/tests/fixtures/errors/enum_pure_case_with_value.phpt
@@ -1,0 +1,69 @@
+===source===
+<?php
+enum Direction {
+    case North = 1;
+    case South;
+}
+===errors===
+Case North of pure enum Direction must not have a value
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Enum": {
+          "name": "Direction",
+          "scalar_type": null,
+          "implements": [],
+          "members": [
+            {
+              "kind": {
+                "Case": {
+                  "name": "North",
+                  "value": {
+                    "kind": {
+                      "Int": 1
+                    },
+                    "span": {
+                      "start": 40,
+                      "end": 41
+                    }
+                  },
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 27,
+                "end": 42
+              }
+            },
+            {
+              "kind": {
+                "Case": {
+                  "name": "South",
+                  "value": null,
+                  "attributes": []
+                }
+              },
+              "span": {
+                "start": 47,
+                "end": 58
+              }
+            }
+          ],
+          "attributes": []
+        }
+      },
+      "span": {
+        "start": 6,
+        "end": 60
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 60
+  }
+}
+===php_error===
+PHP Fatal error:  Case North of non-backed enum Direction must not have a value in Standard input code on line 3


### PR DESCRIPTION
## Summary

Closes #259.

- Backed enums (`enum E: int`) now emit a `ParseError::Forbidden` error for any `case` missing a `= <value>`
- Pure enums emit a `ParseError::Forbidden` error for any `case` that has a `= <value>`
- Error span points to the case name (missing value) or the `=` token (unwanted value)
- Updated `corpus/stmt/class/enum_with_string.phpt` (pre-existing fixture with a backed enum missing a value) to include the new `===errors===` entry
- Updated `errors/enum_error_then_valid_function.phpt` (pure enum with `case Active = ;`) to include the additional validation error alongside the pre-existing "expected expression"
- Added two new error fixtures: `enum_backed_case_missing_value.phpt` and `enum_pure_case_with_value.phpt`

## Test plan

- [x] `cargo test` passes (all integration, php_syntax, printer, visitor tests)
- [x] New fixtures include `===php_error===` matching `php -l` output
- [x] Existing fixtures updated to reflect the new errors