### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-05-09
+
+### Added
+
+- Enhanced parser validation for constructor promotion modifiers — explicitly rejects multiple modifiers on promoted parameters in anonymous classes and refines `readonly` validation on properties (`php-rs-parser`).
+- Improved error diagnostics with proper error context in recovery paths — error recovery now preserves more meaningful context for debugging (`php-rs-parser`).
+- CI validation: printer output now validated against `php -l` to ensure round-trip output is syntactically valid PHP (`php-parser`).
+- Comprehensive printer edge-case coverage including `new` expressions with empty arguments, property hooks, DNF types, pipe operator expressions, and clone with list arguments (`php-printer`).
+
+### Fixed
+
+- Parser validates parenthesized arrow functions in pipe operator (`|>`) expressions — prevents invalid syntax like `|> ($x) => $x` (`php-rs-parser`).
+- Parser now rejects invalid PHP constructs during parsing rather than silently accepting them and potentially dropping AST nodes (`php-rs-parser`).
+- Control characters in heredoc/nowdoc and braces in string interpolation now properly escaped in printer output (`php-printer`).
+- Variadic parameter modifiers now print in correct order (`&` before `...`) to match PHP syntax (`php-printer`).
+- Printer now always emits parentheses for `new` expressions, ensuring valid PHP output in all contexts (`php-printer`).
+- Property hooks printer fixture updated with valid PHP syntax and edge cases (`php-printer`).
+
+### Changed
+
+- All `.unwrap()` calls replaced with `.expect()` with documented invariants explaining why panic is guaranteed not to occur (`php-parser`).
+- Clippy warnings in example binaries resolved (`php-parser`).
+- Test fixtures now include `===php_error===` sections where appropriate to validate against PHP's own syntax validation (`php-parser`).
+- Fixture test runner parallelized with `rayon` for faster test execution (`php-parser`).
+
+### Documentation
+
+- Added inline documentation explaining dead-code suppressions in test utilities (`php-parser/tests/common.rs`).
+- Parser recursion depth limits and error recovery behavior documented in source (`php-rs-parser`).
+
+### Tests
+
+- Comprehensive edge cases for variadic parameter modifiers (`php-rs-parser`).
+- Printer fixtures expanded to cover `new` expressions, property hooks, and DNF type combinations (`php-printer`).
+
+---
+
 ## [0.9.8] - 2026-05-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.8"
+version = "0.10.0"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -25,10 +25,10 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.9.8" }
-php-lexer = { path = "crates/php-lexer", version = "0.9.8" }
-php-rs-parser = { path = "crates/php-parser", version = "0.9.8" }
-php-printer = { path = "crates/php-printer", version = "0.9.8" }
+php-ast = { path = "crates/php-ast", version = "0.10.0" }
+php-lexer = { path = "crates/php-lexer", version = "0.10.0" }
+php-rs-parser = { path = "crates/php-parser", version = "0.10.0" }
+php-printer = { path = "crates/php-printer", version = "0.10.0" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Release v0.10.0

Bumps version from 0.9.8 to 0.10.0 with comprehensive improvements across parser validation, printer robustness, and code quality.

### Added

- Enhanced parser validation for constructor promotion modifiers — explicitly rejects multiple modifiers on promoted parameters in anonymous classes and refines `readonly` validation on properties
- Improved error diagnostics with proper error context in recovery paths — error recovery now preserves more meaningful context for debugging
- CI validation: printer output now validated against `php -l` to ensure round-trip output is syntactically valid PHP
- Comprehensive printer edge-case coverage including `new` expressions with empty arguments, property hooks, DNF types, pipe operator expressions, and clone with list arguments

### Fixed

- Parser validates parenthesized arrow functions in pipe operator (`|>`) expressions — prevents invalid syntax like `|> ($x) => $x`
- Parser now rejects invalid PHP constructs during parsing rather than silently accepting them and potentially dropping AST nodes
- Control characters in heredoc/nowdoc and braces in string interpolation now properly escaped in printer output
- Variadic parameter modifiers now print in correct order (`&` before `...`) to match PHP syntax
- Printer now always emits parentheses for `new` expressions, ensuring valid PHP output in all contexts
- Property hooks printer fixture updated with valid PHP syntax and edge cases

### Changed

- All `.unwrap()` calls replaced with `.expect()` with documented invariants explaining why panic is guaranteed not to occur
- Clippy warnings in example binaries resolved
- Test fixtures now include `===php_error===` sections where appropriate to validate against PHP's own syntax validation
- Fixture test runner parallelized with `rayon` for faster test execution

### Documentation

- Added inline documentation explaining dead-code suppressions in test utilities
- Parser recursion depth limits and error recovery behavior documented in source

### Tests

- Comprehensive edge cases for variadic parameter modifiers
- Printer fixtures expanded to cover `new` expressions, property hooks, and DNF type combinations

---

See [CHANGELOG.md](https://github.com/jorgsowa/rust-php-parser/blob/release/v0.10.0/CHANGELOG.md) for full details.