### PR TITLE
feat(ast): attach doc_comment to ConstItem for top-level constants

### DIFF
--- a/crates/php-ast/src/ast.rs
+++ b/crates/php-ast/src/ast.rs
@@ -877,6 +877,8 @@ pub struct ConstItem<'arena, 'src> {
     pub value: Expr<'arena, 'src>,
     pub attributes: ArenaVec<'arena, Attribute<'arena, 'src>>,
     pub span: Span,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub doc_comment: Option<Comment<'src>>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/php-parser/src/stmt/mod.rs
+++ b/crates/php-parser/src/stmt/mod.rs
@@ -2008,8 +2008,9 @@ fn parse_const_with_attrs<'arena, 'src>(
     parser.advance(); // consume 'const'
 
     let mut items = parser.alloc_vec();
-    // Attributes apply to the first item only.
+    // Attributes and doc comment apply to the first item only.
     let mut pending_attrs = Some(attributes);
+    let mut pending_doc = parser.take_doc_comment(start);
     loop {
         let item_start = parser.start_span();
         let const_name = if let Some((text, _)) = parser.eat_identifier_or_keyword() {
@@ -2026,11 +2027,13 @@ fn parse_const_with_attrs<'arena, 'src>(
         let value = expr::parse_expr(parser);
         let item_span = Span::new(item_start, value.span.end);
         let item_attrs = pending_attrs.take().unwrap_or_else(|| parser.alloc_vec());
+        let doc_comment = pending_doc.take();
         items.push(ConstItem {
             name: const_name,
             value,
             attributes: item_attrs,
             span: item_span,
+            doc_comment,
         });
 
         if parser.eat(TokenKind::Comma).is_none() {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/const_doc_comment.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/const_doc_comment.phpt
@@ -1,0 +1,49 @@
+===source===
+<?php
+
+/** The answer to everything */
+const ANSWER = 42;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Const": [
+          {
+            "name": "ANSWER",
+            "value": {
+              "kind": {
+                "Int": 42
+              },
+              "span": {
+                "start": 54,
+                "end": 56
+              }
+            },
+            "attributes": [],
+            "span": {
+              "start": 45,
+              "end": 56
+            },
+            "doc_comment": {
+              "kind": "Doc",
+              "text": "/** The answer to everything */",
+              "span": {
+                "start": 7,
+                "end": 38
+              }
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 39,
+        "end": 57
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 57
+  }
+}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/const_doc_comment_multi.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/const_doc_comment_multi.phpt
@@ -1,0 +1,83 @@
+===source===
+<?php
+
+/** Only for FIRST */
+const FIRST = 1, SECOND = 2, THIRD = 3;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Const": [
+          {
+            "name": "FIRST",
+            "value": {
+              "kind": {
+                "Int": 1
+              },
+              "span": {
+                "start": 43,
+                "end": 44
+              }
+            },
+            "attributes": [],
+            "span": {
+              "start": 35,
+              "end": 44
+            },
+            "doc_comment": {
+              "kind": "Doc",
+              "text": "/** Only for FIRST */",
+              "span": {
+                "start": 7,
+                "end": 28
+              }
+            }
+          },
+          {
+            "name": "SECOND",
+            "value": {
+              "kind": {
+                "Int": 2
+              },
+              "span": {
+                "start": 55,
+                "end": 56
+              }
+            },
+            "attributes": [],
+            "span": {
+              "start": 46,
+              "end": 56
+            }
+          },
+          {
+            "name": "THIRD",
+            "value": {
+              "kind": {
+                "Int": 3
+              },
+              "span": {
+                "start": 66,
+                "end": 67
+              }
+            },
+            "attributes": [],
+            "span": {
+              "start": 58,
+              "end": 67
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 29,
+        "end": 68
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 68
+  }
+}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/const_doc_comment_namespace.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/const_doc_comment_namespace.phpt
@@ -1,0 +1,73 @@
+===source===
+<?php
+
+namespace App\Config;
+
+/** Maximum retry count */
+const MAX_RETRIES = 3;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Namespace": {
+          "name": {
+            "parts": [
+              "App",
+              "Config"
+            ],
+            "kind": "Qualified",
+            "span": {
+              "start": 17,
+              "end": 27
+            }
+          },
+          "body": "Simple"
+        }
+      },
+      "span": {
+        "start": 7,
+        "end": 28
+      }
+    },
+    {
+      "kind": {
+        "Const": [
+          {
+            "name": "MAX_RETRIES",
+            "value": {
+              "kind": {
+                "Int": 3
+              },
+              "span": {
+                "start": 77,
+                "end": 78
+              }
+            },
+            "attributes": [],
+            "span": {
+              "start": 63,
+              "end": 78
+            },
+            "doc_comment": {
+              "kind": "Doc",
+              "text": "/** Maximum retry count */",
+              "span": {
+                "start": 30,
+                "end": 56
+              }
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 57,
+        "end": 79
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 79
+  }
+}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/const_doc_comment_with_attribute.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/const_doc_comment_with_attribute.phpt
@@ -1,0 +1,68 @@
+===source===
+<?php
+
+/** @api */
+#[SomeAttribute]
+const VERSION = '1.0.0';
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Const": [
+          {
+            "name": "VERSION",
+            "value": {
+              "kind": {
+                "String": "1.0.0"
+              },
+              "span": {
+                "start": 52,
+                "end": 59
+              }
+            },
+            "attributes": [
+              {
+                "name": {
+                  "parts": [
+                    "SomeAttribute"
+                  ],
+                  "kind": "Unqualified",
+                  "span": {
+                    "start": 21,
+                    "end": 34
+                  }
+                },
+                "args": [],
+                "span": {
+                  "start": 21,
+                  "end": 34
+                }
+              }
+            ],
+            "span": {
+              "start": 42,
+              "end": 59
+            },
+            "doc_comment": {
+              "kind": "Doc",
+              "text": "/** @api */",
+              "span": {
+                "start": 7,
+                "end": 18
+              }
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 36,
+        "end": 60
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 60
+  }
+}

--- a/crates/php-parser/tests/fixtures/corpus/stmt/const_no_doc_comment.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/const_no_doc_comment.phpt
@@ -1,0 +1,101 @@
+===source===
+<?php
+
+/* block comment */
+const BLOCK = 1;
+
+// line comment
+const LINE = 2;
+
+# hash comment
+const HASH = 3;
+===ast===
+{
+  "stmts": [
+    {
+      "kind": {
+        "Const": [
+          {
+            "name": "BLOCK",
+            "value": {
+              "kind": {
+                "Int": 1
+              },
+              "span": {
+                "start": 41,
+                "end": 42
+              }
+            },
+            "attributes": [],
+            "span": {
+              "start": 33,
+              "end": 42
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 27,
+        "end": 43
+      }
+    },
+    {
+      "kind": {
+        "Const": [
+          {
+            "name": "LINE",
+            "value": {
+              "kind": {
+                "Int": 2
+              },
+              "span": {
+                "start": 74,
+                "end": 75
+              }
+            },
+            "attributes": [],
+            "span": {
+              "start": 67,
+              "end": 75
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 61,
+        "end": 76
+      }
+    },
+    {
+      "kind": {
+        "Const": [
+          {
+            "name": "HASH",
+            "value": {
+              "kind": {
+                "Int": 3
+              },
+              "span": {
+                "start": 106,
+                "end": 107
+              }
+            },
+            "attributes": [],
+            "span": {
+              "start": 99,
+              "end": 107
+            }
+          }
+        ]
+      },
+      "span": {
+        "start": 93,
+        "end": 108
+      }
+    }
+  ],
+  "span": {
+    "start": 0,
+    "end": 108
+  }
+}

--- a/crates/php-printer/src/printer.rs
+++ b/crates/php-printer/src/printer.rs
@@ -294,12 +294,15 @@ impl Printer {
             StmtKind::Namespace(ns) => self.print_namespace(ns),
             StmtKind::Use(use_decl) => self.print_use(use_decl),
             StmtKind::Const(items) => {
+                if let Some(first) = items.first() {
+                    self.print_doc_comment(&first.doc_comment);
+                    self.print_attributes(&first.attributes);
+                }
                 self.w("const ");
                 for (i, item) in items.iter().enumerate() {
                     if i > 0 {
                         self.w(", ");
                     }
-                    self.print_attributes(&item.attributes);
                     self.w(item.name);
                     self.w(" = ");
                     self.print_expr(&item.value, PREC_LOWEST);

--- a/crates/php-printer/tests/fixtures/const_doc_comment.phpt
+++ b/crates/php-printer/tests/fixtures/const_doc_comment.phpt
@@ -1,0 +1,7 @@
+===source===
+<?php
+/** The answer to everything */
+const ANSWER = 42;
+===print===
+/** The answer to everything */
+const ANSWER = 42;


### PR DESCRIPTION
## Summary

- Adds `doc_comment: Option<Comment<'src>>` to `ConstItem` — the last declaration node missing this field — closing the gap raised in #277
- In multi-constant declarations (`const A = 1, B = 2;`) the doc comment applies to the first item only, mirroring the existing `pending_attrs` pattern
- Fixes a pre-existing printer bug: attributes on `const` statements were emitted after the `const` keyword (invalid PHP); both `doc_comment` and `attributes` are now printed before `const`

## Test plan

- [ ] `const_doc_comment.phpt` — basic doc comment attachment
- [ ] `const_doc_comment_multi.phpt` — doc comment on first item only in multi-constant declaration; second/third items omit the field
- [ ] `const_doc_comment_with_attribute.phpt` — doc comment and attribute co-exist; round-trip stable
- [ ] `const_no_doc_comment.phpt` — block, line, and hash comments do NOT attach
- [ ] `const_doc_comment_namespace.phpt` — works inside a namespace body
- [ ] `const_doc_comment.phpt` (printer) — parse → print round-trip preserves the doc comment

Closes #277