### PR TITLE
ci: run printer tests on single PHP version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Run printer tests
         run: cargo test --test printer
 
+      - name: Validate printer output with php -l
+        run: ./scripts/validate-printer-output.sh
+
   coverage:
     name: Coverage
     needs: [test, printer]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,29 @@ jobs:
           key: ${{ matrix.php-version }}
 
       - name: Run tests
-        run: cargo test --lib && cargo test --test integration && cargo test --test printer
+        run: cargo test --lib && cargo test --test integration
+
+  printer:
+    name: Printer Tests
+    needs: php-syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run printer tests
+        run: cargo test --test printer
 
   coverage:
     name: Coverage
-    needs: test
+    needs: [test, printer]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/scripts/validate-printer-output.sh
+++ b/scripts/validate-printer-output.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+FIXTURES_DIR="crates/php-printer/tests/fixtures"
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+failed=0
+
+for fixture in "$FIXTURES_DIR"/*.phpt; do
+    # Extract the ===print=== section
+    if ! output=$(sed -n '/^===print===/,/^$/p' "$fixture" | tail -n +2 | sed '$ d'); then
+        echo "⚠ Warning: no ===print=== section in $(basename "$fixture"), skipping"
+        continue
+    fi
+
+    # Create temp file with <?php prefix
+    temp_file="$TEMP_DIR/$(basename "$fixture" .phpt).php"
+    echo "<?php" > "$temp_file"
+    echo "$output" >> "$temp_file"
+
+    # Run php -l
+    if ! php -l "$temp_file" > /dev/null 2>&1; then
+        echo "✗ FAIL: $(basename "$fixture")"
+        php -l "$temp_file" || true
+        ((failed++))
+    else
+        echo "✓ $(basename "$fixture")"
+    fi
+done
+
+if [ $failed -gt 0 ]; then
+    echo ""
+    echo "❌ $failed fixture(s) failed PHP syntax validation"
+    exit 1
+else
+    echo ""
+    echo "✅ All printer fixtures pass PHP syntax validation"
+fi


### PR DESCRIPTION
## Summary

Printer tests are version-agnostic and produce identical output regardless of which PHP version was used to parse the input. This change:

1. Extracts printer tests into a separate job that runs only on PHP 8.5, eliminating redundant CI runs across the entire version matrix
2. Adds validation that printer fixture outputs pass `php -l` syntax checking, catching parser divergence where the Rust parser accepts code that PHP rejects

## Changes

- **test** job: runs parser and unit tests across all PHP versions [8.1-8.5]
- **printer** job: runs printer tests once on latest PHP version [8.5]
- **validation** script: ensures printer output is syntactically valid PHP
- **coverage** job: depends on both test and printer to ensure all tests pass

This maintains full test coverage while reducing CI time and catching PHP compatibility issues.