### PR TITLE
chore: release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-04-25
+
+### Fixed
+
+- Leading-zero and negative-zero indices in simple string interpolation (`$arr[00]`, `$arr[07]`, `$arr[-0]`) are now correctly classified as string keys instead of `Int(0)`, matching PHP's tokenizer behaviour (`php-rs-parser`).
+
+---
+
 ## [0.9.1] - 2026-04-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -24,10 +24,10 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.9.1" }
-php-lexer = { path = "crates/php-lexer", version = "0.9.1" }
-php-rs-parser = { path = "crates/php-parser", version = "0.9.1" }
-php-printer = { path = "crates/php-printer", version = "0.9.1" }
+php-ast = { path = "crates/php-ast", version = "0.9.2" }
+php-lexer = { path = "crates/php-lexer", version = "0.9.2" }
+php-rs-parser = { path = "crates/php-parser", version = "0.9.2" }
+php-printer = { path = "crates/php-printer", version = "0.9.2" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Leading-zero and negative-zero indices in simple string interpolation (`$arr[00]`, `$arr[07]`, `$arr[-0]`, `$arr[-00]`) were incorrectly parsed as `Int(0)` instead of string keys.
- PHP's tokenizer only accepts `"0"` or `[1-9][0-9]*` as integer indices in simple interpolation; all other forms are string keys at runtime.
- Added `is_php_interp_int` / `is_php_interp_nonzero_int` helpers that enforce the PHP-specific rule.
- Fixes the corpus fixture `encapsedString.phpt` where `"000"` was emitted as `Int: 0` instead of `String: "000"`.
- Bumps workspace version to `0.9.2`.

## Test plan

- [ ] `cargo test -p php-rs-parser` passes (new fixture `interp_index_leading_zero.phpt` covers all edge cases)
- [ ] `cargo test` passes across all crates
- [ ] Corpus fixture `encapsedString.phpt` updated to reflect corrected AST