### PR TITLE
chore: release v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] - 2026-04-26
+
+### Added
+
+- `doc_comment: Option<Comment<'src>>` field on `ConstItem` — top-level constants now carry their preceding doc comment in the AST. In multi-constant declarations (`const A = 1, B = 2;`) the doc comment is attached to the first item only, mirroring the existing `pending_attrs` pattern (`php-ast`, `php-rs-parser`, #277).
+
+### Fixed
+
+- Printer emitted attributes on `const` statements after the `const` keyword (invalid PHP); both doc comments and attributes are now printed before `const` (`php-printer`, #277).
+
+---
+
 ## [0.9.2] - 2026-04-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -24,10 +24,10 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.9.2" }
-php-lexer = { path = "crates/php-lexer", version = "0.9.2" }
-php-rs-parser = { path = "crates/php-parser", version = "0.9.2" }
-php-printer = { path = "crates/php-printer", version = "0.9.2" }
+php-ast = { path = "crates/php-ast", version = "0.9.3" }
+php-lexer = { path = "crates/php-lexer", version = "0.9.3" }
+php-rs-parser = { path = "crates/php-parser", version = "0.9.3" }
+php-printer = { path = "crates/php-printer", version = "0.9.3" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }

--- a/crates/php-parser/tests/fixtures/corpus/stmt/const_doc_comment_with_attribute.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/const_doc_comment_with_attribute.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.5
 ===source===
 <?php
 


### PR DESCRIPTION
## Summary

- Adds `doc_comment: Option<Comment<'src>>` to `ConstItem` — top-level constants now carry their preceding doc comment in the AST (#277)
- Fixes printer emitting attributes on `const` statements after the `const` keyword; doc comments and attributes are now both printed before `const` (#277)
- Internal refactoring: centralized Pratt operator dispatch, extracted lexer tests, split stmt/expr parser modules (no public API changes)

## Changelog

See [CHANGELOG.md](CHANGELOG.md) for the full entry.