### PR TITLE
chore: release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-04-20
+
+### Added
+
+- Backed enum cases (`enum E: int`) now require a value; pure enum cases now reject values. Both emit `ParseError::Forbidden` pointing to the missing or unwanted `=` token (`php-rs-parser`, #269).
+- `readonly` properties and constructor-promoted parameters without a type hint now emit `ParseError::Forbidden` (`php-rs-parser`, #268).
+- `break` and `continue` outside a loop or `switch` now emit a parse error; numeric level arguments are validated against the current loop depth (`php-rs-parser`, #265).
+
+### Tests
+
+- Span coverage fixtures added for `const` statement declarations (`php-rs-parser`, #267).
+- Span coverage fixtures added for first-class callable expressions (`php-rs-parser`, #266).
+
+### Documentation
+
+- CONTRIBUTING guide improved and ROADMAP restructured (#264).
+- Acknowledgements section added for nikic/PHP-Parser and the PHP community (#254).
+- README reorganized for clarity and audience separation (#253).
+- `docs/INDEX.md` navigation path for tool consumers updated (#250).
+
+---
+
 ## [0.8.1] - 2026-04-19
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -24,10 +24,10 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.8.1" }
-php-lexer = { path = "crates/php-lexer", version = "0.8.1" }
-php-rs-parser = { path = "crates/php-parser", version = "0.8.1" }
-php-printer = { path = "crates/php-printer", version = "0.8.1" }
+php-ast = { path = "crates/php-ast", version = "0.9.0" }
+php-lexer = { path = "crates/php-lexer", version = "0.9.0" }
+php-rs-parser = { path = "crates/php-parser", version = "0.9.0" }
+php-printer = { path = "crates/php-printer", version = "0.9.0" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.9.0 to 0.9.0 across all four crates
- Add CHANGELOG entry for 0.9.0

## What's in 0.9.0

**Added**
- Backed enum cases now require a value; pure enum cases now reject values (#269)
- `readonly` properties/promoted params without a type hint now emit a parse error (#268)
- `break`/`continue` outside a loop or `switch` now emit a parse error with depth validation (#265)

**Tests**
- Span coverage for `const` statement declarations (#267)
- Span coverage for first-class callable expressions (#266)

**Documentation**
- CONTRIBUTING + ROADMAP restructured (#264)
- Acknowledgements for nikic/PHP-Parser (#254)
- README reorganized (#253)
- docs/INDEX.md updated (#250)

## After merge

Tag `v0.9.0` and create a GitHub Release with the CHANGELOG entry as notes.