### PR TITLE
chore: release 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.5] - 2026-04-27
+
+### Added
+
+- Interactive WebAssembly playground deployed to GitHub Pages — parse and format PHP in the browser, powered by the Rust parser compiled to WASM (`php-wasm`).
+- New `php-wasm` crate: `wasm-bindgen` bindings exposing `parse()`, `format()`, `parser_version()`, and `build_commit()` to JavaScript.
+- GitHub Actions workflow (`playground.yml`) that builds the WASM package with `wasm-pack` and deploys the playground on every push to `main` that touches parser or playground files.
+
+### Fixed
+
+- Playground statusbar version link pointed to `releases/tag/0.9.x` (missing `v` prefix); corrected to `releases/tag/v0.9.x` to match the actual tag format (`playground`).
+
+### Documentation
+
+- Added playground link to the top of `README.md`.
+- `parse_stmt` stack-depth behaviour documented in source (`php-rs-parser`).
+
+---
+
 ## [0.9.4] - 2026-04-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A fast, fault-tolerant PHP parser written in Rust. Produces a full typed AST with source spans, recovers from syntax errors, and covers PHP 7.4–8.5 syntax.
 
+**[Try the interactive playground →](https://jorgsowa.github.io/rust-php-parser/)**
+
 ## Quick Start
 
 ```rust

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -160,7 +160,7 @@ export default function App() {
         {parserVersion && (
           <a
             className="statusbar-item statusbar-link"
-            href={`https://github.com/jorgsowa/rust-php-parser/releases/tag/${parserVersion}`}
+            href={`https://github.com/jorgsowa/rust-php-parser/releases/tag/v${parserVersion}`}
             target="_blank"
             rel="noreferrer"
             title="Release notes"


### PR DESCRIPTION
## Summary

- Bumps version to 0.9.5
- Adds CHANGELOG entry for the WebAssembly playground and `php-wasm` crate
- Fixes playground statusbar version link (missing `v` prefix in release tag URL)
- Adds playground link to the top of `README.md`