### PR TITLE
fix: prevent invalid AST state (abstract method with body)

### DIFF
--- a/crates/php-ast/src/ast/decls.rs
+++ b/crates/php-ast/src/ast/decls.rs
@@ -137,6 +137,24 @@ pub struct MethodDecl<'arena, 'src> {
     pub doc_comment: Option<Comment<'src>>,
 }
 
+impl<'arena, 'src> MethodDecl<'arena, 'src> {
+    pub fn is_valid(&self) -> bool {
+        // Abstract methods must not have a body
+        !(self.is_abstract && self.body.is_some())
+    }
+
+    #[cfg(debug_assertions)]
+    pub fn assert_valid(&self) {
+        assert!(
+            self.is_valid(),
+            "invalid method: abstract method cannot have a body"
+        );
+    }
+
+    #[cfg(not(debug_assertions))]
+    pub fn assert_valid(&self) {}
+}
+
 #[derive(Debug, Serialize)]
 pub struct ClassConstDecl<'arena, 'src> {
     pub name: Ident<'src>,

--- a/crates/php-parser/src/stmt/class.rs
+++ b/crates/php-parser/src/stmt/class.rs
@@ -721,7 +721,7 @@ fn parse_method_member<'arena, 'src>(
         None
     };
 
-    let body = if parser.check(TokenKind::LeftBrace) {
+    let mut body = if parser.check(TokenKind::LeftBrace) {
         parser.expect(TokenKind::LeftBrace);
         let mut stmts = parser.alloc_vec_with_capacity(16);
         let saved_loop_depth = parser.loop_depth;
@@ -748,12 +748,16 @@ fn parse_method_member<'arena, 'src>(
             message: "abstract method cannot contain a body".into(),
             span: Span::new(member_start, parser.previous_end()),
         });
+        // Discard the body to maintain AST invariant
+        body = None;
     }
     if in_interface && body.is_some() {
         parser.error(ParseError::Forbidden {
             message: "interface method cannot contain a body".into(),
             span: Span::new(member_start, parser.previous_end()),
         });
+        // Discard the body to maintain AST invariant
+        body = None;
     }
 
     let span = Span::new(member_start, parser.previous_end());

--- a/crates/php-parser/src/stmt/enum_decl.rs
+++ b/crates/php-parser/src/stmt/enum_decl.rs
@@ -283,7 +283,7 @@ pub(super) fn parse_enum<'arena, 'src>(
                 None
             };
 
-            let body = if parser.check(TokenKind::LeftBrace) {
+            let mut body = if parser.check(TokenKind::LeftBrace) {
                 parser.expect(TokenKind::LeftBrace);
                 let mut stmts = parser.alloc_vec_with_capacity(16);
                 let saved_loop_depth = parser.loop_depth;
@@ -302,6 +302,11 @@ pub(super) fn parse_enum<'arena, 'src>(
                 parser.expect(TokenKind::Semicolon);
                 None
             };
+
+            // Discard body if abstract to maintain AST invariant
+            if is_abstract && body.is_some() {
+                body = None;
+            }
 
             let span = Span::new(member_start, parser.previous_end());
             members.push(EnumMember {

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/php4Style.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/php4Style.phpt
@@ -74,7 +74,7 @@ abstract method cannot contain a body
                   "by_ref": false,
                   "params": [],
                   "return_type": null,
-                  "body": [],
+                  "body": null,
                   "attributes": []
                 }
               },

--- a/crates/php-parser/tests/fixtures/corpus/stmt/class/php4Style_php84.phpt
+++ b/crates/php-parser/tests/fixtures/corpus/stmt/class/php4Style_php84.phpt
@@ -74,7 +74,7 @@ abstract method cannot contain a body
                   "by_ref": false,
                   "params": [],
                   "return_type": null,
-                  "body": [],
+                  "body": null,
                   "attributes": []
                 }
               },

--- a/crates/php-parser/tests/fixtures/errors/abstract_method_with_body_1.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_method_with_body_1.phpt
@@ -28,27 +28,7 @@ abstract method cannot contain a body
                   "by_ref": false,
                   "params": [],
                   "return_type": null,
-                  "body": [
-                    {
-                      "kind": {
-                        "Echo": [
-                          {
-                            "kind": {
-                              "String": "body"
-                            },
-                            "span": {
-                              "start": 58,
-                              "end": 64
-                            }
-                          }
-                        ]
-                      },
-                      "span": {
-                        "start": 53,
-                        "end": 65
-                      }
-                    }
-                  ],
+                  "body": null,
                   "attributes": []
                 }
               },

--- a/crates/php-parser/tests/fixtures/errors/abstract_method_with_body_2.phpt
+++ b/crates/php-parser/tests/fixtures/errors/abstract_method_with_body_2.phpt
@@ -45,25 +45,7 @@ abstract method cannot contain a body
                       "end": 65
                     }
                   },
-                  "body": [
-                    {
-                      "kind": {
-                        "Return": {
-                          "kind": {
-                            "String": ""
-                          },
-                          "span": {
-                            "start": 75,
-                            "end": 77
-                          }
-                        }
-                      },
-                      "span": {
-                        "start": 68,
-                        "end": 78
-                      }
-                    }
-                  ],
+                  "body": null,
                   "attributes": []
                 }
               },

--- a/crates/php-parser/tests/fixtures/errors/interface_method_with_body.phpt
+++ b/crates/php-parser/tests/fixtures/errors/interface_method_with_body.phpt
@@ -22,27 +22,7 @@ interface method cannot contain a body
                   "by_ref": false,
                   "params": [],
                   "return_type": null,
-                  "body": [
-                    {
-                      "kind": {
-                        "Echo": [
-                          {
-                            "kind": {
-                              "String": "body"
-                            },
-                            "span": {
-                              "start": 51,
-                              "end": 57
-                            }
-                          }
-                        ]
-                      },
-                      "span": {
-                        "start": 46,
-                        "end": 58
-                      }
-                    }
-                  ],
+                  "body": null,
                   "attributes": []
                 }
               },

--- a/crates/php-parser/tests/fixtures/errors/interface_method_with_body_multiple.phpt
+++ b/crates/php-parser/tests/fixtures/errors/interface_method_with_body_multiple.phpt
@@ -22,25 +22,7 @@ interface method cannot contain a body
                   "by_ref": false,
                   "params": [],
                   "return_type": null,
-                  "body": [
-                    {
-                      "kind": {
-                        "Return": {
-                          "kind": {
-                            "Int": 1
-                          },
-                          "span": {
-                            "start": 53,
-                            "end": 54
-                          }
-                        }
-                      },
-                      "span": {
-                        "start": 46,
-                        "end": 55
-                      }
-                    }
-                  ],
+                  "body": null,
                   "attributes": []
                 }
               },

--- a/crates/php-printer/src/printer/decls.rs
+++ b/crates/php-printer/src/printer/decls.rs
@@ -143,6 +143,10 @@ impl<'src> Printer<'src> {
     }
 
     pub(crate) fn print_method(&mut self, method: &MethodDecl, span_end: u32) {
+        debug_assert!(
+            method.is_valid(),
+            "invalid method: abstract method cannot have a body"
+        );
         self.print_doc_comment(&method.doc_comment);
         self.print_attributes(&method.attributes);
         if method.is_abstract {


### PR DESCRIPTION
## Summary

Fixes a critical bug where MethodDecl could represent an invalid state with both `is_abstract=true` and `body=Some(stmts)`, violating PHP semantics where abstract methods cannot have bodies.

The parser was detecting this condition and reporting an error, but still creating the invalid AST state. The printer assumed this invalid state never occurred, which could lead to outputting invalid PHP code.

## Changes

- Add `MethodDecl::is_valid()` validation method and debug assertion
- Parser now discards body when `is_abstract=true` (prevents invalid state at source)
- Printer asserts method validity before printing (catches violations)
- Update test fixtures to reflect correct AST (abstract methods have `body: null`)

## Impact

- Printer can no longer output invalid PHP for abstract methods with bodies
- AST is guaranteed to maintain the invariant: `is_abstract=true` → `body=None`
- Error reporting for invalid syntax is preserved