### PR TITLE
fix: correctly classify leading-zero indices in string interpolation

### DIFF
--- a/crates/php-parser/src/interpolation.rs
+++ b/crates/php-parser/src/interpolation.rs
@@ -724,6 +724,10 @@ fn is_var_char(b: u8) -> bool {
 /// Parse an array index from simple string interpolation: `$arr[expr]`.
 /// Handles integers (including negative like `-1`), `$variable` references,
 /// and bare string keys (e.g. `$arr[key]`).
+///
+/// PHP's integer-index rule is stricter than Rust's `parse::<i64>()`:
+/// only `"0"` or `[1-9][0-9]*` are valid positive indices, and `-[1-9][0-9]*`
+/// for negative. Forms like `"-0"`, `"00"`, `"07"` are string keys.
 fn parse_simple_index<'arena, 'src>(
     arena: &'arena bumpalo::Bump,
     source: &'src str,
@@ -732,18 +736,21 @@ fn parse_simple_index<'arena, 'src>(
     idx_end: u32,
 ) -> Expr<'arena, 'src> {
     let span = Span::new(idx_offset, idx_end);
-    // Integer index, including negative (e.g. -1)
-    if let Ok(num) = idx_str.parse::<i64>() {
-        return Expr {
-            kind: ExprKind::Int(num),
-            span,
-        };
-    }
-    // Negative integer written as `-N`
+    // Negative integer: must be `-` followed by [1-9][0-9]* (no leading zero, no "-0")
     if let Some(digits) = idx_str.strip_prefix('-') {
-        if let Ok(num) = digits.parse::<i64>() {
+        if is_php_interp_nonzero_int(digits) {
+            if let Ok(num) = digits.parse::<i64>() {
+                return Expr {
+                    kind: ExprKind::Int(-num),
+                    span,
+                };
+            }
+        }
+    // Positive integer: "0" or [1-9][0-9]*
+    } else if is_php_interp_int(idx_str) {
+        if let Ok(num) = idx_str.parse::<i64>() {
             return Expr {
-                kind: ExprKind::Int(-num),
+                kind: ExprKind::Int(num),
                 span,
             };
         }
@@ -757,12 +764,35 @@ fn parse_simple_index<'arena, 'src>(
             span,
         };
     }
-    // Bare string key (e.g. $arr[key])
+    // Bare string key (e.g. $arr[key], $arr[-0], $arr[00])
     let key_start = idx_offset as usize;
     let key_end = idx_end as usize;
     Expr {
         kind: ExprKind::String(arena.alloc_str(&source[key_start..key_end])),
         span,
+    }
+}
+
+/// Returns true if `s` is a valid PHP simple-interpolation positive integer: `"0"` or `[1-9][0-9]*`.
+/// Rejects leading-zero forms like `"00"` or `"07"` which PHP treats as string keys.
+fn is_php_interp_int(s: &str) -> bool {
+    match s.as_bytes() {
+        [b'0'] => true,
+        [first, rest @ ..] if *first >= b'1' && *first <= b'9' => {
+            rest.iter().all(|b| b.is_ascii_digit())
+        }
+        _ => false,
+    }
+}
+
+/// Returns true if `s` is a valid PHP simple-interpolation nonzero integer: `[1-9][0-9]*`.
+/// Used for the digits after `-`; `-0` is a string key in PHP, not an integer.
+fn is_php_interp_nonzero_int(s: &str) -> bool {
+    match s.as_bytes() {
+        [first, rest @ ..] if *first >= b'1' && *first <= b'9' => {
+            rest.iter().all(|b| b.is_ascii_digit())
+        }
+        _ => false,
     }
 }
 

--- a/crates/php-parser/tests/fixtures/categories/string_interpolation/interp_index_leading_zero.phpt
+++ b/crates/php-parser/tests/fixtures/categories/string_interpolation/interp_index_leading_zero.phpt
@@ -1,0 +1,503 @@
+===source===
+<?php
+// PHP's simple-interpolation integer rule: only "0" or [1-9][0-9]*
+// Leading-zero forms and -0 are string keys, not integers.
+"$a[0]";
+"$a[1]";
+"$a[42]";
+"$a[-1]";
+"$a[-42]";
+"$a[-0]";
+"$a[-00]";
+"$a[00]";
+"$a[07]";
+"$a[-0x0]";
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "InterpolatedString": [
+              {
+                "Expr": {
+                  "kind": {
+                    "ArrayAccess": {
+                      "array": {
+                        "kind": {
+                          "Variable": "a"
+                        },
+                        "span": {
+                          "start": 135,
+                          "end": 137
+                        }
+                      },
+                      "index": {
+                        "kind": {
+                          "Int": 0
+                        },
+                        "span": {
+                          "start": 138,
+                          "end": 139
+                        }
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 135,
+                    "end": 140
+                  }
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 134,
+            "end": 141
+          }
+        }
+      },
+      "span": {
+        "start": 134,
+        "end": 142
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "InterpolatedString": [
+              {
+                "Expr": {
+                  "kind": {
+                    "ArrayAccess": {
+                      "array": {
+                        "kind": {
+                          "Variable": "a"
+                        },
+                        "span": {
+                          "start": 144,
+                          "end": 146
+                        }
+                      },
+                      "index": {
+                        "kind": {
+                          "Int": 1
+                        },
+                        "span": {
+                          "start": 147,
+                          "end": 148
+                        }
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 144,
+                    "end": 149
+                  }
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 143,
+            "end": 150
+          }
+        }
+      },
+      "span": {
+        "start": 143,
+        "end": 151
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "InterpolatedString": [
+              {
+                "Expr": {
+                  "kind": {
+                    "ArrayAccess": {
+                      "array": {
+                        "kind": {
+                          "Variable": "a"
+                        },
+                        "span": {
+                          "start": 153,
+                          "end": 155
+                        }
+                      },
+                      "index": {
+                        "kind": {
+                          "Int": 42
+                        },
+                        "span": {
+                          "start": 156,
+                          "end": 158
+                        }
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 153,
+                    "end": 159
+                  }
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 152,
+            "end": 160
+          }
+        }
+      },
+      "span": {
+        "start": 152,
+        "end": 161
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "InterpolatedString": [
+              {
+                "Expr": {
+                  "kind": {
+                    "ArrayAccess": {
+                      "array": {
+                        "kind": {
+                          "Variable": "a"
+                        },
+                        "span": {
+                          "start": 163,
+                          "end": 165
+                        }
+                      },
+                      "index": {
+                        "kind": {
+                          "Int": -1
+                        },
+                        "span": {
+                          "start": 166,
+                          "end": 168
+                        }
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 163,
+                    "end": 169
+                  }
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 162,
+            "end": 170
+          }
+        }
+      },
+      "span": {
+        "start": 162,
+        "end": 171
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "InterpolatedString": [
+              {
+                "Expr": {
+                  "kind": {
+                    "ArrayAccess": {
+                      "array": {
+                        "kind": {
+                          "Variable": "a"
+                        },
+                        "span": {
+                          "start": 173,
+                          "end": 175
+                        }
+                      },
+                      "index": {
+                        "kind": {
+                          "Int": -42
+                        },
+                        "span": {
+                          "start": 176,
+                          "end": 179
+                        }
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 173,
+                    "end": 180
+                  }
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 172,
+            "end": 181
+          }
+        }
+      },
+      "span": {
+        "start": 172,
+        "end": 182
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "InterpolatedString": [
+              {
+                "Expr": {
+                  "kind": {
+                    "ArrayAccess": {
+                      "array": {
+                        "kind": {
+                          "Variable": "a"
+                        },
+                        "span": {
+                          "start": 184,
+                          "end": 186
+                        }
+                      },
+                      "index": {
+                        "kind": {
+                          "String": "-0"
+                        },
+                        "span": {
+                          "start": 187,
+                          "end": 189
+                        }
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 184,
+                    "end": 190
+                  }
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 183,
+            "end": 191
+          }
+        }
+      },
+      "span": {
+        "start": 183,
+        "end": 192
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "InterpolatedString": [
+              {
+                "Expr": {
+                  "kind": {
+                    "ArrayAccess": {
+                      "array": {
+                        "kind": {
+                          "Variable": "a"
+                        },
+                        "span": {
+                          "start": 194,
+                          "end": 196
+                        }
+                      },
+                      "index": {
+                        "kind": {
+                          "String": "-00"
+                        },
+                        "span": {
+                          "start": 197,
+                          "end": 200
+                        }
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 194,
+                    "end": 201
+                  }
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 193,
+            "end": 202
+          }
+        }
+      },
+      "span": {
+        "start": 193,
+        "end": 203
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "InterpolatedString": [
+              {
+                "Expr": {
+                  "kind": {
+                    "ArrayAccess": {
+                      "array": {
+                        "kind": {
+                          "Variable": "a"
+                        },
+                        "span": {
+                          "start": 205,
+                          "end": 207
+                        }
+                      },
+                      "index": {
+                        "kind": {
+                          "String": "00"
+                        },
+                        "span": {
+                          "start": 208,
+                          "end": 210
+                        }
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 205,
+                    "end": 211
+                  }
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 204,
+            "end": 212
+          }
+        }
+      },
+      "span": {
+        "start": 204,
+        "end": 213
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "InterpolatedString": [
+              {
+                "Expr": {
+                  "kind": {
+                    "ArrayAccess": {
+                      "array": {
+                        "kind": {
+                          "Variable": "a"
+                        },
+                        "span": {
+                          "start": 215,
+                          "end": 217
+                        }
+                      },
+                      "index": {
+                        "kind": {
+                          "String": "07"
+                        },
+                        "span": {
+                          "start": 218,
+                          "end": 220
+                        }
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 215,
+                    "end": 221
+                  }
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 214,
+            "end": 222
+          }
+        }
+      },
+      "span": {
+        "start": 214,
+        "end": 223
+      }
+    },
+    {
+      "kind": {
+        "Expression": {
+          "kind": {
+            "InterpolatedString": [
+              {
+                "Expr": {
+                  "kind": {
+                    "ArrayAccess": {
+                      "array": {
+                        "kind": {
+                          "Variable": "a"
+                        },
+                        "span": {
+                          "start": 225,
+                          "end": 227
+                        }
+                      },
+                      "index": {
+                        "kind": {
+                          "String": "-0x0"
+                        },
+                        "span": {
+                          "start": 228,
+                          "end": 232
+                        }
+                      }
+                    }
+                  },
+                  "span": {
+                    "start": 225,
+                    "end": 233
+                  }
+                }
+              }
+            ]
+          },
+          "span": {
+            "start": 224,
+            "end": 234
+          }
+        }
+      },
+      "span": {
+        "start": 224,
+        "end": 235
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 235
+  }
+}

--- a/crates/php-parser/tests/fixtures/corpus/scalar/encapsedString.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/scalar/encapsedString.phpt
@@ -317,7 +317,7 @@ B"$A";
                       },
                       "index": {
                         "kind": {
-                          "Int": 0
+                          "String": "000"
                         },
                         "span": {
                           "start": 83,


### PR DESCRIPTION
## Summary

- `parse_simple_index` in `interpolation.rs` used Rust's `.parse::<i64>()` to detect integer indices in simple string interpolation (`"$arr[index]"`). Rust's parser accepts forms like `"-0"`, `"-00"`, `"00"`, `"07"` as valid integers, but PHP's tokenizer treats all of these as **string keys** at runtime.
- PHP's rule: only `"0"` or `[1-9][0-9]*` are integer indices; only `-[1-9][0-9]*` are negative integer indices. Everything else (including `-0`) is a string key.
- Added `is_php_interp_int` / `is_php_interp_nonzero_int` helpers enforcing the PHP-specific rule.
- Fixed existing corpus fixture `encapsedString.phpt` where `"$A[000]"` was recorded as `Int: 0` (now correctly `String: "000"`).
- Added `interp_index_leading_zero.phpt` covering all 10 cases.

## Discovery

Found while analyzing the [mago](https://github.com/carthage-software/mago) parser corpus for new test ideas. Mago's `scalar_encapsed_neg_var_offset.php` fixture tests `"$a[-0]"` among others, which prompted verifying PHP's actual runtime behavior.

## PHP verification

```php
$a = ["-0" => "string_key", 0 => "int_key"];
echo "$a[-0]";  // string_key  ← string, not integer

$a = ["-1" => "string_key", -1 => "int_key"];
echo "$a[-1]";  // int_key     ← integer, as expected
```

## Test plan
- [ ] `cargo test` passes (all suites green)
- [ ] New fixture `interp_index_leading_zero.phpt` covers `"$a[-0]"`, `"$a[-00]"`, `"$a[00]"`, `"$a[07]"`, `"$a[-0x0]"` producing `String`, and `"$a[0]"`, `"$a[-1]"` etc. producing `Int`