### PR TITLE
chore: release version 0.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.7] - 2026-05-06
+
+### Added
+
+- Context-aware anchor sets for error recovery — parser now maintains contextual error recovery anchors to improve diagnostics in various syntactic contexts (issue #276) (`php-rs-parser`).
+
+### Fixed
+
+- Declaration docblocks are now preserved during parsing instead of being dropped (`php-rs-parser`).
+- Parse errors for invalid names now emit `ExprKind::Error` instead of `Identifier("<error>")`, improving error diagnostics (`php-rs-parser`).
+- `Name::Error` variant added for synthesized error names during error recovery (`php-ast`, `php-rs-parser`).
+- Enum constant validation: private enum constants now properly reject the `final` modifier (`php-rs-parser`).
+- Enum constant validation: static and abstract modifiers on enum constants now properly validated (`php-rs-parser`).
+- PHP version-specific error message handling aligned across all PHP 8.1–8.5 error recovery fixtures (`php-rs-parser`).
+
+### Changed
+
+- Internal refactoring: `ERROR_PLACEHOLDER` string literals replaced with typed `Ident` at declaration name sites (`php-rs-parser`).
+
+### Tests
+
+- Comprehensive enum constant parser and printer coverage (`php-rs-parser`, `php-printer`).
+- Expression span edge-case fixtures from parser audit (`php-rs-parser`).
+- Version-specific interface and trait error recovery fixtures for PHP 8.1–8.5 coverage (`php-rs-parser`).
+- Comprehensive error recovery fixtures for various syntactic contexts (issue #276) (`php-rs-parser`).
+
+---
+
 ## [0.9.6] - 2026-04-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.6"
+version = "0.9.7"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -25,10 +25,10 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.9.6" }
-php-lexer = { path = "crates/php-lexer", version = "0.9.6" }
-php-rs-parser = { path = "crates/php-parser", version = "0.9.6" }
-php-printer = { path = "crates/php-printer", version = "0.9.6" }
+php-ast = { path = "crates/php-ast", version = "0.9.7" }
+php-lexer = { path = "crates/php-lexer", version = "0.9.7" }
+php-rs-parser = { path = "crates/php-parser", version = "0.9.7" }
+php-printer = { path = "crates/php-printer", version = "0.9.7" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }

--- a/crates/php-parser/tests/fixtures/categories/phpdoc/readonly_class_with_docblock.phpt
+++ b/crates/php-parser/tests/fixtures/categories/phpdoc/readonly_class_with_docblock.phpt
@@ -1,3 +1,5 @@
+===config===
+min_php=8.2
 ===source===
 <?php
 

--- a/crates/php-printer/src/printer/decls.rs
+++ b/crates/php-printer/src/printer/decls.rs
@@ -499,7 +499,8 @@ impl Printer {
                     self.newline();
                     self.write_indent();
                 }
-                self.w(line.trim_end());
+                let trimmed = if i == 0 { line.trim_end() } else { line.trim() };
+                self.w(trimmed);
             }
             self.newline();
             self.write_indent();


### PR DESCRIPTION
## Summary
- Updated all workspace crates to version 0.9.7
- Added comprehensive changelog covering error recovery improvements, enum constant validation fixes, and docblock preservation
- 20+ commits since v0.9.6 including parser robustness enhancements and test coverage expansion

## Changes
- **Added**: Context-aware error recovery anchors (issue #276)
- **Fixed**: Declaration docblocks, error name expressions, enum constant validation
- **Changed**: Internal ERROR_PLACEHOLDER refactoring
- **Tests**: 30+ new fixtures for edge cases and PHP 8.1–8.5 compatibility

## CI Fixes
- **PHP Syntax (8.1)**: Added `min_php=8.2` gating to `readonly_class_with_docblock.phpt` fixture (readonly class syntax is PHP 8.2+)
- **Coverage**: Fixed docblock indentation in printer round-trip tests by normalizing continuation line whitespace