### PR TITLE
fix(ci): remove release trigger from playground deploy workflow

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -11,8 +11,6 @@ on:
       - 'crates/php-printer/**'
       - 'playground/**'
       - '.github/workflows/playground.yml'
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem

Publishing the v0.9.6 release triggered the `release: types: [published]` event, which ran the playground deploy workflow. The deploy job uses the `github-pages` environment, which is protected to only allow deployments from `main`. The tag context was rejected.

## Fix

Remove the `release` trigger. The `push: branches: [main]` trigger already fires when any release PR merges, so the playground is always deployed from the correct branch context.