### PR TITLE
chore: release 0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.6] - 2026-04-27
+
+### Added
+
+- Playground AST tree is now interactive with collapsible nodes — click any node to expand or collapse its subtree (`playground`).
+
+### Fixed
+
+- Workspace dependency versions in `Cargo.toml` were still pinned to `0.9.4` after the 0.9.5 release; corrected to `0.9.5` (`Cargo.toml`).
+---
+
 ## [0.9.5] - 2026-04-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.5"
+version = "0.9.6"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -25,10 +25,10 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.9.5" }
-php-lexer = { path = "crates/php-lexer", version = "0.9.5" }
-php-rs-parser = { path = "crates/php-parser", version = "0.9.5" }
-php-printer = { path = "crates/php-printer", version = "0.9.5" }
+php-ast = { path = "crates/php-ast", version = "0.9.6" }
+php-lexer = { path = "crates/php-lexer", version = "0.9.6" }
+php-rs-parser = { path = "crates/php-parser", version = "0.9.6" }
+php-printer = { path = "crates/php-printer", version = "0.9.6" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Bump workspace version to 0.9.6
- Interactive collapsible AST tree nodes in the playground
- Fix workspace dependency versions (were pinned to 0.9.4 after 0.9.5 release)

## Test plan

- [ ] CI passes (lint + tests across PHP 8.1–8.5)
- [ ] Merge PR
- [ ] Tag `v0.9.6` on the merge commit
- [ ] Create GitHub release from the tag