### PR TITLE
fix: add Name::Error variant for synthesised names (#275)

### DIFF
--- a/crates/php-ast/src/ast/decls.rs
+++ b/crates/php-ast/src/ast/decls.rs
@@ -2,11 +2,11 @@ use serde::Serialize;
 
 use crate::Span;
 
-use super::{ArenaVec, Attribute, Comment, Expr, Name, Stmt, TypeHint};
+use super::{ArenaVec, Attribute, Comment, Expr, Ident, Name, Stmt, TypeHint};
 
 #[derive(Debug, Serialize)]
 pub struct FunctionDecl<'arena, 'src> {
-    pub name: &'src str,
+    pub name: Ident<'src>,
     pub params: ArenaVec<'arena, Param<'arena, 'src>>,
     pub body: ArenaVec<'arena, Stmt<'arena, 'src>>,
     pub return_type: Option<TypeHint<'arena, 'src>>,
@@ -18,7 +18,7 @@ pub struct FunctionDecl<'arena, 'src> {
 
 #[derive(Debug, Serialize)]
 pub struct Param<'arena, 'src> {
-    pub name: &'src str,
+    pub name: Ident<'src>,
     pub type_hint: Option<TypeHint<'arena, 'src>>,
     pub default: Option<Expr<'arena, 'src>>,
     pub by_ref: bool,
@@ -45,7 +45,7 @@ pub enum Visibility {
 
 #[derive(Debug, Serialize)]
 pub struct ClassDecl<'arena, 'src> {
-    pub name: Option<&'src str>,
+    pub name: Option<Ident<'src>>,
     pub modifiers: ClassModifiers,
     pub extends: Option<Name<'arena, 'src>>,
     pub implements: ArenaVec<'arena, Name<'arena, 'src>>,
@@ -78,7 +78,7 @@ pub enum ClassMemberKind<'arena, 'src> {
 
 #[derive(Debug, Serialize)]
 pub struct PropertyDecl<'arena, 'src> {
-    pub name: &'src str,
+    pub name: Ident<'src>,
     pub visibility: Option<Visibility>,
     pub set_visibility: Option<Visibility>,
     pub is_static: bool,
@@ -123,7 +123,7 @@ pub struct PropertyHook<'arena, 'src> {
 
 #[derive(Debug, Serialize)]
 pub struct MethodDecl<'arena, 'src> {
-    pub name: &'src str,
+    pub name: Ident<'src>,
     pub visibility: Option<Visibility>,
     pub is_static: bool,
     pub is_abstract: bool,
@@ -139,7 +139,7 @@ pub struct MethodDecl<'arena, 'src> {
 
 #[derive(Debug, Serialize)]
 pub struct ClassConstDecl<'arena, 'src> {
-    pub name: &'src str,
+    pub name: Ident<'src>,
     pub visibility: Option<Visibility>,
     pub is_final: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -181,7 +181,7 @@ pub enum TraitAdaptationKind<'arena, 'src> {
 
 #[derive(Debug, Serialize)]
 pub struct InterfaceDecl<'arena, 'src> {
-    pub name: &'src str,
+    pub name: Ident<'src>,
     pub extends: ArenaVec<'arena, Name<'arena, 'src>>,
     pub members: ArenaVec<'arena, ClassMember<'arena, 'src>>,
     pub attributes: ArenaVec<'arena, Attribute<'arena, 'src>>,
@@ -191,7 +191,7 @@ pub struct InterfaceDecl<'arena, 'src> {
 
 #[derive(Debug, Serialize)]
 pub struct TraitDecl<'arena, 'src> {
-    pub name: &'src str,
+    pub name: Ident<'src>,
     pub members: ArenaVec<'arena, ClassMember<'arena, 'src>>,
     pub attributes: ArenaVec<'arena, Attribute<'arena, 'src>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -200,7 +200,7 @@ pub struct TraitDecl<'arena, 'src> {
 
 #[derive(Debug, Serialize)]
 pub struct EnumDecl<'arena, 'src> {
-    pub name: &'src str,
+    pub name: Ident<'src>,
     pub scalar_type: Option<Name<'arena, 'src>>,
     pub implements: ArenaVec<'arena, Name<'arena, 'src>>,
     pub members: ArenaVec<'arena, EnumMember<'arena, 'src>>,
@@ -229,7 +229,7 @@ pub enum EnumMemberKind<'arena, 'src> {
 
 #[derive(Debug, Serialize)]
 pub struct EnumCase<'arena, 'src> {
-    pub name: &'src str,
+    pub name: Ident<'src>,
     pub value: Option<Expr<'arena, 'src>>,
     pub attributes: ArenaVec<'arena, Attribute<'arena, 'src>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/php-ast/src/ast/names.rs
+++ b/crates/php-ast/src/ast/names.rs
@@ -6,6 +6,112 @@ use crate::Span;
 
 use super::ArenaVec;
 
+/// A bare identifier — the kind that names a function, class, parameter,
+/// enum case, etc. Distinct from [`Name`], which represents possibly-qualified
+/// names.
+///
+/// Memory layout is identical to `&'src str` (16 bytes); `Option<Ident>` is
+/// also 16 bytes via the standard pointer niche. The "error" state — produced
+/// during error recovery when no identifier was found in the source — is
+/// represented by an empty string slice, which cannot occur for a real PHP
+/// identifier (the lexer rejects empty matches).
+///
+/// Use [`Ident::name`] / [`Ident::ERROR`] to construct, [`Ident::as_str`] to
+/// extract a real name, [`Ident::is_error`] to test for the error state.
+/// Serialises as a JSON string for real names and `null` for the error state.
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct Ident<'src>(&'src str);
+
+impl<'src> Ident<'src> {
+    /// Sentinel for "no identifier was parsed" — same memory layout as a real
+    /// `Ident`, distinguished by the empty-string interior.
+    pub const ERROR: Self = Self("");
+
+    /// Construct an identifier from a non-empty source slice.
+    /// Empty input is rejected in debug builds — use [`Ident::ERROR`] instead.
+    #[inline]
+    pub fn name(s: &'src str) -> Self {
+        debug_assert!(!s.is_empty(), "Ident::name() called with empty string");
+        Self(s)
+    }
+
+    /// Returns `Some(s)` for a real identifier, `None` for the error state.
+    #[inline]
+    pub fn as_str(&self) -> Option<&'src str> {
+        if self.0.is_empty() {
+            None
+        } else {
+            Some(self.0)
+        }
+    }
+
+    /// Returns `true` if this identifier was synthesised during error recovery.
+    #[inline]
+    pub fn is_error(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the inner string, or `"<error>"` for the error state.
+    /// Useful when constructing diagnostic messages.
+    #[inline]
+    pub fn or_error(&self) -> &'src str {
+        if self.0.is_empty() {
+            "<error>"
+        } else {
+            self.0
+        }
+    }
+}
+
+impl<'src> std::fmt::Debug for Ident<'src> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0.is_empty() {
+            f.write_str("Ident::ERROR")
+        } else {
+            f.debug_tuple("Ident").field(&self.0).finish()
+        }
+    }
+}
+
+impl<'src> std::fmt::Display for Ident<'src> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.or_error())
+    }
+}
+
+impl<'src> serde::Serialize for Ident<'src> {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        if self.0.is_empty() {
+            s.serialize_none()
+        } else {
+            s.serialize_str(self.0)
+        }
+    }
+}
+
+impl<'src> PartialEq<&str> for Ident<'src> {
+    fn eq(&self, other: &&str) -> bool {
+        !self.0.is_empty() && self.0 == *other
+    }
+}
+
+#[cfg(test)]
+mod ident_layout_tests {
+    use super::Ident;
+
+    /// `Ident` is `#[repr(transparent)]` over `&str`; this test guards the
+    /// invariant so the size never accidentally regresses.
+    #[test]
+    fn ident_has_same_size_as_str_slice() {
+        assert_eq!(std::mem::size_of::<Ident>(), std::mem::size_of::<&str>());
+        assert_eq!(
+            std::mem::size_of::<Option<Ident>>(),
+            std::mem::size_of::<Option<&str>>()
+        );
+    }
+}
+
 /// A PHP name (identifier, qualified name, fully-qualified name, or relative name).
 ///
 /// The `Simple` variant is the fast path for the common case (~95%) of single

--- a/crates/php-ast/src/ast/names.rs
+++ b/crates/php-ast/src/ast/names.rs
@@ -64,12 +64,13 @@ impl<'arena, 'src> Name<'arena, 'src> {
         match self {
             Self::Simple { value, .. } => value,
             Self::Complex { span, .. } => &src[span.start as usize..span.end as usize],
-            Self::Error { .. } => "<error>",
+            Self::Error { .. } => "",
         }
     }
 
     /// Joins all parts with `\` and prepends `\` if fully qualified.
     /// Returns `Cow::Borrowed` for simple names (zero allocation).
+    /// Returns an empty `Cow::Borrowed("")` for `Name::Error`.
     #[inline]
     pub fn to_string_repr(&self) -> Cow<'src, str> {
         match self {
@@ -82,18 +83,19 @@ impl<'arena, 'src> Name<'arena, 'src> {
                     Cow::Owned(joined)
                 }
             }
-            Self::Error { .. } => Cow::Borrowed("<error>"),
+            Self::Error { .. } => Cow::Borrowed(""),
         }
     }
 
     /// Joins all parts with `\` without any leading backslash.
     /// Returns `Cow::Borrowed` for simple names (zero allocation).
+    /// Returns an empty `Cow::Borrowed("")` for `Name::Error`.
     #[inline]
     pub fn join_parts(&self) -> Cow<'src, str> {
         match self {
             Self::Simple { value, .. } => Cow::Borrowed(value),
             Self::Complex { parts, .. } => Cow::Owned(parts.join("\\")),
-            Self::Error { .. } => Cow::Borrowed("<error>"),
+            Self::Error { .. } => Cow::Borrowed(""),
         }
     }
 

--- a/crates/php-ast/src/ast/names.rs
+++ b/crates/php-ast/src/ast/names.rs
@@ -14,6 +14,10 @@ use super::ArenaVec;
 ///
 /// The `Complex` variant handles qualified (`Foo\Bar`), fully-qualified (`\Foo\Bar`),
 /// and relative (`namespace\Foo`) names.
+///
+/// The `Error` variant is synthesised during error recovery when the parser
+/// expected a name but found none. It carries only a span so consumers can
+/// distinguish it from any user-written name.
 pub enum Name<'arena, 'src> {
     /// Single unqualified identifier — no `ArenaVec` allocation.
     /// `&'src str` instead of `Cow` since this is always a borrowed slice of the source.
@@ -24,13 +28,17 @@ pub enum Name<'arena, 'src> {
         kind: NameKind,
         span: Span,
     },
+    /// Synthesised during error recovery when no real name could be parsed.
+    /// Distinguishable from any user-written name; visitors and tools can
+    /// explicitly skip or flag these.
+    Error { span: Span },
 }
 
 impl<'arena, 'src> Name<'arena, 'src> {
     #[inline]
     pub fn span(&self) -> Span {
         match self {
-            Self::Simple { span, .. } | Self::Complex { span, .. } => *span,
+            Self::Simple { span, .. } | Self::Complex { span, .. } | Self::Error { span } => *span,
         }
     }
 
@@ -39,6 +47,7 @@ impl<'arena, 'src> Name<'arena, 'src> {
         match self {
             Self::Simple { .. } => NameKind::Unqualified,
             Self::Complex { kind, .. } => *kind,
+            Self::Error { .. } => NameKind::Error,
         }
     }
 
@@ -55,6 +64,7 @@ impl<'arena, 'src> Name<'arena, 'src> {
         match self {
             Self::Simple { value, .. } => value,
             Self::Complex { span, .. } => &src[span.start as usize..span.end as usize],
+            Self::Error { .. } => "<error>",
         }
     }
 
@@ -72,6 +82,7 @@ impl<'arena, 'src> Name<'arena, 'src> {
                     Cow::Owned(joined)
                 }
             }
+            Self::Error { .. } => Cow::Borrowed("<error>"),
         }
     }
 
@@ -82,6 +93,7 @@ impl<'arena, 'src> Name<'arena, 'src> {
         match self {
             Self::Simple { value, .. } => Cow::Borrowed(value),
             Self::Complex { parts, .. } => Cow::Owned(parts.join("\\")),
+            Self::Error { .. } => Cow::Borrowed("<error>"),
         }
     }
 
@@ -92,6 +104,7 @@ impl<'arena, 'src> Name<'arena, 'src> {
         match self {
             Self::Simple { value, .. } => std::slice::from_ref(value),
             Self::Complex { parts, .. } => parts,
+            Self::Error { .. } => &[],
         }
     }
 }
@@ -111,6 +124,14 @@ impl<'arena, 'src> std::fmt::Debug for Name<'arena, 'src> {
                 .field("kind", kind)
                 .field("span", span)
                 .finish(),
+            Self::Error { span } => {
+                let empty: [&str; 0] = [];
+                f.debug_struct("Name")
+                    .field("parts", &empty)
+                    .field("kind", &NameKind::Error)
+                    .field("span", span)
+                    .finish()
+            }
         }
     }
 }
@@ -130,6 +151,12 @@ impl<'arena, 'src> serde::Serialize for Name<'arena, 'src> {
                 st.serialize_field("kind", kind)?;
                 st.serialize_field("span", span)?;
             }
+            Self::Error { span } => {
+                let empty: [&str; 0] = [];
+                st.serialize_field("parts", &empty[..])?;
+                st.serialize_field("kind", &NameKind::Error)?;
+                st.serialize_field("span", span)?;
+            }
         }
         st.end()
     }
@@ -145,6 +172,8 @@ pub enum NameKind {
     FullyQualified,
     /// A name starting with the `namespace` keyword: `namespace\Foo`.
     Relative,
+    /// Synthesised during error recovery — no real name was present in the source.
+    Error,
 }
 
 /// PHP built-in type keyword — zero-cost alternative to `Name::Simple` for the

--- a/crates/php-ast/src/ast/stmts.rs
+++ b/crates/php-ast/src/ast/stmts.rs
@@ -3,8 +3,8 @@ use serde::Serialize;
 use crate::Span;
 
 use super::{
-    ArenaVec, Attribute, ClassDecl, Comment, EnumDecl, Expr, FunctionDecl, InterfaceDecl, Name,
-    TraitDecl,
+    ArenaVec, Attribute, ClassDecl, Comment, EnumDecl, Expr, FunctionDecl, Ident, InterfaceDecl,
+    Name, TraitDecl,
 };
 
 #[derive(Debug, Serialize)]
@@ -55,7 +55,7 @@ pub enum StmtKind<'arena, 'src> {
     Switch(&'arena SwitchStmt<'arena, 'src>),
 
     /// Goto statement
-    Goto(&'src str),
+    Goto(Ident<'src>),
 
     /// Label statement
     Label(&'arena str),
@@ -230,7 +230,7 @@ pub struct UseItem<'arena, 'src> {
 
 #[derive(Debug, Serialize)]
 pub struct ConstItem<'arena, 'src> {
-    pub name: &'src str,
+    pub name: Ident<'src>,
     pub value: Expr<'arena, 'src>,
     pub attributes: ArenaVec<'arena, Attribute<'arena, 'src>>,
     pub span: Span,
@@ -240,7 +240,7 @@ pub struct ConstItem<'arena, 'src> {
 
 #[derive(Debug, Serialize)]
 pub struct StaticVar<'arena, 'src> {
-    pub name: &'src str,
+    pub name: Ident<'src>,
     pub default: Option<Expr<'arena, 'src>>,
     pub span: Span,
 }

--- a/crates/php-ast/src/visitor.rs
+++ b/crates/php-ast/src/visitor.rs
@@ -1039,34 +1039,36 @@ impl<'arena, 'src, V: ScopeVisitor<'arena, 'src>> Visitor<'arena, 'src> for Scop
         self.inner.visit_stmt(stmt, &self.scope)?;
         match &stmt.kind {
             StmtKind::Function(func) => {
-                let prev_fn = self.scope.function_name.replace(func.name);
+                let prev_fn = std::mem::replace(&mut self.scope.function_name, func.name.as_str());
                 walk_stmt(self, stmt)?;
                 self.scope.function_name = prev_fn;
             }
             StmtKind::Class(class) => {
                 let prev_class = self.scope.class_name;
                 let prev_fn = self.scope.function_name.take();
-                self.scope.class_name = class.name;
+                self.scope.class_name = class.name.and_then(|n| n.as_str());
                 walk_stmt(self, stmt)?;
                 self.scope.class_name = prev_class;
                 self.scope.function_name = prev_fn;
             }
             StmtKind::Interface(iface) => {
-                let prev_class = self.scope.class_name.replace(iface.name);
+                let prev_class = std::mem::replace(&mut self.scope.class_name, iface.name.as_str());
                 let prev_fn = self.scope.function_name.take();
                 walk_stmt(self, stmt)?;
                 self.scope.class_name = prev_class;
                 self.scope.function_name = prev_fn;
             }
             StmtKind::Trait(trait_decl) => {
-                let prev_class = self.scope.class_name.replace(trait_decl.name);
+                let prev_class =
+                    std::mem::replace(&mut self.scope.class_name, trait_decl.name.as_str());
                 let prev_fn = self.scope.function_name.take();
                 walk_stmt(self, stmt)?;
                 self.scope.class_name = prev_class;
                 self.scope.function_name = prev_fn;
             }
             StmtKind::Enum(enum_decl) => {
-                let prev_class = self.scope.class_name.replace(enum_decl.name);
+                let prev_class =
+                    std::mem::replace(&mut self.scope.class_name, enum_decl.name.as_str());
                 let prev_fn = self.scope.function_name.take();
                 walk_stmt(self, stmt)?;
                 self.scope.class_name = prev_class;
@@ -1126,7 +1128,7 @@ impl<'arena, 'src, V: ScopeVisitor<'arena, 'src>> Visitor<'arena, 'src> for Scop
     fn visit_class_member(&mut self, member: &ClassMember<'arena, 'src>) -> ControlFlow<()> {
         self.inner.visit_class_member(member, &self.scope)?;
         if let ClassMemberKind::Method(method) = &member.kind {
-            let prev_fn = self.scope.function_name.replace(method.name);
+            let prev_fn = std::mem::replace(&mut self.scope.function_name, method.name.as_str());
             walk_class_member(self, member)?;
             self.scope.function_name = prev_fn;
         } else {
@@ -1138,7 +1140,7 @@ impl<'arena, 'src, V: ScopeVisitor<'arena, 'src>> Visitor<'arena, 'src> for Scop
     fn visit_enum_member(&mut self, member: &EnumMember<'arena, 'src>) -> ControlFlow<()> {
         self.inner.visit_enum_member(member, &self.scope)?;
         if let EnumMemberKind::Method(method) = &member.kind {
-            let prev_fn = self.scope.function_name.replace(method.name);
+            let prev_fn = std::mem::replace(&mut self.scope.function_name, method.name.as_str());
             walk_enum_member(self, member)?;
             self.scope.function_name = prev_fn;
         } else {
@@ -1357,7 +1359,7 @@ mod tests {
             span: Span::DUMMY,
         });
         let func = arena.alloc(FunctionDecl {
-            name: "foo",
+            name: Ident::name("foo"),
             params: ArenaVec::new_in(&arena),
             body: func_body,
             return_type: None,

--- a/crates/php-parser/src/diagnostics.rs
+++ b/crates/php-parser/src/diagnostics.rs
@@ -3,9 +3,6 @@ use php_lexer::TokenKind;
 use std::borrow::Cow;
 use thiserror::Error;
 
-/// Placeholder name used in recovered AST nodes when the real name could not be parsed.
-pub(crate) const ERROR_PLACEHOLDER: &str = "<error>";
-
 /// A parse error or diagnostic emitted during parsing.
 ///
 /// The parser recovers from all errors and always produces a complete AST,

--- a/crates/php-parser/src/expr/atom.rs
+++ b/crates/php-parser/src/expr/atom.rs
@@ -634,13 +634,21 @@ pub(super) fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> 
         TokenKind::Backslash => {
             let start = parser.start_span();
             let name = parser.parse_name();
-            let ident = match name.to_string_repr() {
-                Cow::Borrowed(s) => NameStr::Src(s),
-                Cow::Owned(ref s) => NameStr::Arena(parser.arena.alloc_str(s)),
-            };
-            Expr {
-                kind: ExprKind::Identifier(ident),
-                span: Span::new(start, name.span().end),
+            let span = Span::new(start, name.span().end);
+            if matches!(name, Name::Error { .. }) {
+                Expr {
+                    kind: ExprKind::Error,
+                    span,
+                }
+            } else {
+                let ident = match name.to_string_repr() {
+                    Cow::Borrowed(s) => NameStr::Src(s),
+                    Cow::Owned(ref s) => NameStr::Arena(parser.arena.alloc_str(s)),
+                };
+                Expr {
+                    kind: ExprKind::Identifier(ident),
+                    span,
+                }
             }
         }
 
@@ -1062,12 +1070,20 @@ pub(super) fn parse_atom<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> 
         TokenKind::Namespace if parser.peek_kind() == Some(TokenKind::Backslash) => {
             let start = parser.start_span();
             let name = parser.parse_name();
-            let text = parser
-                .arena
-                .alloc_str(&format!("namespace\\{}", name.join_parts()));
-            Expr {
-                kind: ExprKind::Identifier(NameStr::Arena(text)),
-                span: Span::new(start, name.span().end),
+            let span = Span::new(start, name.span().end);
+            if matches!(name, Name::Error { .. }) {
+                Expr {
+                    kind: ExprKind::Error,
+                    span,
+                }
+            } else {
+                let text = parser
+                    .arena
+                    .alloc_str(&format!("namespace\\{}", name.join_parts()));
+                Expr {
+                    kind: ExprKind::Identifier(NameStr::Arena(text)),
+                    span,
+                }
             }
         }
         TokenKind::Namespace => {
@@ -1237,13 +1253,21 @@ fn parse_new_expr<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Expr<'a
         _ => {
             // Parse as a name (possibly qualified)
             let name = parser.parse_name();
-            let ident = match name.to_string_repr() {
-                Cow::Borrowed(s) => NameStr::Src(s),
-                Cow::Owned(ref s) => NameStr::Arena(parser.arena.alloc_str(s)),
-            };
-            Expr {
-                kind: ExprKind::Identifier(ident),
-                span: name.span(),
+            let span = name.span();
+            if matches!(name, Name::Error { .. }) {
+                Expr {
+                    kind: ExprKind::Error,
+                    span,
+                }
+            } else {
+                let ident = match name.to_string_repr() {
+                    Cow::Borrowed(s) => NameStr::Src(s),
+                    Cow::Owned(ref s) => NameStr::Arena(parser.arena.alloc_str(s)),
+                };
+                Expr {
+                    kind: ExprKind::Identifier(ident),
+                    span,
+                }
             }
         }
     };

--- a/crates/php-parser/src/expr/mod.rs
+++ b/crates/php-parser/src/expr/mod.rs
@@ -1,7 +1,7 @@
 use php_ast::*;
 use php_lexer::TokenKind;
 
-use crate::diagnostics::{ParseError, ERROR_PLACEHOLDER};
+use crate::diagnostics::ParseError;
 use crate::instrument;
 use crate::parser::{Parser, MAX_DEPTH};
 use crate::precedence::{self, ASSIGNMENT_BP, NULL_COALESCE_LEFT_BP, TERNARY_BP};
@@ -547,13 +547,18 @@ pub fn parse_expr_bp<'arena, 'src>(
                     if let Some(result) = parser.eat_identifier_or_keyword() {
                         result
                     } else {
-                        let span = parser.current_span();
+                        let err_span = parser.current_span();
                         parser.error(ParseError::Expected {
                             expected: "identifier".into(),
                             found: parser.current_kind(),
-                            span,
+                            span: err_span,
                         });
-                        (ERROR_PLACEHOLDER, span)
+                        let span = Span::new(lhs.span.start, err_span.end);
+                        lhs = Expr {
+                            kind: ExprKind::Error,
+                            span,
+                        };
+                        continue;
                     };
 
                 if parser.check(TokenKind::LeftParen) {

--- a/crates/php-parser/src/parser.rs
+++ b/crates/php-parser/src/parser.rs
@@ -278,10 +278,22 @@ impl<'arena, 'src> Parser<'arena, 'src> {
     pub fn variable_name(&self, token: Token) -> &'src str {
         let start = token.span.start as usize;
         let end = token.span.end as usize;
-        if start < end {
+        if start + 1 < end {
             &self.source[start + 1..end]
         } else {
             ""
+        }
+    }
+
+    /// Like [`variable_name`] but returns an [`Ident`] — empty/zero-length
+    /// inputs yield [`Ident::ERROR`].
+    #[inline]
+    pub fn variable_ident(&self, token: Token) -> Ident<'src> {
+        let s = self.variable_name(token);
+        if s.is_empty() {
+            Ident::ERROR
+        } else {
+            Ident::name(s)
         }
     }
 

--- a/crates/php-parser/src/parser.rs
+++ b/crates/php-parser/src/parser.rs
@@ -1,7 +1,7 @@
 use php_ast::*;
 use php_lexer::{Lexer, LexerError, LexerErrorKind, Token, TokenKind};
 
-use crate::diagnostics::{ParseError, ERROR_PLACEHOLDER};
+use crate::diagnostics::ParseError;
 use crate::expr;
 use crate::instrument;
 use crate::stmt;
@@ -675,12 +675,14 @@ impl<'arena, 'src> Parser<'arena, 'src> {
             if let Some((text, span)) = self.eat_identifier_or_keyword() {
                 (text, span)
             } else {
+                let err_span = self.current_span();
                 self.error(ParseError::Expected {
                     expected: "identifier".into(),
                     found: self.current_kind(),
-                    span: self.current_span(),
+                    span: err_span,
                 });
-                (ERROR_PLACEHOLDER, self.current_span())
+                let span = Span::new(start, err_span.end);
+                return Name::Error { span };
             };
 
         // Fast path: single unqualified identifier (the common case, ~95% of names).

--- a/crates/php-parser/src/stmt/class.rs
+++ b/crates/php-parser/src/stmt/class.rs
@@ -1,7 +1,7 @@
 use php_ast::*;
 use php_lexer::TokenKind;
 
-use crate::diagnostics::{ParseError, ERROR_PLACEHOLDER};
+use crate::diagnostics::ParseError;
 use crate::expr;
 use crate::instrument;
 use crate::parser::Parser;
@@ -45,21 +45,23 @@ pub(super) fn parse_class<'arena, 'src>(
     parser.advance(); // consume 'class'
 
     let (name, name_span) = if let Some((text, span)) = parser.eat_identifier_or_keyword() {
-        (text, span)
+        (Ident::name(text), span)
     } else {
         parser.error(ParseError::Expected {
             expected: "class name".into(),
             found: parser.current_kind(),
             span: parser.current_span(),
         });
-        (ERROR_PLACEHOLDER, parser.current_span())
+        (Ident::ERROR, parser.current_span())
     };
 
-    if is_reserved_class_name(name) {
-        parser.error(ParseError::Forbidden {
-            message: format!("cannot use '{}' as class name", name).into(),
-            span: name_span,
-        });
+    if let Some(text) = name.as_str() {
+        if is_reserved_class_name(text) {
+            parser.error(ParseError::Forbidden {
+                message: format!("cannot use '{}' as class name", text).into(),
+                span: name_span,
+            });
+        }
     }
 
     let extends = if parser.eat(TokenKind::Extends).is_some() {
@@ -626,7 +628,7 @@ fn parse_class_const_member<'arena, 'src>(
     let mut const_items = parser.alloc_vec();
     loop {
         let const_name = if let Some((text, _)) = parser.eat_identifier_or_keyword() {
-            text
+            Ident::name(text)
         } else {
             let span = parser.current_span();
             parser.error(ParseError::Expected {
@@ -634,7 +636,7 @@ fn parse_class_const_member<'arena, 'src>(
                 found: parser.current_kind(),
                 span,
             });
-            ERROR_PLACEHOLDER
+            Ident::ERROR
         };
         parser.expect(TokenKind::Equals);
         let value = expr::parse_expr(parser);
@@ -697,14 +699,14 @@ fn parse_method_member<'arena, 'src>(
     parser.advance(); // consume `function`
     let by_ref = parser.eat(TokenKind::Ampersand).is_some();
     let method_name = if let Some((text, _)) = parser.eat_identifier_or_keyword() {
-        text
+        Ident::name(text)
     } else {
         parser.error(ParseError::Expected {
             expected: "method name".into(),
             found: parser.current_kind(),
             span: parser.current_span(),
         });
-        ERROR_PLACEHOLDER
+        Ident::ERROR
     };
 
     parser.expect(TokenKind::LeftParen);
@@ -778,7 +780,7 @@ fn parse_property_member<'arena, 'src>(
     type_hint: Option<TypeHint<'arena, 'src>>,
 ) {
     let var_token = parser.advance();
-    let prop_name = parser.variable_name(var_token);
+    let prop_name = parser.variable_ident(var_token);
 
     let default = if parser.eat(TokenKind::Equals).is_some() {
         // Suppress `{` subscript so a following hook block `{ get => ...; }`
@@ -840,7 +842,7 @@ fn parse_property_member<'arena, 'src>(
     } else if parser.eat(TokenKind::Comma).is_some() {
         while parser.check(TokenKind::Variable) {
             let var_token = parser.advance();
-            let pname = parser.variable_name(var_token);
+            let pname = parser.variable_ident(var_token);
 
             let pdefault = if parser.eat(TokenKind::Equals).is_some() {
                 Some(expr::parse_expr(parser))
@@ -899,21 +901,23 @@ pub(super) fn parse_interface<'arena, 'src>(
     let start = parser.start_span();
     parser.advance();
     let (name, name_span) = if let Some((text, span)) = parser.eat_identifier_or_keyword() {
-        (text, span)
+        (Ident::name(text), span)
     } else {
         parser.error(ParseError::Expected {
             expected: "interface name".into(),
             found: parser.current_kind(),
             span: parser.current_span(),
         });
-        (ERROR_PLACEHOLDER, parser.current_span())
+        (Ident::ERROR, parser.current_span())
     };
 
-    if is_reserved_class_name(name) {
-        parser.error(ParseError::Forbidden {
-            message: format!("cannot use '{}' as interface name", name).into(),
-            span: name_span,
-        });
+    if let Some(text) = name.as_str() {
+        if is_reserved_class_name(text) {
+            parser.error(ParseError::Forbidden {
+                message: format!("cannot use '{}' as interface name", text).into(),
+                span: name_span,
+            });
+        }
     }
 
     let extends = if parser.eat(TokenKind::Extends).is_some() {
@@ -953,14 +957,14 @@ pub(super) fn parse_trait<'arena, 'src>(
     let start = parser.start_span();
     parser.advance();
     let name = if let Some((text, _)) = parser.eat_identifier_or_keyword() {
-        text
+        Ident::name(text)
     } else {
         parser.error(ParseError::Expected {
             expected: "trait name".into(),
             found: parser.current_kind(),
             span: parser.current_span(),
         });
-        ERROR_PLACEHOLDER
+        Ident::ERROR
     };
 
     parser.expect(TokenKind::LeftBrace);

--- a/crates/php-parser/src/stmt/enum_decl.rs
+++ b/crates/php-parser/src/stmt/enum_decl.rs
@@ -1,7 +1,7 @@
 use php_ast::*;
 use php_lexer::TokenKind;
 
-use crate::diagnostics::{ParseError, ERROR_PLACEHOLDER};
+use crate::diagnostics::ParseError;
 use crate::expr;
 use crate::parser::Parser;
 use crate::version::PhpVersion;
@@ -14,14 +14,14 @@ pub(super) fn parse_enum<'arena, 'src>(
     parser.advance(); // consume 'enum'
 
     let name = if let Some((text, _)) = parser.eat_identifier_or_keyword() {
-        text
+        Ident::name(text)
     } else {
         parser.error(ParseError::Expected {
             expected: "enum name".into(),
             found: parser.current_kind(),
             span: parser.current_span(),
         });
-        ERROR_PLACEHOLDER
+        Ident::ERROR
     };
 
     // Backed enum: enum Foo: string
@@ -86,7 +86,7 @@ pub(super) fn parse_enum<'arena, 'src>(
             }
             let (case_name, case_name_span) =
                 if let Some((text, span)) = parser.eat_identifier_or_keyword() {
-                    (text, span)
+                    (Ident::name(text), span)
                 } else {
                     let span = parser.current_span();
                     parser.error(ParseError::Expected {
@@ -94,7 +94,7 @@ pub(super) fn parse_enum<'arena, 'src>(
                         found: parser.current_kind(),
                         span,
                     });
-                    (ERROR_PLACEHOLDER, span)
+                    (Ident::ERROR, span)
                 };
             let equals_token = parser.eat(TokenKind::Equals);
             let value = if equals_token.is_some() {
@@ -221,14 +221,14 @@ pub(super) fn parse_enum<'arena, 'src>(
             };
 
             let const_name = if let Some((text, _)) = parser.eat_identifier_or_keyword() {
-                text
+                Ident::name(text)
             } else {
                 parser.error(ParseError::Expected {
                     expected: "constant name".into(),
                     found: parser.current_kind(),
                     span: parser.current_span(),
                 });
-                ERROR_PLACEHOLDER
+                Ident::ERROR
             };
             parser.expect(TokenKind::Equals);
             let value = expr::parse_expr(parser);
@@ -261,9 +261,9 @@ pub(super) fn parse_enum<'arena, 'src>(
             parser.advance();
             let by_ref = parser.eat(TokenKind::Ampersand).is_some();
             let method_name = if let Some((text, _)) = parser.eat_identifier_or_keyword() {
-                text
+                Ident::name(text)
             } else {
-                ERROR_PLACEHOLDER
+                Ident::ERROR
             };
 
             parser.expect(TokenKind::LeftParen);

--- a/crates/php-parser/src/stmt/mod.rs
+++ b/crates/php-parser/src/stmt/mod.rs
@@ -1918,6 +1918,7 @@ fn parse_use<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Stmt<'arena,
                             cp.push(p);
                         }
                     }
+                    Name::Error { .. } => {}
                 }
                 cp
             };

--- a/crates/php-parser/src/stmt/mod.rs
+++ b/crates/php-parser/src/stmt/mod.rs
@@ -1,7 +1,7 @@
 use php_ast::*;
 use php_lexer::TokenKind;
 
-use crate::diagnostics::{ParseError, ERROR_PLACEHOLDER};
+use crate::diagnostics::ParseError;
 use crate::expr;
 use crate::instrument;
 use crate::parser::Parser;
@@ -1060,14 +1060,14 @@ fn parse_function<'arena, 'src>(
     let by_ref = parser.eat(TokenKind::Ampersand).is_some();
 
     let name = if let Some((text, _)) = parser.eat_identifier_or_keyword() {
-        text
+        Ident::name(text)
     } else {
         parser.error(ParseError::Expected {
             expected: "function name".into(),
             found: parser.current_kind(),
             span: parser.current_span(),
         });
-        ERROR_PLACEHOLDER
+        Ident::ERROR
     };
 
     let open_paren = parser.expect(TokenKind::LeftParen);
@@ -1262,9 +1262,9 @@ pub fn parse_param_list<'arena, 'src>(
 
         let name_token = parser.expect(TokenKind::Variable);
         let name_span_end = name_token.as_ref().map(|t| t.span.end);
-        let name: &str = name_token
-            .map(|t| parser.variable_name(t))
-            .unwrap_or(ERROR_PLACEHOLDER);
+        let name = name_token
+            .map(|t| parser.variable_ident(t))
+            .unwrap_or(Ident::ERROR);
 
         let default = if parser.eat(TokenKind::Equals).is_some() {
             if visibility.is_some() {
@@ -1346,7 +1346,7 @@ fn try_parse_simple_param_fastpath_minimal<'arena, 'src>(
     // Safe to fast path. Now consume the tokens.
     let name_token = parser.advance();
     let name_span_end = name_token.span.end;
-    let name: &str = parser.variable_name(name_token);
+    let name = parser.variable_ident(name_token);
 
     Some(Param {
         name,
@@ -1644,9 +1644,9 @@ fn parse_goto<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Stmt<'arena
     parser.advance();
     let name_token = parser.expect(TokenKind::Identifier);
     let src = parser.source;
-    let name: &str = name_token
-        .map(|t| &src[t.span.start as usize..t.span.end as usize])
-        .unwrap_or(ERROR_PLACEHOLDER);
+    let name = name_token
+        .map(|t| Ident::name(&src[t.span.start as usize..t.span.end as usize]))
+        .unwrap_or(Ident::ERROR);
     parser.expect(TokenKind::Semicolon);
     let span = Span::new(start, parser.previous_end());
     Stmt {
@@ -2023,14 +2023,14 @@ fn parse_const_with_attrs<'arena, 'src>(
     loop {
         let item_start = parser.start_span();
         let const_name = if let Some((text, _)) = parser.eat_identifier_or_keyword() {
-            text
+            Ident::name(text)
         } else {
             parser.error(ParseError::Expected {
                 expected: "constant name".into(),
                 found: parser.current_kind(),
                 span: parser.current_span(),
             });
-            ERROR_PLACEHOLDER
+            Ident::ERROR
         };
         parser.expect(TokenKind::Equals);
         let value = expr::parse_expr(parser);
@@ -2112,9 +2112,9 @@ fn parse_static_var<'arena, 'src>(parser: &'_ mut Parser<'arena, 'src>) -> Stmt<
     loop {
         let var_start = parser.start_span();
         let var_token = parser.expect(TokenKind::Variable);
-        let name: &str = var_token
-            .map(|t| parser.variable_name(t))
-            .unwrap_or(ERROR_PLACEHOLDER);
+        let name = var_token
+            .map(|t| parser.variable_ident(t))
+            .unwrap_or(Ident::ERROR);
 
         let default = if parser.eat(TokenKind::Equals).is_some() {
             Some(expr::parse_expr(parser))

--- a/crates/php-parser/src/stmt/trait_use.rs
+++ b/crates/php-parser/src/stmt/trait_use.rs
@@ -1,7 +1,7 @@
 use php_ast::*;
 use php_lexer::TokenKind;
 
-use crate::diagnostics::{ParseError, ERROR_PLACEHOLDER};
+use crate::diagnostics::ParseError;
 use crate::parser::Parser;
 
 /// Parse trait adaptation block: `{ A::foo insteadof B; foo as bar; ... }`
@@ -28,10 +28,7 @@ pub(super) fn parse_trait_adaptations<'arena, 'src>(
                     found: parser.current_kind(),
                     span,
                 });
-                Name::Simple {
-                    value: ERROR_PLACEHOLDER,
-                    span,
-                }
+                Name::Error { span }
             };
 
             // Check for `insteadof` or `as`

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_12.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_12.phpt
@@ -15,9 +15,7 @@ expected ';' after expression
           "kind": {
             "New": {
               "class": {
-                "kind": {
-                  "Identifier": "<error>"
-                },
+                "kind": "Error",
                 "span": {
                   "start": 9,
                   "end": 9

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_12_php82.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_12_php82.phpt
@@ -15,9 +15,7 @@ expected ';' after expression
           "kind": {
             "New": {
               "class": {
-                "kind": {
-                  "Identifier": "<error>"
-                },
+                "kind": "Error",
                 "span": {
                   "start": 9,
                   "end": 9

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_16.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_16.phpt
@@ -3,41 +3,11 @@
 Foo::
 ===errors===
 expected identifier, found end of file
-expected ';' after expression
 ===ast===
 {
   "stmts": [
     {
-      "kind": {
-        "Expression": {
-          "kind": {
-            "ClassConstAccess": {
-              "class": {
-                "kind": {
-                  "Identifier": "Foo"
-                },
-                "span": {
-                  "start": 6,
-                  "end": 9
-                }
-              },
-              "member": {
-                "kind": {
-                  "Identifier": "<error>"
-                },
-                "span": {
-                  "start": 11,
-                  "end": 11
-                }
-              }
-            }
-          },
-          "span": {
-            "start": 6,
-            "end": 11
-          }
-        }
-      },
+      "kind": "Error",
       "span": {
         "start": 6,
         "end": 11

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_19.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_19.phpt
@@ -25,38 +25,17 @@ expected identifier, found ')'
                 {
                   "name": null,
                   "value": {
-                    "kind": {
-                      "ClassConstAccess": {
-                        "class": {
-                          "kind": {
-                            "Identifier": "Bar"
-                          },
-                          "span": {
-                            "start": 11,
-                            "end": 14
-                          }
-                        },
-                        "member": {
-                          "kind": {
-                            "Identifier": "<error>"
-                          },
-                          "span": {
-                            "start": 16,
-                            "end": 17
-                          }
-                        }
-                      }
-                    },
+                    "kind": "Error",
                     "span": {
                       "start": 11,
-                      "end": 16
+                      "end": 17
                     }
                   },
                   "unpack": false,
                   "by_ref": false,
                   "span": {
                     "start": 11,
-                    "end": 16
+                    "end": 17
                   }
                 }
               ]

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_22.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_22.phpt
@@ -47,7 +47,7 @@ unclosed ''}'' opened at Span { start: 171, end: 176 }
           "name": "foo",
           "params": [
             {
-              "name": "<error>",
+              "name": null,
               "type_hint": {
                 "kind": {
                   "Named": {
@@ -148,7 +148,7 @@ unclosed ''}'' opened at Span { start: 171, end: 176 }
               }
             },
             {
-              "name": "<error>",
+              "name": null,
               "type_hint": {
                 "kind": {
                   "Named": {
@@ -216,7 +216,7 @@ unclosed ''}'' opened at Span { start: 171, end: 176 }
           "name": "foo",
           "params": [
             {
-              "name": "<error>",
+              "name": null,
               "type_hint": null,
               "default": null,
               "by_ref": false,
@@ -267,7 +267,7 @@ unclosed ''}'' opened at Span { start: 171, end: 176 }
           "name": "foo",
           "params": [
             {
-              "name": "<error>",
+              "name": null,
               "type_hint": null,
               "default": null,
               "by_ref": true,
@@ -318,7 +318,7 @@ unclosed ''}'' opened at Span { start: 171, end: 176 }
           "name": "foo",
           "params": [
             {
-              "name": "<error>",
+              "name": null,
               "type_hint": {
                 "kind": {
                   "Named": {
@@ -375,7 +375,7 @@ unclosed ''}'' opened at Span { start: 171, end: 176 }
                           "by_ref": false,
                           "params": [
                             {
-                              "name": "<error>",
+                              "name": null,
                               "type_hint": {
                                 "kind": {
                                   "Named": {
@@ -436,7 +436,7 @@ unclosed ''}'' opened at Span { start: 171, end: 176 }
                       "by_ref": false,
                       "params": [
                         {
-                          "name": "<error>",
+                          "name": null,
                           "type_hint": {
                             "kind": {
                               "Named": {

--- a/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_24.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/errorHandling/recovery_24.phpt
@@ -36,10 +36,8 @@ expected identifier, found '{'
           "return_type": {
             "kind": {
               "Named": {
-                "parts": [
-                  "<error>"
-                ],
-                "kind": "Unqualified",
+                "parts": [],
+                "kind": "Error",
                 "span": {
                   "start": 23,
                   "end": 24

--- a/crates/php-parser/tests/fixtures/corpus/expr/newWithoutClass.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/newWithoutClass.phpt
@@ -14,9 +14,7 @@ expected identifier, found ';'
           "kind": {
             "New": {
               "class": {
-                "kind": {
-                  "Identifier": "<error>"
-                },
+                "kind": "Error",
                 "span": {
                   "start": 9,
                   "end": 10

--- a/crates/php-parser/tests/fixtures/corpus/expr/newWithoutClass_php82.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/expr/newWithoutClass_php82.phpt
@@ -14,9 +14,7 @@ expected identifier, found ';'
           "kind": {
             "New": {
               "class": {
-                "kind": {
-                  "Identifier": "<error>"
-                },
+                "kind": "Error",
                 "span": {
                   "start": 9,
                   "end": 10

--- a/crates/php-parser/tests/fixtures/errors/catch_missing_exception.phpt
+++ b/crates/php-parser/tests/fixtures/errors/catch_missing_exception.phpt
@@ -15,10 +15,8 @@ expected ')', found '{'
             {
               "types": [
                 {
-                  "parts": [
-                    "<error>"
-                  ],
-                  "kind": "Unqualified",
+                  "parts": [],
+                  "kind": "Error",
                   "span": {
                     "start": 20,
                     "end": 21

--- a/crates/php-parser/tests/fixtures/errors/class_error_then_valid_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_error_then_valid_class.phpt
@@ -24,7 +24,7 @@ expected ';', found '}'
             {
               "kind": {
                 "Method": {
-                  "name": "<error>",
+                  "name": null,
                   "visibility": "Public",
                   "is_static": false,
                   "is_abstract": false,
@@ -32,7 +32,7 @@ expected ';', found '}'
                   "by_ref": false,
                   "params": [
                     {
-                      "name": "<error>",
+                      "name": null,
                       "type_hint": null,
                       "default": null,
                       "by_ref": false,

--- a/crates/php-parser/tests/fixtures/errors/class_invalid_extends.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_invalid_extends.phpt
@@ -15,10 +15,8 @@ expected identifier, found '{'
             "is_readonly": false
           },
           "extends": {
-            "parts": [
-              "<error>"
-            ],
-            "kind": "Unqualified",
+            "parts": [],
+            "kind": "Error",
             "span": {
               "start": 25,
               "end": 26

--- a/crates/php-parser/tests/fixtures/errors/class_invalid_implements.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_invalid_implements.phpt
@@ -17,10 +17,8 @@ expected identifier, found '{'
           "extends": null,
           "implements": [
             {
-              "parts": [
-                "<error>"
-              ],
-              "kind": "Unqualified",
+              "parts": [],
+              "kind": "Error",
               "span": {
                 "start": 28,
                 "end": 29

--- a/crates/php-parser/tests/fixtures/errors/class_method_error_then_valid_method.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_method_error_then_valid_method.phpt
@@ -31,7 +31,7 @@ expected variable, found ')'
                   "by_ref": false,
                   "params": [
                     {
-                      "name": "<error>",
+                      "name": null,
                       "type_hint": {
                         "kind": {
                           "Named": {

--- a/crates/php-parser/tests/fixtures/errors/class_missing_name.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_missing_name.phpt
@@ -8,7 +8,7 @@ expected class name, found '{'
     {
       "kind": {
         "Class": {
-          "name": "<error>",
+          "name": null,
           "modifiers": {
             "is_abstract": false,
             "is_final": false,

--- a/crates/php-parser/tests/fixtures/errors/class_missing_name_then_valid_function.phpt
+++ b/crates/php-parser/tests/fixtures/errors/class_missing_name_then_valid_function.phpt
@@ -8,7 +8,7 @@ expected class name, found '{'
     {
       "kind": {
         "Class": {
-          "name": "<error>",
+          "name": null,
           "modifiers": {
             "is_abstract": false,
             "is_final": false,

--- a/crates/php-parser/tests/fixtures/errors/function_invalid_return_type.phpt
+++ b/crates/php-parser/tests/fixtures/errors/function_invalid_return_type.phpt
@@ -14,10 +14,8 @@ expected identifier, found '{'
           "return_type": {
             "kind": {
               "Named": {
-                "parts": [
-                  "<error>"
-                ],
-                "kind": "Unqualified",
+                "parts": [],
+                "kind": "Error",
                 "span": {
                   "start": 23,
                   "end": 24

--- a/crates/php-parser/tests/fixtures/errors/invalid_double_readonly_anonymous_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_double_readonly_anonymous_class.phpt
@@ -39,7 +39,7 @@ expected class name, found '{'
     {
       "kind": {
         "Class": {
-          "name": "<error>",
+          "name": null,
           "modifiers": {
             "is_abstract": false,
             "is_final": false,

--- a/crates/php-parser/tests/fixtures/errors/invalid_double_readonly_anonymous_class_php82.phpt
+++ b/crates/php-parser/tests/fixtures/errors/invalid_double_readonly_anonymous_class_php82.phpt
@@ -39,7 +39,7 @@ expected class name, found '{'
     {
       "kind": {
         "Class": {
-          "name": "<error>",
+          "name": null,
           "modifiers": {
             "is_abstract": false,
             "is_final": false,

--- a/crates/php-parser/tests/fixtures/errors/namespace_error_then_valid_namespace.phpt
+++ b/crates/php-parser/tests/fixtures/errors/namespace_error_then_valid_namespace.phpt
@@ -9,10 +9,8 @@ expected identifier, found ';'
       "kind": {
         "Namespace": {
           "name": {
-            "parts": [
-              "<error>"
-            ],
-            "kind": "Unqualified",
+            "parts": [],
+            "kind": "Error",
             "span": {
               "start": 16,
               "end": 17

--- a/crates/php-parser/tests/fixtures/errors/namespace_missing_name.phpt
+++ b/crates/php-parser/tests/fixtures/errors/namespace_missing_name.phpt
@@ -9,10 +9,8 @@ expected identifier, found ';'
       "kind": {
         "Namespace": {
           "name": {
-            "parts": [
-              "<error>"
-            ],
-            "kind": "Unqualified",
+            "parts": [],
+            "kind": "Error",
             "span": {
               "start": 15,
               "end": 16

--- a/crates/php-parser/tests/fixtures/errors/repeated_union_types.phpt
+++ b/crates/php-parser/tests/fixtures/errors/repeated_union_types.phpt
@@ -11,7 +11,7 @@ expected variable, found ')'
           "name": "f",
           "params": [
             {
-              "name": "<error>",
+              "name": null,
               "type_hint": {
                 "kind": {
                   "Union": [

--- a/crates/php-parser/tests/fixtures/errors/trait_error_then_valid_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/trait_error_then_valid_class.phpt
@@ -17,7 +17,7 @@ expected ';', found '}'
             {
               "kind": {
                 "Method": {
-                  "name": "<error>",
+                  "name": null,
                   "visibility": "Public",
                   "is_static": false,
                   "is_abstract": false,
@@ -25,7 +25,7 @@ expected ';', found '}'
                   "by_ref": false,
                   "params": [
                     {
-                      "name": "<error>",
+                      "name": null,
                       "type_hint": null,
                       "default": null,
                       "by_ref": false,

--- a/crates/php-parser/tests/fixtures/errors/use_error_then_valid_class.phpt
+++ b/crates/php-parser/tests/fixtures/errors/use_error_then_valid_class.phpt
@@ -12,10 +12,8 @@ expected identifier, found ';'
           "uses": [
             {
               "name": {
-                "parts": [
-                  "<error>"
-                ],
-                "kind": "Unqualified",
+                "parts": [],
+                "kind": "Error",
                 "span": {
                   "start": 10,
                   "end": 11

--- a/crates/php-parser/tests/fixtures/errors/use_missing_name.phpt
+++ b/crates/php-parser/tests/fixtures/errors/use_missing_name.phpt
@@ -12,10 +12,8 @@ expected identifier, found ';'
           "uses": [
             {
               "name": {
-                "parts": [
-                  "<error>"
-                ],
-                "kind": "Unqualified",
+                "parts": [],
+                "kind": "Error",
                 "span": {
                   "start": 9,
                   "end": 10

--- a/crates/php-printer/src/printer/decls.rs
+++ b/crates/php-printer/src/printer/decls.rs
@@ -13,7 +13,7 @@ impl Printer {
         if func.by_ref {
             self.w("&");
         }
-        self.w(func.name);
+        self.w(func.name.or_error());
         self.w("(");
         self.print_params(&func.params);
         self.w(")");
@@ -85,7 +85,7 @@ impl Printer {
         self.w("class");
         if let Some(name) = class.name {
             self.w(" ");
-            self.w(name);
+            self.w(name.or_error());
         }
         if let Some(extends) = &class.extends {
             self.w(" extends ");
@@ -152,7 +152,7 @@ impl Printer {
         if method.by_ref {
             self.w("&");
         }
-        self.w(method.name);
+        self.w(method.name.or_error());
         self.w("(");
         self.print_params(&method.params);
         self.w(")");
@@ -198,7 +198,7 @@ impl Printer {
             self.w(" ");
         }
         self.w("$");
-        self.w(prop.name);
+        self.w(prop.name.or_error());
         if let Some(default) = &prop.default {
             self.w(" = ");
             self.print_expr(default, PREC_LOWEST);
@@ -273,7 +273,7 @@ impl Printer {
             self.print_type_hint(th);
             self.w(" ");
         }
-        self.w(cc.name);
+        self.w(cc.name.or_error());
         self.w(" = ");
         self.print_expr(&cc.value, PREC_LOWEST);
         self.w(";");
@@ -347,7 +347,7 @@ impl Printer {
         self.print_doc_comment(&iface.doc_comment);
         self.print_attributes(&iface.attributes);
         self.w("interface ");
-        self.w(iface.name);
+        self.w(iface.name.or_error());
         if !iface.extends.is_empty() {
             self.w(" extends ");
             for (i, name) in iface.extends.iter().enumerate() {
@@ -364,7 +364,7 @@ impl Printer {
         self.print_doc_comment(&trait_decl.doc_comment);
         self.print_attributes(&trait_decl.attributes);
         self.w("trait ");
-        self.w(trait_decl.name);
+        self.w(trait_decl.name.or_error());
         self.print_class_body(&trait_decl.members);
     }
 
@@ -372,7 +372,7 @@ impl Printer {
         self.print_doc_comment(&enum_decl.doc_comment);
         self.print_attributes(&enum_decl.attributes);
         self.w("enum ");
-        self.w(enum_decl.name);
+        self.w(enum_decl.name.or_error());
         if let Some(scalar) = &enum_decl.scalar_type {
             self.w(": ");
             self.print_name(scalar);
@@ -412,7 +412,7 @@ impl Printer {
                 self.print_doc_comment(&case.doc_comment);
                 self.print_attributes(&case.attributes);
                 self.w("case ");
-                self.w(case.name);
+                self.w(case.name.or_error());
                 if let Some(val) = &case.value {
                     self.w(" = ");
                     self.print_expr(val, PREC_LOWEST);
@@ -456,7 +456,7 @@ impl Printer {
                 self.w("&");
             }
             self.w("$");
-            self.w(param.name);
+            self.w(param.name.or_error());
             if let Some(default) = &param.default {
                 self.w(" = ");
                 self.print_expr(default, PREC_LOWEST);

--- a/crates/php-printer/src/printer/stmts.rs
+++ b/crates/php-printer/src/printer/stmts.rs
@@ -126,7 +126,7 @@ impl Printer {
             }
             StmtKind::Goto(label) => {
                 self.w("goto ");
-                self.w(label);
+                self.w(label.or_error());
                 self.w(";");
             }
             StmtKind::Label(label) => {
@@ -183,7 +183,7 @@ impl Printer {
                     if i > 0 {
                         self.w(", ");
                     }
-                    self.w(item.name);
+                    self.w(item.name.or_error());
                     self.w(" = ");
                     self.print_expr(&item.value, PREC_LOWEST);
                 }
@@ -196,7 +196,7 @@ impl Printer {
                         self.w(", ");
                     }
                     self.w("$");
-                    self.w(var.name);
+                    self.w(var.name.or_error());
                     if let Some(default) = &var.default {
                         self.w(" = ");
                         self.print_expr(default, PREC_LOWEST);

--- a/crates/php-printer/src/printer/types.rs
+++ b/crates/php-printer/src/printer/types.rs
@@ -19,6 +19,7 @@ impl Printer {
                     self.w(part);
                 }
             }
+            Name::Error { .. } => self.w("<error>"),
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds a dedicated `Name::Error { span }` variant (and matching `NameKind::Error`) so AST consumers can distinguish parser-synthesised placeholder names from user-written code.
- Replaces the two `Name`-typed `ERROR_PLACEHOLDER` sites — `parse_name` fallback and the trait adaptation method-name fallback — with `Name::Error`.
- Updates `Name`'s `span()`, `kind()`, `src_repr()`, `to_string_repr()`, `join_parts()`, `parts_slice()`, `Debug`, `Serialize` and the printer to handle the new variant.

## Scope

Bare-identifier `&'src str` fields (function/class/parameter names, enum cases, etc.) still fall back to the `ERROR_PLACEHOLDER` string sentinel. Promoting those to a typed `Ident` would require threading a new type through every AST node with an ident field — that's a substantially larger refactor and out of scope for this issue, which is framed around `Name`-shaped concerns.

## AST snapshot impact

Synthesised names now serialise as `{ "parts": [], "kind": "Error", "span": ... }` instead of `{ "parts": ["<error>"], "kind": "Unqualified", ... }`. 9 fixtures in `errors/` and `corpus/errorHandling/` were regenerated; diffs are exactly that key change with no other movement.

Closes #275