### PR TITLE
chore: bump workspace dependency versions to 0.9.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.9.4" }
-php-lexer = { path = "crates/php-lexer", version = "0.9.4" }
-php-rs-parser = { path = "crates/php-parser", version = "0.9.4" }
-php-printer = { path = "crates/php-printer", version = "0.9.4" }
+php-ast = { path = "crates/php-ast", version = "0.9.5" }
+php-lexer = { path = "crates/php-lexer", version = "0.9.5" }
+php-rs-parser = { path = "crates/php-parser", version = "0.9.5" }
+php-printer = { path = "crates/php-printer", version = "0.9.5" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Bumps workspace dependency declarations (`php-ast`, `php-lexer`, `php-rs-parser`, `php-printer`) from `0.9.4` to `0.9.5` to match the workspace package version.

## Test plan

- [ ] `cargo check` passes