### PR TITLE
feat: improve docs and playground UI/UX

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -131,6 +131,8 @@ export default function App() {
   const col2 = div2 - div1
   const col3 = 100 - div2
 
+  const [astHighlight, setAstHighlight] = useState<{ start: number; end: number } | null>(null)
+
   return (
     <div className="app">
       <Toolbar
@@ -142,13 +144,13 @@ export default function App() {
 
       <div className="workspace" ref={workspaceRef} style={{ display: route.page === 'playground' ? 'flex' : 'none' }}>
         <div className="pane" style={{ width: `${col1}%` }}>
-          <EditorPane ref={editorRef} initialValue={INITIAL_CODE} onChange={setCode} />
+          <EditorPane ref={editorRef} initialValue={INITIAL_CODE} onChange={setCode} highlight={astHighlight} />
         </div>
 
         <div className="divider" onMouseDown={onDiv1Down} role="separator" />
 
         <div className="pane" style={{ width: `${col2}%` }}>
-          <AstPane output={output} />
+          <AstPane output={output} onHighlight={setAstHighlight} />
         </div>
 
         <div className="divider" onMouseDown={onDiv2Down} role="separator" />
@@ -158,8 +160,8 @@ export default function App() {
         </div>
       </div>
 
-      {route.page === 'docs' && <DocsPage onVisualize={handleVisualize} />}
-      {route.page === 'docs-node' && <NodeDetailPage nodeId={route.nodeId} onVisualize={handleVisualize} />}
+      {route.page === 'docs' && <DocsPage version={version} onVisualize={handleVisualize} />}
+      {route.page === 'docs-node' && <NodeDetailPage version={version} nodeId={route.nodeId} onVisualize={handleVisualize} />}
 
       <div className="statusbar">
         <span className="statusbar-item">PHP {version}</span>

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -160,8 +160,8 @@ export default function App() {
         </div>
       </div>
 
-      {route.page === 'docs' && <DocsPage version={version} onVisualize={handleVisualize} />}
-      {route.page === 'docs-node' && <NodeDetailPage version={version} nodeId={route.nodeId} onVisualize={handleVisualize} />}
+      {route.page === 'docs' && <DocsPage version={version} />}
+      {route.page === 'docs-node' && <NodeDetailPage nodeId={route.nodeId} onVisualize={handleVisualize} />}
 
       <div className="statusbar">
         <span className="statusbar-item">PHP {version}</span>

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -162,7 +162,7 @@ export default function App() {
           </div>
         </div>
 
-        {output?.errors && output.errors.length > 0 && (
+        {route.page === 'playground' && output?.errors && output.errors.length > 0 && (
           <div className="workspace-errors">
             <ErrorPanel output={output} variant="workspace" />
           </div>

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -5,6 +5,7 @@ import { Toolbar, type PhpVersion, type WasmStatus } from './components/Toolbar'
 import { EditorPane, type EditorHandle } from './components/EditorPane'
 import { AstPane } from './components/AstPane'
 import { FormattedPane } from './components/FormattedPane'
+import { ErrorPanel } from './components/ErrorPanel'
 import { DocsPage } from './components/docs/DocsPage'
 import { NodeDetailPage } from './components/docs/NodeDetailPage'
 
@@ -143,21 +144,29 @@ export default function App() {
       />
 
       <div className="workspace" ref={workspaceRef} style={{ display: route.page === 'playground' ? 'flex' : 'none' }}>
-        <div className="pane" style={{ width: `${col1}%` }}>
-          <EditorPane ref={editorRef} initialValue={INITIAL_CODE} onChange={setCode} highlight={astHighlight} />
+        <div className="workspace-panes">
+          <div className="pane" style={{ width: `${col1}%` }}>
+            <EditorPane ref={editorRef} initialValue={INITIAL_CODE} onChange={setCode} highlight={astHighlight} />
+          </div>
+
+          <div className="divider" onMouseDown={onDiv1Down} role="separator" />
+
+          <div className="pane" style={{ width: `${col2}%` }}>
+            <AstPane output={output} onHighlight={setAstHighlight} />
+          </div>
+
+          <div className="divider" onMouseDown={onDiv2Down} role="separator" />
+
+          <div className="pane" style={{ width: `${col3}%` }}>
+            <FormattedPane output={output} />
+          </div>
         </div>
 
-        <div className="divider" onMouseDown={onDiv1Down} role="separator" />
-
-        <div className="pane" style={{ width: `${col2}%` }}>
-          <AstPane output={output} onHighlight={setAstHighlight} />
-        </div>
-
-        <div className="divider" onMouseDown={onDiv2Down} role="separator" />
-
-        <div className="pane" style={{ width: `${col3}%` }}>
-          <FormattedPane output={output} />
-        </div>
+        {output?.errors && output.errors.length > 0 && (
+          <div className="workspace-errors">
+            <ErrorPanel output={output} variant="workspace" />
+          </div>
+        )}
       </div>
 
       {route.page === 'docs' && <DocsPage version={version} />}

--- a/playground/src/components/AstPane.tsx
+++ b/playground/src/components/AstPane.tsx
@@ -4,11 +4,12 @@ import { JsonTree, type TreeState } from './JsonTree'
 
 interface Props {
   output: ParseResult | null
+  onHighlight?: (span: { start: number; end: number } | null) => void
 }
 
 type Mode = 'default' | 'all-wrapped' | 'all-unwrapped'
 
-export function AstPane({ output }: Props) {
+export function AstPane({ output, onHighlight }: Props) {
   const [mode, setMode]           = useState<Mode>('default')
   const [exceptions, setExceptions] = useState<Set<string>>(new Set())
 
@@ -28,7 +29,8 @@ export function AstPane({ output }: Props) {
         return next
       })
     },
-  }), [mode, exceptions])
+    onHighlight,
+  }), [mode, exceptions, onHighlight])
 
   const wrapAll   = () => { setMode('all-wrapped');   setExceptions(new Set()) }
   const unwrapAll = () => { setMode('all-unwrapped'); setExceptions(new Set()) }

--- a/playground/src/components/AstPane.tsx
+++ b/playground/src/components/AstPane.tsx
@@ -7,19 +7,15 @@ interface Props {
   onHighlight?: (span: { start: number; end: number } | null) => void
 }
 
-type Mode = 'default' | 'all-wrapped' | 'all-unwrapped'
+type Mode = 'expanded' | 'collapsed'
 
 export function AstPane({ output, onHighlight }: Props) {
-  const [mode, setMode]           = useState<Mode>('default')
-  const [exceptions, setExceptions] = useState<Set<string>>(new Set())
+  const [mode, setMode]               = useState<Mode>('expanded')
+  const [exceptions, setExceptions]   = useState<Set<string>>(new Set())
 
   const state = useMemo<TreeState>(() => ({
-    isExpanded(path, isSpan) {
-      switch (mode) {
-        case 'default':      return isSpan ? exceptions.has(path) : !exceptions.has(path)
-        case 'all-wrapped':  return exceptions.has(path)
-        case 'all-unwrapped': return !exceptions.has(path)
-      }
+    isExpanded(path) {
+      return mode === 'expanded' ? !exceptions.has(path) : exceptions.has(path)
     },
     onToggle(path) {
       setExceptions(prev => {
@@ -32,19 +28,19 @@ export function AstPane({ output, onHighlight }: Props) {
     onHighlight,
   }), [mode, exceptions, onHighlight])
 
-  const wrapAll   = () => { setMode('all-wrapped');   setExceptions(new Set()) }
-  const unwrapAll = () => { setMode('all-unwrapped'); setExceptions(new Set()) }
+  const collapseAll = () => { setMode('collapsed'); setExceptions(new Set()) }
+  const expandAll   = () => { setMode('expanded');  setExceptions(new Set()) }
 
-  const wrapActive   = mode === 'all-wrapped'   && exceptions.size === 0
-  const unwrapActive = mode === 'all-unwrapped' && exceptions.size === 0
+  const collapseActive = mode === 'collapsed' && exceptions.size === 0
+  const expandActive   = mode === 'expanded'  && exceptions.size === 0
 
   return (
     <div className="panel">
       <div className="panel-header">
         <span>AST</span>
         <div className="panel-header-actions">
-          <button className={`jt-btn${wrapActive   ? ' jt-btn--active' : ''}`} onClick={wrapAll}>wrap all</button>
-          <button className={`jt-btn${unwrapActive ? ' jt-btn--active' : ''}`} onClick={unwrapAll}>unwrap all</button>
+          <button className={`jt-btn${collapseActive ? ' jt-btn--active' : ''}`} onClick={collapseAll}>wrap all</button>
+          <button className={`jt-btn${expandActive   ? ' jt-btn--active' : ''}`} onClick={expandAll}>unwrap all</button>
         </div>
       </div>
       <div className="panel-body">

--- a/playground/src/components/EditorPane.tsx
+++ b/playground/src/components/EditorPane.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, forwardRef, useImperativeHandle } from 'react'
-import { EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLineGutter } from '@codemirror/view'
-import { EditorState } from '@codemirror/state'
+import { EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLineGutter, Decoration } from '@codemirror/view'
+import { EditorState, StateField, StateEffect } from '@codemirror/state'
 import { indentOnInput, bracketMatching, foldGutter, syntaxHighlighting } from '@codemirror/language'
 import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands'
 import { searchKeymap, highlightSelectionMatches } from '@codemirror/search'
@@ -10,13 +10,31 @@ import { amberTheme, amberHighlight } from '../theme'
 interface Props {
   initialValue: string
   onChange: (val: string) => void
+  highlight?: { start: number; end: number } | null
 }
 
 export interface EditorHandle {
   loadCode(code: string): void
 }
 
-export const EditorPane = forwardRef<EditorHandle, Props>(function EditorPane({ initialValue, onChange }, ref) {
+const setHighlight = StateEffect.define<{ start: number; end: number } | null>()
+
+const highlightField = StateField.define({
+  create: () => ({ start: -1, end: -1 }),
+  update: (value, tr) => {
+    for (const effect of tr.effects) {
+      if (effect.is(setHighlight)) return effect.value ?? { start: -1, end: -1 }
+    }
+    return value
+  },
+  provide: f => EditorView.decorations.from(f, value => {
+    if (value.start < 0) return Decoration.none
+    const mark = Decoration.mark({ class: 'cm-highlight-span' })
+    return Decoration.set([mark.range(value.start, value.end)])
+  }),
+})
+
+export const EditorPane = forwardRef<EditorHandle, Props>(function EditorPane({ initialValue, onChange, highlight }, ref) {
   const wrapRef = useRef<HTMLDivElement>(null)
   const viewRef = useRef<EditorView | null>(null)
 
@@ -39,6 +57,7 @@ export const EditorPane = forwardRef<EditorHandle, Props>(function EditorPane({ 
           syntaxHighlighting(amberHighlight),
           keymap.of([indentWithTab, ...defaultKeymap, ...historyKeymap, ...searchKeymap]),
           EditorView.lineWrapping,
+          highlightField,
           EditorView.updateListener.of(update => {
             if (update.docChanged) onChange(update.state.doc.toString())
           }),
@@ -51,6 +70,14 @@ export const EditorPane = forwardRef<EditorHandle, Props>(function EditorPane({ 
     // initialValue only used for first render; onChange is stable from useCallback
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  useEffect(() => {
+    const view = viewRef.current
+    if (!view) return
+    view.dispatch({
+      effects: setHighlight.of(highlight ?? null),
+    })
+  }, [highlight])
 
   useImperativeHandle(ref, () => ({
     loadCode(code: string) {

--- a/playground/src/components/ErrorPanel.tsx
+++ b/playground/src/components/ErrorPanel.tsx
@@ -1,0 +1,25 @@
+import type { ParseResult } from '../php_wasm'
+
+interface Props {
+  output: ParseResult | null
+  variant?: 'panel' | 'workspace'
+}
+
+export function ErrorPanel({ output, variant = 'panel' }: Props) {
+  const errors = output?.errors ?? []
+
+  if (errors.length === 0) return null
+
+  const wrapperClass = variant === 'workspace' ? 'workspace-error-list' : 'panel-section panel-section--errors'
+
+  return (
+    <div className={wrapperClass}>
+      {errors.map((err, i) => (
+        <div key={i} className="err-item">
+          <div className="err-msg">{err.message}</div>
+          <div className="err-loc">offset {err.start}–{err.end}</div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/playground/src/components/FormattedPane.tsx
+++ b/playground/src/components/FormattedPane.tsx
@@ -49,24 +49,9 @@ export function FormattedPane({ output }: Props) {
 
   return (
     <div className="panel">
-      <div className="panel-header">
-        Formatted
-        {errors.length > 0 && (
-          <span className="panel-header-badge">{errors.length} error{errors.length !== 1 ? 's' : ''}</span>
-        )}
-      </div>
-      <div className="panel-body panel-body--split">
-        <div ref={wrapRef} className="panel-section panel-section--grow editor-wrap" />
-        {errors.length > 0 && (
-          <div className="panel-section panel-section--errors">
-            {errors.map((err, i) => (
-              <div key={i} className="err-item">
-                <div className="err-msg">{err.message}</div>
-                <div className="err-loc">offset {err.start}–{err.end}</div>
-              </div>
-            ))}
-          </div>
-        )}
+      <div className="panel-header">Formatted</div>
+      <div className="panel-body">
+        <div ref={wrapRef} className="editor-wrap" />
       </div>
     </div>
   )

--- a/playground/src/components/JsonTree.tsx
+++ b/playground/src/components/JsonTree.tsx
@@ -132,11 +132,17 @@ function buildLines(
   if (entries.length === 0)
     return [{ indent, content: <>{K}<span className="jt-punct">{'{}'}</span>{C}</> }]
 
+  // For single-key enums (e.g., { "Function": {...} }), skip the key wrapper and show the value directly
+  if (entries.length === 1) {
+    const [singleKey, singleValue] = entries[0]
+    // Only unwrap if it's not a span object itself
+    if (singleKey !== 'start' && singleKey !== 'end') {
+      return buildLines(singleValue, indent, state, `${path}.${singleKey}`, key, comma, parentSpan)
+    }
+  }
+
   const expanded = state.isExpanded(path, false)
   const label = summary(obj)
-
-  // Only show label if it's meaningful (more than one key or key is not "kind")
-  const showLabel = entries.length !== 1 || key !== 'kind'
 
   // Extract span from this node if present
   const nodeSpan = isSpanObj(obj.span) ? (obj.span as { start: number; end: number }) : undefined
@@ -145,8 +151,8 @@ function buildLines(
 
   if (!expanded) {
     const content = nodeSpan
-      ? <span onMouseEnter={onNodeMouseEnter} onMouseLeave={onNodeMouseLeave}>{K}<Collapsed label={showLabel ? label : ''} bracket="{ … }" onClick={toggle} />{C}</span>
-      : <>{K}<Collapsed label={showLabel ? label : ''} bracket="{ … }" onClick={toggle} />{C}</>
+      ? <span onMouseEnter={onNodeMouseEnter} onMouseLeave={onNodeMouseLeave}>{K}<Collapsed label={label} bracket="{ … }" onClick={toggle} />{C}</span>
+      : <>{K}<Collapsed label={label} bracket="{ … }" onClick={toggle} />{C}</>
     return [{
       indent,
       content,
@@ -155,8 +161,8 @@ function buildLines(
   const lines: Line[] = [{
     indent,
     content: nodeSpan
-      ? <span onMouseEnter={onNodeMouseEnter} onMouseLeave={onNodeMouseLeave}>{K}<Chevron label={showLabel ? label : ''} onClick={toggle} /><span className="jt-punct"> {'{'}</span></span>
-      : <>{K}<Chevron label={showLabel ? label : ''} onClick={toggle} /><span className="jt-punct"> {'{'}</span></>,
+      ? <span onMouseEnter={onNodeMouseEnter} onMouseLeave={onNodeMouseLeave}>{K}<Chevron label={label} onClick={toggle} /><span className="jt-punct"> {'{'}</span></span>
+      : <>{K}<Chevron label={label} onClick={toggle} /><span className="jt-punct"> {'{'}</span></>,
   }]
   entries.forEach(([k, v], i) => {
     lines.push(...buildLines(v, indent + 1, state, `${path}.${k}`, k, i < entries.length - 1, nodeSpan))

--- a/playground/src/components/JsonTree.tsx
+++ b/playground/src/components/JsonTree.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 
 export interface TreeState {
-  isExpanded: (path: string, isSpan: boolean) => boolean
+  isExpanded: (path: string) => boolean
   onToggle: (path: string) => void
   onHighlight?: (span: { start: number; end: number } | null) => void
 }
@@ -20,26 +20,30 @@ function isSpanObj(val: unknown): val is { start: number; end: number } {
   )
 }
 
-// Returns a short label for a collapsed compound value.
-function summary(value: unknown): string {
-  if (Array.isArray(value)) return String(value.length)
-  if (!value || typeof value !== 'object') return ''
-  const obj = value as Record<string, unknown>
-  const keys = Object.keys(obj)
-  // Single-key enum variant wrapper: { VariantName: … }
-  if (keys.length === 1) return keys[0]
-  // AST node: { kind: { VariantName: … }, span: … }
-  const kind = obj.kind
-  if (kind && typeof kind === 'object' && !Array.isArray(kind)) {
-    const kk = Object.keys(kind as object)
-    if (kk.length === 1) return kk[0]
-  }
-  return ''
+function isAstNode(val: unknown): val is Record<string, unknown> {
+  if (!val || typeof val !== 'object' || Array.isArray(val)) return false
+  const obj = val as Record<string, unknown>
+  // Require both a PascalCase-variant kind field AND a span — plain structs
+  // like Program { stmts, span } or Arg { ..., span } have no kind and must
+  // fall through to the plain-object path instead.
+  return getVariantInfo(obj.kind) !== null && isSpanObj(obj.span)
+}
+
+function isPascalCase(key: string): boolean {
+  const c = key.charCodeAt(0)
+  return c >= 65 && c <= 90
+}
+
+function getVariantInfo(kind: unknown): { name: string; data: unknown } | null {
+  if (!kind || typeof kind !== 'object' || Array.isArray(kind)) return null
+  const keys = Object.keys(kind as object)
+  if (keys.length !== 1 || !isPascalCase(keys[0])) return null
+  return { name: keys[0], data: (kind as Record<string, unknown>)[keys[0]] }
 }
 
 function Collapsed({ label, bracket, onClick }: { label: string; bracket: string; onClick: () => void }) {
   return (
-    <span className="jt-toggle" onClick={onClick} title="Unwrap">
+    <span className="jt-toggle" onClick={onClick} title="Expand">
       ▸{label ? ` ${label} ` : ' '}{bracket}
     </span>
   )
@@ -47,7 +51,7 @@ function Collapsed({ label, bracket, onClick }: { label: string; bracket: string
 
 function Chevron({ label, onClick }: { label: string; onClick: () => void }) {
   return (
-    <span className="jt-toggle jt-toggle--open" onClick={onClick} title="Wrap">
+    <span className="jt-toggle jt-toggle--open" onClick={onClick} title="Collapse">
       ▾{label ? ` ${label}` : ''}
     </span>
   )
@@ -60,12 +64,12 @@ function buildLines(
   path: string,
   key?: string,
   comma?: boolean,
-  parentSpan?: { start: number; end: number },
 ): Line[] {
   const K = key != null
     ? <><span className="jt-key">{key}</span><span className="jt-punct">: </span></>
     : null
   const C = comma ? <span className="jt-punct">,</span> : null
+  const toggle = () => state.onToggle(path)
 
   // Primitives
   if (value === null)
@@ -77,95 +81,157 @@ function buildLines(
   if (typeof value === 'string')
     return [{ indent, content: <>{K}<span className="jt-str">"{value}"</span>{C}</> }]
 
-  const toggle = () => state.onToggle(path)
-
-  // Span objects — special collapsed form
+  // Span — always compact inline with hover-to-highlight, no toggle
   if (isSpanObj(value)) {
-    const expanded = state.isExpanded(path, true)
-    const onMouseEnter = () => state.onHighlight?.(value)
-    const onMouseLeave = () => state.onHighlight?.(null)
-    if (!expanded) {
-      return [{
-        indent,
-        content: (
-          <>{K}<span className="jt-span" onClick={toggle} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} title="Unwrap span">
-            span({value.start}..{value.end})
-          </span>{C}</>
-        ),
-      }]
-    }
-    return [
-      { indent, content: <>{K}<span className="jt-span jt-span--on" onClick={toggle} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} title="Wrap span">▾ span</span><span className="jt-punct"> {'{'}</span></> },
-      { indent: indent + 1, content: <><span className="jt-key">start</span><span className="jt-punct">: </span><span className="jt-num">{value.start}</span><span className="jt-punct">,</span></> },
-      { indent: indent + 1, content: <><span className="jt-key">end</span><span className="jt-punct">: </span><span className="jt-num">{value.end}</span></> },
-      { indent, content: <><span className="jt-punct">{'}'}</span>{C}</> },
-    ]
+    const span = value
+    return [{
+      indent,
+      content: (
+        <>{K}<span
+          className="jt-span"
+          onMouseEnter={() => state.onHighlight?.(span)}
+          onMouseLeave={() => state.onHighlight?.(null)}
+        >{span.start}..{span.end}</span>{C}</>
+      ),
+    }]
   }
 
-  // Arrays
+  // Arrays — collapsible
   if (Array.isArray(value)) {
     if (value.length === 0)
       return [{ indent, content: <>{K}<span className="jt-punct">[]</span>{C}</> }]
-
-    const expanded = state.isExpanded(path, false)
+    const expanded = state.isExpanded(path)
     if (!expanded) {
       return [{
         indent,
-        content: <>{K}<Collapsed label={summary(value)} bracket={`[${value.length}]`} onClick={toggle} />{C}</>,
+        content: <>{K}<Collapsed label="" bracket={`[${value.length}]`} onClick={toggle} />{C}</>,
       }]
     }
-    const lines: Line[] = [{
-      indent,
-      content: <>{K}<Chevron label="" onClick={toggle} /><span className="jt-punct">[</span></>,
-    }]
+    const lines: Line[] = [{ indent, content: <>{K}<Chevron label="" onClick={toggle} /><span className="jt-punct">[</span></> }]
     value.forEach((item, i) => {
-      lines.push(...buildLines(item, indent + 1, state, `${path}.${i}`, undefined, i < value.length - 1, parentSpan))
+      lines.push(...buildLines(item, indent + 1, state, `${path}.${i}`, undefined, i < value.length - 1))
     })
     lines.push({ indent, content: <><span className="jt-punct">]</span>{C}</> })
     return lines
   }
 
-  // Objects
   const obj = value as Record<string, unknown>
   const entries = Object.entries(obj)
 
   if (entries.length === 0)
     return [{ indent, content: <>{K}<span className="jt-punct">{'{}'}</span>{C}</> }]
 
-  // For single-key enums (e.g., { "Function": {...} }), skip the key wrapper and show the value directly
-  if (entries.length === 1) {
-    const [singleKey, singleValue] = entries[0]
-    // Only unwrap if it's not a span object itself
-    if (singleKey !== 'start' && singleKey !== 'end') {
-      return buildLines(singleValue, indent, state, `${path}.${singleKey}`, undefined, comma, parentSpan)
+  // AST node: object with a span field — collapsible, flattens kind.Variant fields
+  if (isAstNode(obj)) {
+    const span = obj.span as { start: number; end: number }
+    const variant = getVariantInfo(obj.kind)
+    const label = variant?.name ?? ''
+    const expanded = state.isExpanded(path)
+    const onEnter = () => state.onHighlight?.(span)
+    const onLeave = () => state.onHighlight?.(null)
+
+    if (!expanded) {
+      return [{
+        indent,
+        content: (
+          <span onMouseEnter={onEnter} onMouseLeave={onLeave}>
+            {K}<Collapsed label={label} bracket="{ … }" onClick={toggle} />{C}
+          </span>
+        ),
+      }]
     }
-  }
 
-  const expanded = state.isExpanded(path, false)
-  const label = summary(obj)
-
-  // Extract span from this node if present
-  const nodeSpan = isSpanObj(obj.span) ? (obj.span as { start: number; end: number }) : undefined
-  const onNodeMouseEnter = nodeSpan ? () => state.onHighlight?.(nodeSpan) : undefined
-  const onNodeMouseLeave = nodeSpan ? () => state.onHighlight?.(null) : undefined
-
-  if (!expanded) {
-    const content = nodeSpan
-      ? <span onMouseEnter={onNodeMouseEnter} onMouseLeave={onNodeMouseLeave}>{K}<Collapsed label={label} bracket="{ … }" onClick={toggle} />{C}</span>
-      : <>{K}<Collapsed label={label} bracket="{ … }" onClick={toggle} />{C}</>
-    return [{
+    const lines: Line[] = [{
       indent,
-      content,
+      content: (
+        <span onMouseEnter={onEnter} onMouseLeave={onLeave}>
+          {K}<Chevron label={label} onClick={toggle} /><span className="jt-punct"> {'{'}</span>
+        </span>
+      ),
     }]
+
+    // variant is guaranteed non-null by isAstNode
+    const { name: varName, data } = variant!
+    if (data && typeof data === 'object' && !Array.isArray(data)) {
+      // Object variant: flatten its fields directly into the node body.
+      // Skip `span` — the outer node's span is always shown last and the
+      // variant data's span would create a confusing duplicate.
+      const variantEntries = Object.entries(data as Record<string, unknown>)
+        .filter(([k]) => k !== 'span')
+      variantEntries.forEach(([k, v], i) => {
+        const hasMore = i < variantEntries.length - 1
+        lines.push(...buildLines(v, indent + 1, state, `${path}.kind.${varName}.${k}`, k, hasMore || true))
+      })
+    } else if (data !== undefined && data !== null) {
+      // Primitive or array variant value — show without key, span follows
+      lines.push(...buildLines(data, indent + 1, state, `${path}.kind.${varName}`, undefined, true))
+    }
+    // Unit variant (no data): nothing between label and span
+
+    // Any extra outer fields besides kind and span (rare in practice)
+    entries.filter(([k]) => k !== 'kind' && k !== 'span').forEach(([k, v]) => {
+      lines.push(...buildLines(v, indent + 1, state, `${path}.${k}`, k, true))
+    })
+
+    // Span always last, no trailing comma
+    lines.push(...buildLines(span, indent + 1, state, `${path}.span`, 'span', false))
+    lines.push({ indent, content: <><span className="jt-punct">{'}'}</span>{C}</> })
+    return lines
   }
-  const lines: Line[] = [{
-    indent,
-    content: nodeSpan
-      ? <span onMouseEnter={onNodeMouseEnter} onMouseLeave={onNodeMouseLeave}>{K}<Chevron label={label} onClick={toggle} /><span className="jt-punct"> {'{'}</span></span>
-      : <>{K}<Chevron label={label} onClick={toggle} /><span className="jt-punct"> {'{'}</span></>,
-  }]
+
+  // Single-key PascalCase enum variant — always expanded, key shown as type label
+  if (entries.length === 1 && isPascalCase(entries[0][0])) {
+    const [variantName, variantVal] = entries[0]
+    const variantPath = `${path}.${variantName}`
+
+    if (variantVal === null || typeof variantVal !== 'object') {
+      // Primitive associated value: Variant("x")
+      let primContent: ReactNode = null
+      if (variantVal === null) primContent = <span className="jt-null">null</span>
+      else if (typeof variantVal === 'boolean') primContent = <span className="jt-kw">{String(variantVal)}</span>
+      else if (typeof variantVal === 'number') primContent = <span className="jt-num">{variantVal}</span>
+      else if (typeof variantVal === 'string') primContent = <span className="jt-str">"{variantVal}"</span>
+      return [{
+        indent,
+        content: <>{K}<span className="jt-variant">{variantName}</span><span className="jt-punct">(</span>{primContent}<span className="jt-punct">)</span>{C}</>,
+      }]
+    }
+
+    if (Array.isArray(variantVal)) {
+      if (variantVal.length === 0)
+        return [{ indent, content: <>{K}<span className="jt-variant">{variantName}</span><span className="jt-punct"> []</span>{C}</> }]
+      const expanded = state.isExpanded(variantPath)
+      const toggleV = () => state.onToggle(variantPath)
+      if (!expanded) {
+        return [{
+          indent,
+          content: <>{K}<span className="jt-variant">{variantName}</span>{' '}<Collapsed label="" bracket={`[${variantVal.length}]`} onClick={toggleV} />{C}</>,
+        }]
+      }
+      const lines: Line[] = [{ indent, content: <>{K}<span className="jt-variant">{variantName}</span>{' '}<Chevron label="" onClick={toggleV} /><span className="jt-punct">[</span></> }]
+      variantVal.forEach((item, i) => {
+        lines.push(...buildLines(item, indent + 1, state, `${variantPath}.${i}`, undefined, i < variantVal.length - 1))
+      })
+      lines.push({ indent, content: <><span className="jt-punct">]</span>{C}</> })
+      return lines
+    }
+
+    // Object associated value — always expanded
+    const variantEntries = Object.entries(variantVal as Record<string, unknown>)
+    if (variantEntries.length === 0)
+      return [{ indent, content: <>{K}<span className="jt-variant">{variantName}</span><span className="jt-punct"> {'{}'}</span>{C}</> }]
+    const lines: Line[] = [{ indent, content: <>{K}<span className="jt-variant">{variantName}</span><span className="jt-punct"> {'{'}</span></> }]
+    variantEntries.forEach(([k, v], i) => {
+      lines.push(...buildLines(v, indent + 1, state, `${variantPath}.${k}`, k, i < variantEntries.length - 1))
+    })
+    lines.push({ indent, content: <><span className="jt-punct">{'}'}</span>{C}</> })
+    return lines
+  }
+
+  // Plain object — always expanded, no toggle
+  const lines: Line[] = [{ indent, content: <>{K}<span className="jt-punct">{'{'}</span></> }]
   entries.forEach(([k, v], i) => {
-    lines.push(...buildLines(v, indent + 1, state, `${path}.${k}`, k, i < entries.length - 1, nodeSpan))
+    lines.push(...buildLines(v, indent + 1, state, `${path}.${k}`, k, i < entries.length - 1))
   })
   lines.push({ indent, content: <><span className="jt-punct">{'}'}</span>{C}</> })
   return lines

--- a/playground/src/components/JsonTree.tsx
+++ b/playground/src/components/JsonTree.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 export interface TreeState {
   isExpanded: (path: string, isSpan: boolean) => boolean
   onToggle: (path: string) => void
+  onHighlight?: (span: { start: number; end: number } | null) => void
 }
 
 type Line = { indent: number; content: ReactNode }
@@ -59,6 +60,7 @@ function buildLines(
   path: string,
   key?: string,
   comma?: boolean,
+  parentSpan?: { start: number; end: number },
 ): Line[] {
   const K = key != null
     ? <><span className="jt-key">{key}</span><span className="jt-punct">: </span></>
@@ -80,18 +82,20 @@ function buildLines(
   // Span objects — special collapsed form
   if (isSpanObj(value)) {
     const expanded = state.isExpanded(path, true)
+    const onMouseEnter = () => state.onHighlight?.(value)
+    const onMouseLeave = () => state.onHighlight?.(null)
     if (!expanded) {
       return [{
         indent,
         content: (
-          <>{K}<span className="jt-span" onClick={toggle} title="Unwrap span">
+          <>{K}<span className="jt-span" onClick={toggle} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} title="Unwrap span">
             span({value.start}..{value.end})
           </span>{C}</>
         ),
       }]
     }
     return [
-      { indent, content: <>{K}<span className="jt-span jt-span--on" onClick={toggle} title="Wrap span">▾ span</span><span className="jt-punct"> {'{'}</span></> },
+      { indent, content: <>{K}<span className="jt-span jt-span--on" onClick={toggle} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} title="Wrap span">▾ span</span><span className="jt-punct"> {'{'}</span></> },
       { indent: indent + 1, content: <><span className="jt-key">start</span><span className="jt-punct">: </span><span className="jt-num">{value.start}</span><span className="jt-punct">,</span></> },
       { indent: indent + 1, content: <><span className="jt-key">end</span><span className="jt-punct">: </span><span className="jt-num">{value.end}</span></> },
       { indent, content: <><span className="jt-punct">{'}'}</span>{C}</> },
@@ -115,7 +119,7 @@ function buildLines(
       content: <>{K}<Chevron label="" onClick={toggle} /><span className="jt-punct">[</span></>,
     }]
     value.forEach((item, i) => {
-      lines.push(...buildLines(item, indent + 1, state, `${path}.${i}`, undefined, i < value.length - 1))
+      lines.push(...buildLines(item, indent + 1, state, `${path}.${i}`, undefined, i < value.length - 1, parentSpan))
     })
     lines.push({ indent, content: <><span className="jt-punct">]</span>{C}</> })
     return lines
@@ -131,18 +135,28 @@ function buildLines(
   const expanded = state.isExpanded(path, false)
   const label = summary(obj)
 
+  // Extract span from this node if present
+  const nodeSpan = isSpanObj(obj.span) ? (obj.span as { start: number; end: number }) : undefined
+  const onNodeMouseEnter = nodeSpan ? () => state.onHighlight?.(nodeSpan) : undefined
+  const onNodeMouseLeave = nodeSpan ? () => state.onHighlight?.(null) : undefined
+
   if (!expanded) {
+    const content = nodeSpan
+      ? <span onMouseEnter={onNodeMouseEnter} onMouseLeave={onNodeMouseLeave}>{K}<Collapsed label={label} bracket="{ … }" onClick={toggle} />{C}</span>
+      : <>{K}<Collapsed label={label} bracket="{ … }" onClick={toggle} />{C}</>
     return [{
       indent,
-      content: <>{K}<Collapsed label={label} bracket="{ … }" onClick={toggle} />{C}</>,
+      content,
     }]
   }
   const lines: Line[] = [{
     indent,
-    content: <>{K}<Chevron label={label} onClick={toggle} /><span className="jt-punct"> {'{'}</span></>,
+    content: nodeSpan
+      ? <span onMouseEnter={onNodeMouseEnter} onMouseLeave={onNodeMouseLeave}>{K}<Chevron label={label} onClick={toggle} /><span className="jt-punct"> {'{'}</span></span>
+      : <>{K}<Chevron label={label} onClick={toggle} /><span className="jt-punct"> {'{'}</span></>,
   }]
   entries.forEach(([k, v], i) => {
-    lines.push(...buildLines(v, indent + 1, state, `${path}.${k}`, k, i < entries.length - 1))
+    lines.push(...buildLines(v, indent + 1, state, `${path}.${k}`, k, i < entries.length - 1, nodeSpan))
   })
   lines.push({ indent, content: <><span className="jt-punct">{'}'}</span>{C}</> })
   return lines

--- a/playground/src/components/JsonTree.tsx
+++ b/playground/src/components/JsonTree.tsx
@@ -135,6 +135,9 @@ function buildLines(
   const expanded = state.isExpanded(path, false)
   const label = summary(obj)
 
+  // Only show label if it's meaningful (more than one key or key is not "kind")
+  const showLabel = entries.length !== 1 || key !== 'kind'
+
   // Extract span from this node if present
   const nodeSpan = isSpanObj(obj.span) ? (obj.span as { start: number; end: number }) : undefined
   const onNodeMouseEnter = nodeSpan ? () => state.onHighlight?.(nodeSpan) : undefined
@@ -142,8 +145,8 @@ function buildLines(
 
   if (!expanded) {
     const content = nodeSpan
-      ? <span onMouseEnter={onNodeMouseEnter} onMouseLeave={onNodeMouseLeave}>{K}<Collapsed label={label} bracket="{ … }" onClick={toggle} />{C}</span>
-      : <>{K}<Collapsed label={label} bracket="{ … }" onClick={toggle} />{C}</>
+      ? <span onMouseEnter={onNodeMouseEnter} onMouseLeave={onNodeMouseLeave}>{K}<Collapsed label={showLabel ? label : ''} bracket="{ … }" onClick={toggle} />{C}</span>
+      : <>{K}<Collapsed label={showLabel ? label : ''} bracket="{ … }" onClick={toggle} />{C}</>
     return [{
       indent,
       content,
@@ -152,8 +155,8 @@ function buildLines(
   const lines: Line[] = [{
     indent,
     content: nodeSpan
-      ? <span onMouseEnter={onNodeMouseEnter} onMouseLeave={onNodeMouseLeave}>{K}<Chevron label={label} onClick={toggle} /><span className="jt-punct"> {'{'}</span></span>
-      : <>{K}<Chevron label={label} onClick={toggle} /><span className="jt-punct"> {'{'}</span></>,
+      ? <span onMouseEnter={onNodeMouseEnter} onMouseLeave={onNodeMouseLeave}>{K}<Chevron label={showLabel ? label : ''} onClick={toggle} /><span className="jt-punct"> {'{'}</span></span>
+      : <>{K}<Chevron label={showLabel ? label : ''} onClick={toggle} /><span className="jt-punct"> {'{'}</span></>,
   }]
   entries.forEach(([k, v], i) => {
     lines.push(...buildLines(v, indent + 1, state, `${path}.${k}`, k, i < entries.length - 1, nodeSpan))

--- a/playground/src/components/JsonTree.tsx
+++ b/playground/src/components/JsonTree.tsx
@@ -137,7 +137,7 @@ function buildLines(
     const [singleKey, singleValue] = entries[0]
     // Only unwrap if it's not a span object itself
     if (singleKey !== 'start' && singleKey !== 'end') {
-      return buildLines(singleValue, indent, state, `${path}.${singleKey}`, key, comma, parentSpan)
+      return buildLines(singleValue, indent, state, `${path}.${singleKey}`, undefined, comma, parentSpan)
     }
   }
 

--- a/playground/src/components/docs/DocsPage.tsx
+++ b/playground/src/components/docs/DocsPage.tsx
@@ -53,14 +53,6 @@ export function DocsPage({ version }: Props) {
     return filtered
   }, [searchTerm, selectedGroups, version])
 
-  const groupedNodes = useMemo(() => {
-    const grouped: Record<string, typeof astNodes> = {}
-    filteredNodes.forEach(node => {
-      if (!grouped[node.group]) grouped[node.group] = []
-      grouped[node.group].push(node)
-    })
-    return grouped
-  }, [filteredNodes])
 
   const groupCounts = useMemo(() => {
     const counts: Record<string, number> = {}
@@ -133,26 +125,14 @@ export function DocsPage({ version }: Props) {
             </button>
           </div>
         ) : (
-          <div className="docs-grouped">
-            {SEMANTIC_GROUPS.map(groupName => {
-              const groupNodes = groupedNodes[groupName] || []
-              if (groupNodes.length === 0) return null
-
-              return (
-                <div key={groupName} className="docs-group-section">
-                  <h2 className="docs-group-title">{groupName}</h2>
-                  <div className="node-grid">
-                    {groupNodes.map(node => (
-                      <NodeCard
-                        key={node.id}
-                        node={node}
-                        nodeLink={`#docs/${node.id}`}
-                      />
-                    ))}
-                  </div>
-                </div>
-              )
-            })}
+          <div className="node-grid">
+            {filteredNodes.map(node => (
+              <NodeCard
+                key={node.id}
+                node={node}
+                nodeLink={`#docs/${node.id}`}
+              />
+            ))}
           </div>
         )}
       </div>

--- a/playground/src/components/docs/DocsPage.tsx
+++ b/playground/src/components/docs/DocsPage.tsx
@@ -1,8 +1,10 @@
 import { useState, useMemo } from 'react'
 import { astNodes, type AstNode } from '../../data/ast-nodes'
 import { NodeCard } from './NodeCard'
+import type { PhpVersion } from '../Toolbar'
 
 interface Props {
+  version: PhpVersion
   onVisualize: (code: string) => void
 }
 
@@ -16,12 +18,20 @@ const CATEGORY_LABELS: Record<Category, string> = {
   helper: 'Helpers'
 }
 
-export function DocsPage({ onVisualize }: Props) {
+export function DocsPage({ version, onVisualize }: Props) {
   const [searchTerm, setSearchTerm] = useState('')
   const [selectedCategory, setSelectedCategory] = useState<Category | null>(null)
 
   const filteredNodes = useMemo(() => {
     let filtered = astNodes
+
+    // Filter by PHP version
+    filtered = filtered.filter(node => {
+      if (!node.phpVersion) return true
+      const nodeMinVersion = parseFloat(node.phpVersion)
+      const currentVersion = parseFloat(version)
+      return currentVersion >= nodeMinVersion
+    })
 
     if (selectedCategory) {
       filtered = filtered.filter(node => node.category === selectedCategory)
@@ -37,7 +47,7 @@ export function DocsPage({ onVisualize }: Props) {
     }
 
     return filtered
-  }, [searchTerm, selectedCategory])
+  }, [searchTerm, selectedCategory, version])
 
   const categories: Category[] = ['statement', 'expression', 'declaration', 'type', 'helper']
   const categoryCounts = useMemo(() => {

--- a/playground/src/components/docs/DocsPage.tsx
+++ b/playground/src/components/docs/DocsPage.tsx
@@ -7,19 +7,23 @@ interface Props {
   version: PhpVersion
 }
 
-type Category = 'statement' | 'expression' | 'declaration' | 'type' | 'helper'
-
-const CATEGORY_LABELS: Record<Category, string> = {
-  statement: 'Statements',
-  expression: 'Expressions',
-  declaration: 'Declarations',
-  type: 'Types',
-  helper: 'Helpers'
-}
+const SEMANTIC_GROUPS = [
+  'Control Flow',
+  'Define Code',
+  'Output/Communication',
+  'Variables & Values',
+  'Operations',
+  'Function/Method Calls',
+  'Class/Object Operations',
+  'Declarations',
+  'Types',
+  'Other Expressions',
+  'Helpers'
+]
 
 export function DocsPage({ version }: Props) {
   const [searchTerm, setSearchTerm] = useState('')
-  const [selectedCategory, setSelectedCategory] = useState<Category | null>(null)
+  const [selectedGroups, setSelectedGroups] = useState<Set<string>>(new Set())
 
   const filteredNodes = useMemo(() => {
     let filtered = astNodes
@@ -32,8 +36,9 @@ export function DocsPage({ version }: Props) {
       return currentVersion >= nodeMinVersion
     })
 
-    if (selectedCategory) {
-      filtered = filtered.filter(node => node.category === selectedCategory)
+    // Filter by groups (if any selected, only show those; if none selected, show all)
+    if (selectedGroups.size > 0) {
+      filtered = filtered.filter(node => selectedGroups.has(node.group))
     }
 
     if (searchTerm.trim()) {
@@ -46,22 +51,39 @@ export function DocsPage({ version }: Props) {
     }
 
     return filtered
-  }, [searchTerm, selectedCategory, version])
+  }, [searchTerm, selectedGroups, version])
 
-  const categories: Category[] = ['statement', 'expression', 'declaration', 'type', 'helper']
-  const categoryCounts = useMemo(() => {
-    const counts: Record<Category, number> = {
-      statement: 0,
-      expression: 0,
-      declaration: 0,
-      type: 0,
-      helper: 0
-    }
+  const groupedNodes = useMemo(() => {
+    const grouped: Record<string, typeof astNodes> = {}
+    filteredNodes.forEach(node => {
+      if (!grouped[node.group]) grouped[node.group] = []
+      grouped[node.group].push(node)
+    })
+    return grouped
+  }, [filteredNodes])
+
+  const groupCounts = useMemo(() => {
+    const counts: Record<string, number> = {}
     astNodes.forEach(node => {
-      counts[node.category]++
+      counts[node.group] = (counts[node.group] || 0) + 1
     })
     return counts
   }, [])
+
+  const toggleGroup = (group: string) => {
+    const newGroups = new Set(selectedGroups)
+    if (newGroups.has(group)) {
+      newGroups.delete(group)
+    } else {
+      newGroups.add(group)
+    }
+    setSelectedGroups(newGroups)
+  }
+
+  const clearFilters = () => {
+    setSearchTerm('')
+    setSelectedGroups(new Set())
+  }
 
   return (
     <div className="page-docs">
@@ -80,22 +102,25 @@ export function DocsPage({ version }: Props) {
           aria-label="Search AST nodes"
         />
 
-        <div className="docs-category-tabs">
-          <button
-            className={`category-tab ${selectedCategory === null ? 'active' : ''}`}
-            onClick={() => setSelectedCategory(null)}
-          >
-            All ({astNodes.length})
-          </button>
-          {categories.map(cat => (
-            <button
-              key={cat}
-              className={`category-tab ${selectedCategory === cat ? 'active' : ''}`}
-              onClick={() => setSelectedCategory(cat)}
-            >
-              {CATEGORY_LABELS[cat]} ({categoryCounts[cat]})
+        <div className="docs-group-filters">
+          <div className="group-filter-label">Filter by group:</div>
+          <div className="group-filter-buttons">
+            {SEMANTIC_GROUPS.map(group => (
+              <button
+                key={group}
+                className={`group-filter-btn ${selectedGroups.has(group) ? 'active' : ''}`}
+                onClick={() => toggleGroup(group)}
+                title={`${group} (${groupCounts[group] || 0})`}
+              >
+                {group} ({groupCounts[group] || 0})
+              </button>
+            ))}
+          </div>
+          {selectedGroups.size > 0 && (
+            <button className="docs-reset-filters-btn" onClick={clearFilters}>
+              Clear filters
             </button>
-          ))}
+          )}
         </div>
       </div>
 
@@ -103,25 +128,31 @@ export function DocsPage({ version }: Props) {
         {filteredNodes.length === 0 ? (
           <div className="docs-empty">
             <p>No nodes found matching your search.</p>
-            <button
-              className="docs-reset-btn"
-              onClick={() => {
-                setSearchTerm('')
-                setSelectedCategory(null)
-              }}
-            >
+            <button className="docs-reset-btn" onClick={clearFilters}>
               Clear filters
             </button>
           </div>
         ) : (
-          <div className="node-grid">
-            {filteredNodes.map(node => (
-              <NodeCard
-                key={node.id}
-                node={node}
-                nodeLink={`#docs/${node.id}`}
-              />
-            ))}
+          <div className="docs-grouped">
+            {SEMANTIC_GROUPS.map(groupName => {
+              const groupNodes = groupedNodes[groupName] || []
+              if (groupNodes.length === 0) return null
+
+              return (
+                <div key={groupName} className="docs-group-section">
+                  <h2 className="docs-group-title">{groupName}</h2>
+                  <div className="node-grid">
+                    {groupNodes.map(node => (
+                      <NodeCard
+                        key={node.id}
+                        node={node}
+                        nodeLink={`#docs/${node.id}`}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )
+            })}
           </div>
         )}
       </div>

--- a/playground/src/components/docs/DocsPage.tsx
+++ b/playground/src/components/docs/DocsPage.tsx
@@ -1,11 +1,10 @@
 import { useState, useMemo } from 'react'
-import { astNodes, type AstNode } from '../../data/ast-nodes'
+import { astNodes } from '../../data/ast-nodes'
 import { NodeCard } from './NodeCard'
 import type { PhpVersion } from '../Toolbar'
 
 interface Props {
   version: PhpVersion
-  onVisualize: (code: string) => void
 }
 
 type Category = 'statement' | 'expression' | 'declaration' | 'type' | 'helper'
@@ -18,7 +17,7 @@ const CATEGORY_LABELS: Record<Category, string> = {
   helper: 'Helpers'
 }
 
-export function DocsPage({ version, onVisualize }: Props) {
+export function DocsPage({ version }: Props) {
   const [searchTerm, setSearchTerm] = useState('')
   const [selectedCategory, setSelectedCategory] = useState<Category | null>(null)
 
@@ -120,7 +119,6 @@ export function DocsPage({ version, onVisualize }: Props) {
               <NodeCard
                 key={node.id}
                 node={node}
-                onVisualize={onVisualize}
                 nodeLink={`#docs/${node.id}`}
               />
             ))}

--- a/playground/src/components/docs/DocsPage.tsx
+++ b/playground/src/components/docs/DocsPage.tsx
@@ -18,7 +18,7 @@ const SEMANTIC_GROUPS = [
   'Declarations',
   'Types',
   'Other Expressions',
-  'Helpers'
+  'Components'
 ]
 
 export function DocsPage({ version }: Props) {
@@ -72,11 +72,6 @@ export function DocsPage({ version }: Props) {
     setSelectedGroups(newGroups)
   }
 
-  const clearFilters = () => {
-    setSearchTerm('')
-    setSelectedGroups(new Set())
-  }
-
   return (
     <div className="page-docs">
       <div className="docs-header">
@@ -97,6 +92,12 @@ export function DocsPage({ version }: Props) {
         <div className="docs-group-filters">
           <div className="group-filter-label">Filter by group:</div>
           <div className="group-filter-buttons">
+            <button
+              className={`group-filter-btn ${selectedGroups.size === 0 ? 'active' : ''}`}
+              onClick={() => setSelectedGroups(new Set())}
+            >
+              All ({astNodes.length})
+            </button>
             {SEMANTIC_GROUPS.map(group => (
               <button
                 key={group}
@@ -108,11 +109,6 @@ export function DocsPage({ version }: Props) {
               </button>
             ))}
           </div>
-          {selectedGroups.size > 0 && (
-            <button className="docs-reset-filters-btn" onClick={clearFilters}>
-              Clear filters
-            </button>
-          )}
         </div>
       </div>
 
@@ -120,7 +116,13 @@ export function DocsPage({ version }: Props) {
         {filteredNodes.length === 0 ? (
           <div className="docs-empty">
             <p>No nodes found matching your search.</p>
-            <button className="docs-reset-btn" onClick={clearFilters}>
+            <button
+              className="docs-reset-btn"
+              onClick={() => {
+                setSearchTerm('')
+                setSelectedGroups(new Set())
+              }}
+            >
               Clear filters
             </button>
           </div>

--- a/playground/src/components/docs/NodeCard.tsx
+++ b/playground/src/components/docs/NodeCard.tsx
@@ -27,21 +27,78 @@ export function NodeCard({ node, nodeLink }: Props) {
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&#39;')
 
-    // Highlight the main keyword when title is hovered
+    // Highlight the main keyword(s) when title is hovered
     if (node.keywordInExample && showKeywordHighlight) {
-      const keyword = node.keywordInExample
-      const regex = new RegExp(`\\b${keyword}\\b`, 'g')
-      code = code.replace(regex, `<mark class="keyword">${keyword}</mark>`)
+      const keywords = Array.isArray(node.keywordInExample)
+        ? node.keywordInExample
+        : [node.keywordInExample]
+      keywords.forEach(keyword => {
+        // HTML-escape the keyword to match the already-escaped code
+        let htmlEscapedKeyword = keyword
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;')
+        const escapedKeyword = htmlEscapedKeyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        const isSymbol = /^[{}\[\]()@<>?|#]$/.test(keyword) || /^(<{2,}|>{2,})$/.test(keyword)
+        const pattern = isSymbol ? escapedKeyword : `\\b${escapedKeyword}\\b`
+        const regex = new RegExp(pattern, 'g')
+        code = code.replace(regex, `<mark class="keyword">${htmlEscapedKeyword}</mark>`)
+      })
     }
 
     // Highlight field-specific patterns if a field is hovered
     if (highlightedKeyword && node.fieldHighlights && node.fieldHighlights[highlightedKeyword]) {
       const patterns = node.fieldHighlights[highlightedKeyword]
+      // Collect all matches with positions to avoid overlapping highlights
+      const matches: Array<{ start: number; end: number; pattern: string; htmlEscaped: string }> = []
+
       patterns.forEach(pattern => {
+        // HTML-escape the pattern to match the already-escaped code
+        let htmlEscapedPattern = pattern
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;')
         // Escape special regex characters in the pattern
-        const escapedPattern = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        const escapedPattern = htmlEscapedPattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
         const regex = new RegExp(escapedPattern, 'g')
-        code = code.replace(regex, `<mark class="field-highlight">${pattern}</mark>`)
+
+        let match
+        while ((match = regex.exec(code)) !== null) {
+          matches.push({
+            start: match.index,
+            end: match.index + match[0].length,
+            pattern: pattern,
+            htmlEscaped: htmlEscapedPattern
+          })
+        }
+      })
+
+      // Sort by position and length (longest first at same position) to handle overlaps
+      matches.sort((a, b) => {
+        if (a.start !== b.start) return a.start - b.start
+        return (b.end - b.start) - (a.end - a.start)
+      })
+
+      // Remove overlapping matches (keep longer ones)
+      const nonOverlapping = matches.filter((match, i) => {
+        for (let j = 0; j < i; j++) {
+          const other = matches[j]
+          if (other.start <= match.start && match.end <= other.end) {
+            return false // This match overlaps with a longer one
+          }
+        }
+        return true
+      })
+
+      // Apply highlights in reverse order to preserve positions
+      nonOverlapping.reverse().forEach(match => {
+        code = code.slice(0, match.start) +
+               `<mark class="field-highlight">${match.htmlEscaped}</mark>` +
+               code.slice(match.end)
       })
     }
 
@@ -59,11 +116,7 @@ export function NodeCard({ node, nodeLink }: Props) {
       onClick={nodeLink ? handleCardClick : undefined}
     >
       <div className="node-header">
-        <h3
-          className="node-name"
-          onMouseEnter={() => setShowKeywordHighlight(true)}
-          onMouseLeave={() => setShowKeywordHighlight(false)}
-        >
+        <h3 className="node-name">
           {node.name}
         </h3>
         <div className="node-meta">
@@ -78,6 +131,21 @@ export function NodeCard({ node, nodeLink }: Props) {
       <div className="node-example">
         {renderExampleWithHighlight()}
       </div>
+
+      {node.keywordInExample && (
+        <div
+          className="node-keyword"
+          onMouseEnter={() => setShowKeywordHighlight(true)}
+          onMouseLeave={() => setShowKeywordHighlight(false)}
+        >
+          <span className="keyword-label">Keyword:</span>
+          <code className="keyword-code">
+            {Array.isArray(node.keywordInExample)
+              ? node.keywordInExample.join(' / ')
+              : node.keywordInExample}
+          </code>
+        </div>
+      )}
 
       {node.fields && node.fields.length > 0 && (
         <div className="node-fields">

--- a/playground/src/components/docs/NodeCard.tsx
+++ b/playground/src/components/docs/NodeCard.tsx
@@ -3,16 +3,17 @@ import { type AstNode } from '../../data/ast-nodes'
 
 interface Props {
   node: AstNode
-  onVisualize: (code: string) => void
   nodeLink?: string
 }
 
-export function NodeCard({ node, onVisualize, nodeLink }: Props) {
+export function NodeCard({ node, nodeLink }: Props) {
   const [highlightedKeyword, setHighlightedKeyword] = useState<string | null>(null)
   const [showKeywordHighlight, setShowKeywordHighlight] = useState(false)
 
-  const handleVisualize = () => {
-    onVisualize(node.phpExample)
+  const handleCardClick = () => {
+    if (nodeLink) {
+      window.location.hash = nodeLink.replace(/^#/, '')
+    }
   }
 
   const renderExampleWithHighlight = () => {
@@ -53,39 +54,22 @@ export function NodeCard({ node, onVisualize, nodeLink }: Props) {
   }
 
   return (
-    <div className="node-card">
+    <div
+      className={`node-card${nodeLink ? ' node-card--clickable' : ''}`}
+      onClick={nodeLink ? handleCardClick : undefined}
+    >
       <div className="node-header">
-        {nodeLink ? (
-          <a
-            href={nodeLink}
-            className="node-name node-name-link"
-            onMouseEnter={() => setShowKeywordHighlight(true)}
-            onMouseLeave={() => setShowKeywordHighlight(false)}
-            title={`View ${node.name} details`}
-          >
-            {node.name}
-          </a>
-        ) : (
-          <h3
-            className="node-name"
-            onMouseEnter={() => setShowKeywordHighlight(true)}
-            onMouseLeave={() => setShowKeywordHighlight(false)}
-          >
-            {node.name}
-          </h3>
-        )}
+        <h3
+          className="node-name"
+          onMouseEnter={() => setShowKeywordHighlight(true)}
+          onMouseLeave={() => setShowKeywordHighlight(false)}
+        >
+          {node.name}
+        </h3>
         <div className="node-meta">
           {node.phpVersion && (
             <span className="node-version">{node.phpVersion}</span>
           )}
-          <button
-            className="node-visualize-btn"
-            onClick={handleVisualize}
-            title="Load this example in the playground"
-            aria-label={`Visualize ${node.name} in playground`}
-          >
-            ▶
-          </button>
         </div>
       </div>
 
@@ -103,8 +87,9 @@ export function NodeCard({ node, onVisualize, nodeLink }: Props) {
               <li
                 key={idx}
                 className="field-item"
-                onMouseEnter={() => setHighlightedKeyword(field.name)}
+                onMouseEnter={e => { e.stopPropagation(); setHighlightedKeyword(field.name) }}
                 onMouseLeave={() => setHighlightedKeyword(null)}
+                onClick={e => e.stopPropagation()}
               >
                 <span className="field-name">{field.name}</span>
                 <span className="field-type">{field.type}</span>

--- a/playground/src/components/docs/NodeDetailPage.tsx
+++ b/playground/src/components/docs/NodeDetailPage.tsx
@@ -1,15 +1,12 @@
 import { useState } from 'react'
 import { astNodes } from '../../data/ast-nodes'
 import { NodeCard } from './NodeCard'
-import type { PhpVersion } from '../Toolbar'
-
 interface Props {
-  version: PhpVersion
   nodeId: string
   onVisualize: (code: string) => void
 }
 
-export function NodeDetailPage({ version, nodeId, onVisualize }: Props) {
+export function NodeDetailPage({ nodeId, onVisualize }: Props) {
   const node = astNodes.find(n => n.id === nodeId)
   const [copied, setCopied] = useState(false)
 
@@ -41,32 +38,46 @@ export function NodeDetailPage({ version, nodeId, onVisualize }: Props) {
     <div className="page-docs-detail">
       <div className="docs-detail-header">
         <a href="#docs" className="docs-back-link">← Back to docs</a>
-        <button
-          className="docs-copy-link-btn"
-          onClick={handleCopyLink}
-          title="Copy shareable link"
-        >
-          {copied ? '✓ Copied' : '🔗 Copy link'}
-        </button>
+
+        <div className="docs-detail-nav-inline">
+          {prevNode ? (
+            <a href={`#docs/${prevNode.id}`} className="docs-nav-prev">
+              ← {prevNode.name}
+            </a>
+          ) : (
+            <span className="docs-nav-placeholder" />
+          )}
+          {nextNode ? (
+            <a href={`#docs/${nextNode.id}`} className="docs-nav-next">
+              {nextNode.name} →
+            </a>
+          ) : (
+            <span className="docs-nav-placeholder" />
+          )}
+        </div>
+
+        <div className="docs-detail-actions">
+          <button
+            className="node-visualize-btn"
+            onClick={() => onVisualize(node.phpExample)}
+            title="Load this example in the playground"
+          >
+            ▶ Try it
+          </button>
+          <button
+            className="docs-copy-link-btn"
+            onClick={handleCopyLink}
+            title="Copy shareable link"
+          >
+            {copied ? '✓ Copied' : '🔗 Copy link'}
+          </button>
+        </div>
       </div>
 
       <div className="docs-detail-content">
         <div className="docs-detail-card">
-          <NodeCard node={node} onVisualize={onVisualize} />
+          <NodeCard node={node} />
         </div>
-      </div>
-
-      <div className="docs-detail-nav">
-        {prevNode && (
-          <a href={`#docs/${prevNode.id}`} className="docs-nav-prev">
-            ← {prevNode.name}
-          </a>
-        )}
-        {nextNode && (
-          <a href={`#docs/${nextNode.id}`} className="docs-nav-next">
-            {nextNode.name} →
-          </a>
-        )}
       </div>
     </div>
   )

--- a/playground/src/components/docs/NodeDetailPage.tsx
+++ b/playground/src/components/docs/NodeDetailPage.tsx
@@ -59,7 +59,7 @@ export function NodeDetailPage({ nodeId, onVisualize }: Props) {
         <div className="docs-detail-actions">
           <button
             className="node-visualize-btn"
-            onClick={() => onVisualize(node.phpExample)}
+            onClick={() => onVisualize(`<?php\n${node.phpExample}`)}
             title="Load this example in the playground"
           >
             ▶ Try it

--- a/playground/src/components/docs/NodeDetailPage.tsx
+++ b/playground/src/components/docs/NodeDetailPage.tsx
@@ -1,13 +1,15 @@
 import { useState } from 'react'
 import { astNodes } from '../../data/ast-nodes'
 import { NodeCard } from './NodeCard'
+import type { PhpVersion } from '../Toolbar'
 
 interface Props {
+  version: PhpVersion
   nodeId: string
   onVisualize: (code: string) => void
 }
 
-export function NodeDetailPage({ nodeId, onVisualize }: Props) {
+export function NodeDetailPage({ version, nodeId, onVisualize }: Props) {
   const node = astNodes.find(n => n.id === nodeId)
   const [copied, setCopied] = useState(false)
 

--- a/playground/src/data/ast-nodes.ts
+++ b/playground/src/data/ast-nodes.ts
@@ -1513,7 +1513,7 @@ export const astNodes: AstNode[] = [
   // ========== HELPERS ==========
   {
     id: 'helper-arg',
-    group: 'Helpers',
+    group: 'Components',
     name: 'Arg',
     description: 'Function/method argument',
     phpExample: `<?php\nfoo($a, $b, name: $c, ...$spread);`,
@@ -1531,7 +1531,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-array-element',
-    group: 'Helpers',
+    group: 'Components',
     name: 'ArrayElement',
     description: 'A single element in an array literal',
     phpExample: `<?php\n[$val, $key => $val2, ...$spread];`,
@@ -1549,7 +1549,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-attribute',
-    group: 'Helpers',
+    group: 'Components',
     name: 'Attribute',
     description: 'Attribute/annotation',
     phpExample: `<?php\n#[Route($path)]\n#[Deprecated($msg)]\nfunction handler() {}`,
@@ -1565,7 +1565,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-catch-clause',
-    group: 'Helpers',
+    group: 'Components',
     name: 'CatchClause',
     description: 'A single catch in try-catch',
     phpExample: `<?php\ntry {\n  throw new RuntimeException();\n} catch (RuntimeException $e) {\n  echo $e;\n}`,
@@ -1583,7 +1583,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-closure-use-var',
-    group: 'Helpers',
+    group: 'Components',
     name: 'ClosureUseVar',
     description: 'A variable captured by a closure',
     phpExample: `<?php\n$multiplier = 3;\n$fn = function($x) use ($multiplier) {\n  return $x * $multiplier;\n};`,
@@ -1598,7 +1598,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-const-item',
-    group: 'Helpers',
+    group: 'Components',
     name: 'ConstItem',
     description: 'A single constant in a const statement',
     phpExample: `<?php\nconst MAX_SIZE = 100;\nconst DB_HOST = DB_DEFAULT_HOST;`,
@@ -1615,7 +1615,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-elseif-branch',
-    group: 'Helpers',
+    group: 'Components',
     name: 'ElseIfBranch',
     description: 'A single elseif branch in an if statement',
     phpExample: `<?php\nif ($x == 1) {\n  echo $x;\n} elseif ($x == 2) {\n  echo 0;\n}`,
@@ -1631,7 +1631,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-match-arm',
-    group: 'Helpers',
+    group: 'Components',
     name: 'MatchArm',
     description: 'A single arm in a match expression',
     phpExample: `<?php\nmatch($x) {\n  1, 2 => $small,\n  default => $other\n};`,
@@ -1647,7 +1647,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-name',
-    group: 'Helpers',
+    group: 'Components',
     name: 'Name',
     description: 'Namespace-qualified name',
     phpExample: `<?php\nuse App\\Models\\User;\nclass Post extends BaseModel {}`,
@@ -1663,7 +1663,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-program',
-    group: 'Helpers',
+    group: 'Components',
     name: 'Program',
     description: 'Root AST node containing all top-level statements',
     phpExample: `<?php\n$x = 1;\necho $x;`,
@@ -1677,7 +1677,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-span',
-    group: 'Helpers',
+    group: 'Components',
     name: 'Span',
     description: 'Source code location (start and end byte offsets)',
     phpExample: `<?php\n// Every AST node has a Span indicating where in the source it appears`,
@@ -1692,7 +1692,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-static-var',
-    group: 'Helpers',
+    group: 'Components',
     name: 'StaticVar',
     description: 'A single static variable declaration',
     phpExample: `<?php\nfunction counter() {\n  static $count = 0;\n  return ++$count;\n}`,
@@ -1708,7 +1708,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-string-part',
-    group: 'Helpers',
+    group: 'Components',
     name: 'StringPart',
     description: 'A part of an interpolated string (literal text or embedded expression)',
     phpExample: `<?php\n$name = $alice;\necho "Hello $name, you are {$age} old";`,
@@ -1722,7 +1722,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-switch-case',
-    group: 'Helpers',
+    group: 'Components',
     name: 'SwitchCase',
     description: 'A single case in a switch statement',
     phpExample: `<?php\nswitch ($x) {\n  case 1:\n    echo $x;\n    break;\n  default:\n    break;\n}`,
@@ -1738,7 +1738,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-trait-use-decl',
-    group: 'Helpers',
+    group: 'Components',
     name: 'TraitUseDecl',
     description: 'use Trait; inside a class body',
     phpExample: `<?php\nclass MyClass {\n  use TraitA, TraitB {\n    TraitA::foo insteadof TraitB;\n  }\n}`,
@@ -1754,7 +1754,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-use-item',
-    group: 'Helpers',
+    group: 'Components',
     name: 'UseItem',
     description: 'A single imported name in a use statement',
     phpExample: `<?php\nuse App\\Models\\User;\nuse App\\Http\\Controller as Ctrl;`,

--- a/playground/src/data/ast-nodes.ts
+++ b/playground/src/data/ast-nodes.ts
@@ -62,9 +62,11 @@ export const astNodes: AstNode[] = [
     },
     fields: [
       { name: 'name', type: 'Ident', description: 'Class name' },
+      { name: 'modifiers', type: 'ClassModifiers', description: 'Modifiers (abstract, final, readonly)' },
       { name: 'extends', type: 'Option<Name>', description: 'Parent class', optional: true },
       { name: 'implements', type: 'Vec<Name>', description: 'Interfaces' },
-      { name: 'members', type: 'Vec<ClassMember>', description: 'Properties, methods, constants' }
+      { name: 'members', type: 'Vec<ClassMember>', description: 'Properties, methods, constants' },
+      { name: 'attributes', type: 'Vec<Attribute>', description: 'PHP attributes (#[...])' }
     ]
   },
   {
@@ -107,7 +109,7 @@ export const astNodes: AstNode[] = [
       body: ['{}']
     },
     fields: [
-      { name: 'directives', type: 'Vec<(Name, Expr)>', description: 'Directives' },
+      { name: 'directives', type: 'Vec<(str, Expr)>', description: 'Directives' },
       { name: 'body', type: 'Option<Stmt>', description: 'Declare body', optional: true }
     ]
   },
@@ -158,6 +160,7 @@ export const astNodes: AstNode[] = [
     fields: [
       { name: 'name', type: 'Ident', description: 'Enum name' },
       { name: 'scalar_type', type: 'Option<Name>', description: 'Backing type (int or string)', optional: true },
+      { name: 'implements', type: 'Vec<Name>', description: 'Implemented interfaces' },
       { name: 'members', type: 'Vec<EnumMember>', description: 'Cases and methods' }
     ]
   },
@@ -216,9 +219,11 @@ export const astNodes: AstNode[] = [
     },
     fields: [
       { name: 'name', type: 'Ident', description: 'Function name' },
+      { name: 'by_ref', type: 'bool', description: 'Returns by reference (&function)' },
       { name: 'params', type: 'Vec<Param>', description: 'Function parameters' },
       { name: 'body', type: 'Vec<Stmt>', description: 'Function body' },
-      { name: 'return_type', type: 'Option<TypeHint>', description: 'Return type', optional: true }
+      { name: 'return_type', type: 'Option<TypeHint>', description: 'Return type', optional: true },
+      { name: 'attributes', type: 'Vec<Attribute>', description: 'PHP attributes (#[...])' }
     ]
   },
   {
@@ -289,7 +294,7 @@ export const astNodes: AstNode[] = [
     name: 'InlineHtml',
     description: 'Inline HTML outside <?php ... ?>',
     phpExample: `<?php echo $php; ?>\nThis is HTML`,
-    keywordInExample: 'InlineHtml',
+    keywordInExample: 'echo',
     fieldHighlights: {
       html: ['This is HTML']
     },
@@ -351,7 +356,6 @@ export const astNodes: AstNode[] = [
     name: 'Nop',
     description: 'Empty statement (;)',
     phpExample: `<?php\n;`,
-    keywordInExample: 'nop',
     fields: []
   },
   {
@@ -528,7 +532,6 @@ export const astNodes: AstNode[] = [
     name: 'ArrayAccess',
     description: 'Array element access',
     phpExample: `<?php\n$arr[0];\n$arr[$key];\n$arr[];`,
-    keywordInExample: 'access',
     fieldHighlights: {
       array: ['$arr'],
       index: ['0', '$key']
@@ -555,7 +558,8 @@ export const astNodes: AstNode[] = [
       { name: 'by_ref', type: 'bool', description: 'Returns by reference' },
       { name: 'params', type: 'Vec<Param>', description: 'Parameters' },
       { name: 'return_type', type: 'Option<TypeHint>', description: 'Return type', optional: true },
-      { name: 'body', type: 'Expr', description: 'Function body (expression)' }
+      { name: 'body', type: 'Expr', description: 'Function body (expression)' },
+      { name: 'attributes', type: 'Vec<Attribute>', description: 'PHP attributes (#[...])' }
     ]
   },
   {
@@ -564,7 +568,6 @@ export const astNodes: AstNode[] = [
     name: 'Assign',
     description: 'Assignment and compound assignments',
     phpExample: `<?php\n$x = 10;\n$x += 5;\n$result ??= $default;`,
-    keywordInExample: 'null',
     fieldHighlights: {
       target: ['$x', '$result'],
       op: ['+=', '??='],
@@ -573,7 +576,8 @@ export const astNodes: AstNode[] = [
     fields: [
       { name: 'target', type: 'Expr', description: 'Assignment target' },
       { name: 'op', type: 'AssignOp', description: 'Assignment operator (=, +=, .=, etc)' },
-      { name: 'value', type: 'Expr', description: 'Value to assign' }
+      { name: 'value', type: 'Expr', description: 'Value to assign' },
+      { name: 'by_ref', type: 'bool', description: 'Reference assignment ($a =& $b)' }
     ]
   },
   {
@@ -582,7 +586,7 @@ export const astNodes: AstNode[] = [
     name: 'Binary',
     description: 'Binary operation',
     phpExample: `<?php\n$sum = $a + $b;\n$cmp = $x <=> $y;\n$obj instanceof MyClass;`,
-    keywordInExample: 'binary',
+    keywordInExample: 'instanceof',
     fieldHighlights: {
       left: ['$a', '$x', '$obj'],
       op: ['+', 'instanceof'],
@@ -614,7 +618,7 @@ export const astNodes: AstNode[] = [
     name: 'CallableCreate',
     description: 'Callable creation expression (first-class callables)',
     phpExample: `<?php\n$func = strlen(...);\n$method = $obj->method(...);\n$static = MyClass::staticMethod(...);`,
-    keywordInExample: 'callable',
+    phpVersion: '8.1+',
     fieldHighlights: {
       kind: ['strlen(...)', '$obj->method(...)', 'MyClass::staticMethod(...)']
     },
@@ -647,11 +651,11 @@ export const astNodes: AstNode[] = [
     keywordInExample: 'const',
     fieldHighlights: {
       class: ['MyClass'],
-      constant: ['VERSION', 'MY_CONST']
+      member: ['VERSION', 'MY_CONST']
     },
     fields: [
       { name: 'class', type: 'Expr', description: 'Class name' },
-      { name: 'constant', type: 'Expr', description: 'Constant name' }
+      { name: 'member', type: 'Expr', description: 'Constant name' }
     ]
   },
   {
@@ -660,6 +664,7 @@ export const astNodes: AstNode[] = [
     name: 'ClassConstAccessDynamic',
     description: 'Dynamic class constant access (Foo::{expr})',
     phpExample: `<?php\n$const = $version;\nFoo::{$const};`,
+    phpVersion: '8.3+',
     keywordInExample: 'const',
     fieldHighlights: {
       class: ['Foo'],
@@ -719,7 +724,8 @@ export const astNodes: AstNode[] = [
       { name: 'params', type: 'Vec<Param>', description: 'Parameters' },
       { name: 'use_vars', type: 'Vec<ClosureUseVar>', description: 'Use variables' },
       { name: 'return_type', type: 'Option<TypeHint>', description: 'Return type', optional: true },
-      { name: 'body', type: 'Vec<Stmt>', description: 'Function body' }
+      { name: 'body', type: 'Vec<Stmt>', description: 'Function body' },
+      { name: 'attributes', type: 'Vec<Attribute>', description: 'PHP attributes (#[...])' }
     ]
   },
   {
@@ -814,7 +820,7 @@ export const astNodes: AstNode[] = [
     name: 'Heredoc',
     description: 'Heredoc string with interpolation',
     phpExample: `<?php\n$name = $alice;\n$str = <<<EOT\nHello $name\nEOT;`,
-    keywordInExample: 'heredoc',
+    keywordInExample: 'EOT',
     fieldHighlights: {
       label: ['EOT'],
       parts: ['$name']
@@ -830,7 +836,7 @@ export const astNodes: AstNode[] = [
     name: 'Identifier',
     description: 'Bare name used as an expression (function name in a call, class name, etc.)',
     phpExample: `<?php\nstrlen($str);\nMyClass::method();`,
-    keywordInExample: 'identifier',
+    keywordInExample: 'strlen',
     fieldHighlights: {
       name: ['strlen', 'MyClass']
     },
@@ -874,7 +880,7 @@ export const astNodes: AstNode[] = [
     name: 'InterpolatedString',
     description: 'Double-quoted string with variable interpolation',
     phpExample: `<?php\n$name = $alice;\necho "Hello $name";\necho "Result: {$obj->prop}";`,
-    keywordInExample: 'interpolated',
+    keywordInExample: 'echo',
     fieldHighlights: {
       parts: ['$name', '$obj->prop']
     },
@@ -902,7 +908,7 @@ export const astNodes: AstNode[] = [
     name: 'MagicConst',
     description: 'Magic constant (__LINE__, __FILE__, etc)',
     phpExample: `<?php\necho __LINE__;\necho __FILE__;\necho __DIR__;`,
-    keywordInExample: 'magic',
+    keywordInExample: '__LINE__',
     fieldHighlights: {
       kind: ['__LINE__', '__FILE__', '__DIR__']
     },
@@ -967,7 +973,7 @@ export const astNodes: AstNode[] = [
     name: 'Nowdoc',
     description: 'Nowdoc string (no interpolation)',
     phpExample: `<?php\n$str = <<<'EOT'\nLiteral $text\nEOT;`,
-    keywordInExample: 'nowdoc',
+    keywordInExample: 'EOT',
     fieldHighlights: {
       label: ['EOT'],
       value: ['Literal $text']
@@ -1044,7 +1050,7 @@ export const astNodes: AstNode[] = [
     name: 'Omit',
     description: 'Omitted array element (skipped slot)',
     phpExample: `<?php\n[$a, , $c];\nlist($x, , $z) = [1, 2, 3];`,
-    keywordInExample: 'omit',
+    keywordInExample: 'list',
     fields: []
   },
   {
@@ -1053,7 +1059,6 @@ export const astNodes: AstNode[] = [
     name: 'Parenthesized',
     description: 'Expression wrapped in parentheses',
     phpExample: `<?php\n$result = ($a + $b) * $c;\n$value = ($x);`,
-    keywordInExample: 'parens',
     fieldHighlights: {
       expr: ['$a + $b', '$x']
     },
@@ -1097,7 +1102,7 @@ export const astNodes: AstNode[] = [
     name: 'ShellExec',
     description: 'Shell execution (backticks)',
     phpExample: `<?php\n$output = \`ls -la\`;\necho \`date\`;`,
-    keywordInExample: 'shell',
+    keywordInExample: 'echo',
     fieldHighlights: {
       parts: ['ls -la', 'date']
     },
@@ -1150,11 +1155,11 @@ export const astNodes: AstNode[] = [
     keywordInExample: 'static',
     fieldHighlights: {
       class: ['MyClass'],
-      property: ['$property', '$count']
+      member: ['$property', '$count']
     },
     fields: [
       { name: 'class', type: 'Expr', description: 'Class name' },
-      { name: 'property', type: 'Expr', description: 'Property name' }
+      { name: 'member', type: 'Expr', description: 'Property name' }
     ]
   },
   {
@@ -1177,11 +1182,10 @@ export const astNodes: AstNode[] = [
     id: 'expr-string',
     category: 'expression',
     name: 'String',
-    description: 'String literal',
-    phpExample: `<?php\n$str = $hello;\n$str2 = $world;`,
-    keywordInExample: 'string',
+    description: 'String literal (single-quoted or non-interpolated double-quoted)',
+    phpExample: `<?php\n$str = 'hello world';\n$str2 = "goodbye";`,
     fieldHighlights: {
-      value: ['$str', '$str2']
+      value: ['hello world', 'goodbye']
     },
     fields: [
       { name: 'value', type: 'string', description: 'String content' }
@@ -1226,7 +1230,6 @@ export const astNodes: AstNode[] = [
     name: 'UnaryPostfix',
     description: 'Postfix unary operation',
     phpExample: `<?php\n$x++;\n$y--;`,
-    keywordInExample: 'postfix',
     fieldHighlights: {
       operand: ['$x', '$y'],
       op: ['$x++', '$y--']
@@ -1242,7 +1245,6 @@ export const astNodes: AstNode[] = [
     name: 'UnaryPrefix',
     description: 'Prefix unary operation',
     phpExample: `<?php\n$neg = -$x;\n$not = !$flag;\n$inc = ++$counter;`,
-    keywordInExample: 'unary',
     fieldHighlights: {
       op: ['-$x', '!$flag', '++$counter'],
       operand: ['$x', '$flag', '$counter']
@@ -1357,6 +1359,7 @@ export const astNodes: AstNode[] = [
       { name: 'is_static', type: 'bool', description: 'Is static' },
       { name: 'is_abstract', type: 'bool', description: 'Is abstract' },
       { name: 'is_final', type: 'bool', description: 'Is final' },
+      { name: 'by_ref', type: 'bool', description: 'Returns by reference (&method)' },
       { name: 'params', type: 'Vec<Param>', description: 'Parameters' },
       { name: 'return_type', type: 'Option<TypeHint>', description: 'Return type', optional: true },
       { name: 'body', type: 'Option<Vec<Stmt>>', description: 'Method body', optional: true }
@@ -1367,21 +1370,27 @@ export const astNodes: AstNode[] = [
     category: 'declaration',
     name: 'Param',
     description: 'Function/method parameter',
-    phpExample: `<?php\nfunction foo(string $name, int $age = 0, &$ref = null) {}`,
-    keywordInExample: 'param',
+    phpExample: `<?php\nfunction foo(string $name, int $age = 0, &$ref = null, ...$rest) {}`,
+    keywordInExample: 'function',
     fieldHighlights: {
-      name: ['$name', '$age', '$ref'],
+      name: ['$name', '$age', '$ref', '$rest'],
       type_hint: ['string', 'int'],
       default: ['0', 'null'],
       by_ref: ['&$ref'],
-      variadic: []
+      variadic: ['...$rest']
     },
     fields: [
       { name: 'name', type: 'Ident', description: 'Parameter name' },
       { name: 'type_hint', type: 'Option<TypeHint>', description: 'Type hint', optional: true },
       { name: 'default', type: 'Option<Expr>', description: 'Default value', optional: true },
       { name: 'by_ref', type: 'bool', description: 'Passed by reference' },
-      { name: 'variadic', type: 'bool', description: 'Variadic (...$args)' }
+      { name: 'variadic', type: 'bool', description: 'Variadic (...$args)' },
+      { name: 'visibility', type: 'Option<Visibility>', description: 'Constructor promotion visibility', optional: true },
+      { name: 'set_visibility', type: 'Option<Visibility>', description: 'Asymmetric set visibility (PHP 8.4+)', optional: true },
+      { name: 'is_readonly', type: 'bool', description: 'Readonly promoted property (PHP 8.1+)' },
+      { name: 'is_final', type: 'bool', description: 'Final promoted property (PHP 8.4+)' },
+      { name: 'attributes', type: 'Vec<Attribute>', description: 'PHP attributes (#[...])' },
+      { name: 'hooks', type: 'Vec<PropertyHook>', description: 'Property hooks on promoted parameter (PHP 8.4+)' }
     ]
   },
   {
@@ -1400,7 +1409,8 @@ export const astNodes: AstNode[] = [
     },
     fields: [
       { name: 'name', type: 'Ident', description: 'Property name' },
-      { name: 'visibility', type: 'Visibility', description: 'public/protected/private' },
+      { name: 'visibility', type: 'Option<Visibility>', description: 'public/protected/private', optional: true },
+      { name: 'set_visibility', type: 'Option<Visibility>', description: 'Asymmetric set visibility (PHP 8.4+)', optional: true },
       { name: 'is_static', type: 'bool', description: 'Is static' },
       { name: 'is_readonly', type: 'bool', description: 'Is readonly' },
       { name: 'type_hint', type: 'Option<TypeHint>', description: 'Type hint', optional: true },
@@ -1508,7 +1518,6 @@ export const astNodes: AstNode[] = [
     name: 'Arg',
     description: 'Function/method argument',
     phpExample: `<?php\nfoo($a, $b, name: $c, ...$spread);`,
-    keywordInExample: 'arg',
     fieldHighlights: {
       name: ['name'],
       value: ['$a', '$b', '$c', '$spread'],
@@ -1527,7 +1536,6 @@ export const astNodes: AstNode[] = [
     name: 'ArrayElement',
     description: 'A single element in an array literal',
     phpExample: `<?php\n[$val, $key => $val2, ...$spread];`,
-    keywordInExample: 'element',
     fieldHighlights: {
       key: ['$key'],
       value: ['$val', '$val2', '$spread'],
@@ -1628,7 +1636,7 @@ export const astNodes: AstNode[] = [
     name: 'MatchArm',
     description: 'A single arm in a match expression',
     phpExample: `<?php\nmatch($x) {\n  1, 2 => $small,\n  default => $other\n};`,
-    keywordInExample: 'arm',
+    keywordInExample: 'default',
     fieldHighlights: {
       conditions: ['1', '2'],
       body: ['$small', '$other']
@@ -1644,10 +1652,10 @@ export const astNodes: AstNode[] = [
     name: 'Name',
     description: 'Namespace-qualified name',
     phpExample: `<?php\nuse App\\Models\\User;\nclass Post extends BaseModel {}`,
-    keywordInExample: 'name',
+    keywordInExample: 'use',
     fieldHighlights: {
       parts: ['App\\\\Models\\\\User', 'BaseModel'],
-      kind: ['use', 'extends']
+      kind: ['Unqualified', 'Qualified', 'FullyQualified']
     },
     fields: [
       { name: 'parts', type: 'Vec<string>', description: 'Name parts (e.g., ["App", "Models", "User"])' },
@@ -1660,7 +1668,7 @@ export const astNodes: AstNode[] = [
     name: 'Program',
     description: 'Root AST node containing all top-level statements',
     phpExample: `<?php\n$x = 1;\necho $x;`,
-    keywordInExample: 'program',
+    keywordInExample: 'echo',
     fieldHighlights: {
       stmts: ['$x = 1', 'echo $x']
     },
@@ -1674,7 +1682,6 @@ export const astNodes: AstNode[] = [
     name: 'Span',
     description: 'Source code location (start and end byte offsets)',
     phpExample: `<?php\n// Every AST node has a Span indicating where in the source it appears`,
-    keywordInExample: 'span',
     fieldHighlights: {
       start: ['start'],
       end: ['end']
@@ -1706,7 +1713,7 @@ export const astNodes: AstNode[] = [
     name: 'StringPart',
     description: 'A part of an interpolated string (literal text or embedded expression)',
     phpExample: `<?php\n$name = $alice;\necho "Hello $name, you are {$age} old";`,
-    keywordInExample: 'part',
+    keywordInExample: 'echo',
     fieldHighlights: {
       kind: ['Hello ', '$name', '$age', ' old']
     },

--- a/playground/src/data/ast-nodes.ts
+++ b/playground/src/data/ast-nodes.ts
@@ -13,7 +13,7 @@ export interface AstNode {
   phpExample: string
   fields?: NodeField[]
   phpVersion?: string
-  keywordInExample?: string
+  keywordInExample?: string | string[]
   fieldHighlights?: Record<string, string[]>
 }
 
@@ -24,10 +24,10 @@ export const astNodes: AstNode[] = [
     group: 'Control Flow',
     name: 'Block',
     description: 'Block of statements',
-    phpExample: `<?php\n{\n  $x = 1;\n  echo $x;\n}`,
-    keywordInExample: 'block',
+    phpExample: `{\n  $x = 1;\n  echo $x;\n}`,
+    keywordInExample: ['{', '}'],
     fieldHighlights: {
-      stmts: ['$x = 1', 'echo $x']
+      stmts: ['$x = 1;', 'echo $x;']
     },
     fields: [
       { name: 'stmts', type: 'Vec<Stmt>', description: 'Statements in block' }
@@ -38,7 +38,7 @@ export const astNodes: AstNode[] = [
     group: 'Control Flow',
     name: 'Break',
     description: 'Break from loop or switch',
-    phpExample: `<?php\nwhile (true) {\n  if ($done) break 2;\n}`,
+    phpExample: `while (true) {\n  if ($done) break;\n}\n\nfor ($i = 0; $i < 5; $i++) {\n  while (true) {\n    if ($done) break 2;\n  }\n}`,
     keywordInExample: 'break',
     fieldHighlights: {
       level: ['2']
@@ -52,13 +52,15 @@ export const astNodes: AstNode[] = [
     group: 'Define Code',
     name: 'Class',
     description: 'Class declaration',
-    phpExample: `<?php\nclass Animal extends Base implements Countable {\n  public string $name;\n  public function speak(): void {}\n}`,
+    phpExample: `#[Entity]\nfinal class Animal extends Base implements Countable {\n  public string $name;\n  public function speak(): void {}\n}`,
     keywordInExample: 'class',
     fieldHighlights: {
       name: ['Animal'],
-      extends: ['Base'],
-      implements: ['Countable'],
-      members: ['public string $name', 'public function speak']
+      modifiers: ['final'],
+      extends: ['extends Base'],
+      implements: ['implements Countable'],
+      members: ['public string $name;', 'public function speak(): void {}'],
+      attributes: ['#[Entity]']
     },
     fields: [
       { name: 'name', type: 'Ident', description: 'Class name' },
@@ -74,7 +76,7 @@ export const astNodes: AstNode[] = [
     group: 'Define Code',
     name: 'Const',
     description: 'Global constant declaration',
-    phpExample: `<?php\nconst MAX_SIZE = 100;\nconst DB_HOST = DB_DEFAULT_HOST;`,
+    phpExample: `const MAX_SIZE = 100;\nconst DB_HOST = DB_DEFAULT_HOST;`,
     keywordInExample: 'const',
     fieldHighlights: {
       items: ['MAX_SIZE = 100', 'DB_HOST = DB_DEFAULT_HOST']
@@ -88,10 +90,10 @@ export const astNodes: AstNode[] = [
     group: 'Control Flow',
     name: 'Continue',
     description: 'Continue to next iteration of loop',
-    phpExample: `<?php\nfor ($i = 0; $i != 10; $i++) {\n  if ($i % 2 == 0) continue;\n  echo $i;\n}`,
+    phpExample: `for ($i = 0; $i != 10; $i++) {\n  if ($i < 0) continue;\n  echo $i;\n}\n\nfor ($i = 0; $i != 10; $i++) {\n  while (true) {\n    if ($done) continue 2;\n  }\n}`,
     keywordInExample: 'continue',
     fieldHighlights: {
-      level: ['continue']
+      level: ['2']
     },
     fields: [
       { name: 'level', type: 'Option<Expr>', description: 'Number of levels to continue', optional: true }
@@ -102,7 +104,7 @@ export const astNodes: AstNode[] = [
     group: 'Define Code',
     name: 'Declare',
     description: 'Declare directives like strict_types',
-    phpExample: `<?php\ndeclare(strict_types=1);\ndeclare(ticks=1) {}`,
+    phpExample: `declare(strict_types=1);\ndeclare(ticks=1) {}`,
     keywordInExample: 'declare',
     fieldHighlights: {
       directives: ['strict_types=1', 'ticks=1'],
@@ -118,10 +120,10 @@ export const astNodes: AstNode[] = [
     group: 'Control Flow',
     name: 'DoWhile',
     description: 'Do-while loop (executes at least once)',
-    phpExample: `<?php\ndo {\n  echo $x;\n  $x--;\n} while ($x != 0);`,
-    keywordInExample: 'do',
+    phpExample: `do {\n  echo $x;\n  $x--;\n} while ($x != 0);`,
+    keywordInExample: ['do', 'while'],
     fieldHighlights: {
-      body: ['echo $x', '$x--'],
+      body: ['echo $x;', '$x--;'],
       condition: ['$x != 0']
     },
     fields: [
@@ -134,11 +136,10 @@ export const astNodes: AstNode[] = [
     group: 'Output/Communication',
     name: 'Echo',
     description: 'Output one or more values',
-    phpExample: `<?php\necho $greeting, $name, PHP_EOL;`,
+    phpExample: `echo $greeting, $name, PHP_EOL;\necho "done";`,
     keywordInExample: 'echo',
     fieldHighlights: {
-      keyword: ['echo'],
-      exprs: ['$greeting', '$name', 'PHP_EOL']
+      exprs: ['$greeting', '$name', 'PHP_EOL', '"done"']
     },
     fields: [
       { name: 'exprs', type: 'Vec<Expr>', description: 'Values to output' }
@@ -149,13 +150,14 @@ export const astNodes: AstNode[] = [
     group: 'Define Code',
     name: 'Enum',
     description: 'Enumeration declaration (PHP 8.1+)',
-    phpExample: `<?php\nenum Status: string {\n  case Active = STATUS_ACTIVE;\n  case Inactive = STATUS_INACTIVE;\n}`,
+    phpExample: `enum Status: string implements Countable {\n  case Active = STATUS_ACTIVE;\n  case Inactive = STATUS_INACTIVE;\n}`,
     phpVersion: '8.1+',
     keywordInExample: 'enum',
     fieldHighlights: {
       name: ['Status'],
       scalar_type: ['string'],
-      members: ['case Active', 'case Inactive']
+      implements: ['implements Countable'],
+      members: ['case Active = STATUS_ACTIVE;', 'case Inactive = STATUS_INACTIVE;']
     },
     fields: [
       { name: 'name', type: 'Ident', description: 'Enum name' },
@@ -169,13 +171,13 @@ export const astNodes: AstNode[] = [
     group: 'Control Flow',
     name: 'For',
     description: 'For loop with init/condition/update',
-    phpExample: `<?php\nfor ($i = 0; $i != 10; $i++) {\n  echo $i;\n}`,
+    phpExample: `for ($i = 0; $i != 10; $i++) {\n  echo $i;\n}`,
     keywordInExample: 'for',
     fieldHighlights: {
       init: ['$i = 0'],
       condition: ['$i != 10'],
       update: ['$i++'],
-      body: ['echo $i']
+      body: ['echo $i;']
     },
     fields: [
       { name: 'init', type: 'Vec<Expr>', description: 'Initialization expressions' },
@@ -189,7 +191,7 @@ export const astNodes: AstNode[] = [
     group: 'Control Flow',
     name: 'Foreach',
     description: 'Foreach loop over an array or iterable',
-    phpExample: `<?php\nforeach ($arr as $key => $value) {\n  echo $key;\n  echo $value;\n}`,
+    phpExample: `foreach ($arr as $key => $value) {\n  echo $key;\n  echo $value;\n}`,
     keywordInExample: 'foreach',
     fieldHighlights: {
       expr: ['$arr'],
@@ -209,13 +211,15 @@ export const astNodes: AstNode[] = [
     group: 'Define Code',
     name: 'Function',
     description: 'Function declaration',
-    phpExample: `<?php\nfunction greet($name): string {\n  return $name;\n}`,
+    phpExample: `#[Route('/api')]\nfunction &greet(string $name): string {\n  return $name;\n}`,
     keywordInExample: 'function',
     fieldHighlights: {
       name: ['greet'],
-      params: ['$name'],
+      by_ref: ['&'],
+      params: ['string $name'],
       return_type: ['string'],
-      body: ['return $name']
+      body: ['return $name'],
+      attributes: ['#[Route(\'/api\')]']
     },
     fields: [
       { name: 'name', type: 'Ident', description: 'Function name' },
@@ -231,10 +235,10 @@ export const astNodes: AstNode[] = [
     group: 'Define Code',
     name: 'Global',
     description: 'Declare global variables',
-    phpExample: `<?php\n$x = 1;\n\nfunction test() {\n  global $x;\n  $x = 2;\n}`,
+    phpExample: `function test() {\n  global $counter, $name;\n}`,
     keywordInExample: 'global',
     fieldHighlights: {
-      vars: ['$x']
+      vars: ['$counter', '$name']
     },
     fields: [
       { name: 'vars', type: 'Vec<Expr>', description: 'Variables to declare global' }
@@ -245,7 +249,7 @@ export const astNodes: AstNode[] = [
     group: 'Define Code',
     name: 'Goto',
     description: 'Go to label',
-    phpExample: `<?php\ngoto end;\necho $skipped;\nend:\necho $done;`,
+    phpExample: `goto end;\necho $skipped;\nend:\necho $done;`,
     keywordInExample: 'goto',
     fieldHighlights: {
       label: ['end']
@@ -259,7 +263,7 @@ export const astNodes: AstNode[] = [
     group: 'Define Code',
     name: 'HaltCompiler',
     description: '__halt_compiler() — everything after is raw data ignored by PHP',
-    phpExample: `<?php\n__halt_compiler();\nThis data is ignored by PHP.`,
+    phpExample: `__halt_compiler();\nThis data is ignored by PHP.`,
     keywordInExample: '__halt_compiler',
     fieldHighlights: {
       data: ['This data is ignored by PHP.']
@@ -273,13 +277,13 @@ export const astNodes: AstNode[] = [
     group: 'Control Flow',
     name: 'If',
     description: 'Conditional statement with if/elseif/else branches',
-    phpExample: `<?php\nif ($x == 1) {\n  echo $positive;\n} elseif ($x == 2) {\n  echo $negative;\n} else {\n  echo $zero;\n}`,
+    phpExample: `if ($x == 1) {\n  echo $positive;\n} elseif ($x == 2) {\n  echo $negative;\n} else {\n  echo $zero;\n}`,
     keywordInExample: 'if',
     fieldHighlights: {
       condition: ['$x == 1'],
-      then_branch: ['echo $positive'],
-      elseif_branches: ['elseif ($x == 2)'],
-      else_branch: ['echo $zero']
+      then_branch: ['{\n  echo $positive;\n}'],
+      elseif_branches: ['elseif ($x == 2) {\n  echo $negative;\n}'],
+      else_branch: ['else {\n  echo $zero;\n}']
     },
     fields: [
       { name: 'condition', type: 'Expr', description: 'Condition to evaluate' },
@@ -294,7 +298,6 @@ export const astNodes: AstNode[] = [
     name: 'InlineHtml',
     description: 'Inline HTML outside <?php ... ?>',
     phpExample: `<?php echo $php; ?>\nThis is HTML`,
-    keywordInExample: 'echo',
     fieldHighlights: {
       html: ['This is HTML']
     },
@@ -307,12 +310,12 @@ export const astNodes: AstNode[] = [
     group: 'Define Code',
     name: 'Interface',
     description: 'Interface declaration',
-    phpExample: `<?php\ninterface Drawable extends Countable {\n  public function draw(): void;\n}`,
+    phpExample: `interface Drawable extends Countable {\n  public function draw(): void;\n}`,
     keywordInExample: 'interface',
     fieldHighlights: {
       name: ['Drawable'],
-      extends: ['Countable'],
-      members: ['public function draw']
+      extends: ['extends Countable'],
+      members: ['public function draw(): void;']
     },
     fields: [
       { name: 'name', type: 'Ident', description: 'Interface name' },
@@ -324,9 +327,8 @@ export const astNodes: AstNode[] = [
     id: 'stmt-label',
     group: 'Define Code',
     name: 'Label',
-    description: 'Label definition',
-    phpExample: `<?php\nloop:\necho $label;\ngoto loop;`,
-    keywordInExample: 'label',
+    description: 'Target point for goto statements',
+    phpExample: `loop:\necho $counter;\ngoto loop;`,
     fieldHighlights: {
       name: ['loop']
     },
@@ -339,11 +341,11 @@ export const astNodes: AstNode[] = [
     group: 'Define Code',
     name: 'Namespace',
     description: 'Namespace declaration',
-    phpExample: `<?php\nnamespace App\\Controllers;\n\nclass Home {}`,
+    phpExample: `namespace App\\Utils {\n  function helper() {}\n  class Helper {}\n}\n\nnamespace {\n  $x = 1;\n}\n`,
     keywordInExample: 'namespace',
     fieldHighlights: {
-      name: ['App\\\\Controllers'],
-      body: ['class Home']
+      name: ['App\\Utils'],
+      body: ['function helper() {}', 'class Helper {}', '$x = 1;']
     },
     fields: [
       { name: 'name', type: 'Option<Name>', description: 'Namespace name', optional: true },
@@ -355,7 +357,7 @@ export const astNodes: AstNode[] = [
     group: 'Define Code',
     name: 'Nop',
     description: 'Empty statement (;)',
-    phpExample: `<?php\n;`,
+    phpExample: `;`,
     fields: []
   },
   {
@@ -363,7 +365,7 @@ export const astNodes: AstNode[] = [
     group: 'Control Flow',
     name: 'Return',
     description: 'Return from a function or method',
-    phpExample: `<?php\nfunction add($a, $b) {\n  return $a + $b;\n}`,
+    phpExample: `function add($a, $b) {\n  return $a + $b;\n}`,
     keywordInExample: 'return',
     fieldHighlights: {
       keyword: ['return'],
@@ -378,10 +380,10 @@ export const astNodes: AstNode[] = [
     group: 'Define Code',
     name: 'StaticVar',
     description: 'Static variable declaration',
-    phpExample: `<?php\nfunction counter() {\n  static $count = 0;\n  return ++$count;\n}`,
+    phpExample: `function counter() {\n  static $count = 0, $max = 100;\n  return ++$count;\n}`,
     keywordInExample: 'static',
     fieldHighlights: {
-      vars: ['$count = 0']
+      vars: ['$count = 0', '$max = 100']
     },
     fields: [
       { name: 'vars', type: 'Vec<StaticVar>', description: 'Static variables' }
@@ -392,11 +394,11 @@ export const astNodes: AstNode[] = [
     group: 'Control Flow',
     name: 'Switch',
     description: 'Switch statement with cases and default',
-    phpExample: `<?php\nswitch ($x) {\n  case 1:\n    echo $x;\n    break;\n  default:\n    echo $default;\n}`,
+    phpExample: `switch ($x) {\n  case 1:\n    $found = true;\n    break;\n  default:\n    echo $default;\n}`,
     keywordInExample: 'switch',
     fieldHighlights: {
       expr: ['$x'],
-      cases: ['case 1', 'default']
+      cases: ['case 1:\n    $found = true;\n    break;', 'default:\n    echo $default;']
     },
     fields: [
       { name: 'expr', type: 'Expr', description: 'Value to switch on' },
@@ -408,10 +410,10 @@ export const astNodes: AstNode[] = [
     group: 'Control Flow',
     name: 'Throw',
     description: 'Throw an exception',
-    phpExample: `<?php\nthrow new RuntimeException($message);`,
+    phpExample: `try {\n  if ($invalid) {\n    throw new InvalidArgumentException($reason);\n  }\n} catch (InvalidArgumentException $e) {\n  echo $e->getMessage();\n}`,
     keywordInExample: 'throw',
     fieldHighlights: {
-      exception: ['new RuntimeException($message)']
+      exception: ['new InvalidArgumentException($reason)']
     },
     fields: [
       { name: 'exception', type: 'Expr', description: 'Exception to throw' }
@@ -422,15 +424,15 @@ export const astNodes: AstNode[] = [
     group: 'Define Code',
     name: 'Trait',
     description: 'Trait declaration',
-    phpExample: `<?php\ntrait Logger {\n  public function log($msg) { echo $msg; }\n}`,
+    phpExample: `trait Logger {\n  private string $name;\n\n  public function log($msg) { echo $msg; }\n}`,
     keywordInExample: 'trait',
     fieldHighlights: {
       name: ['Logger'],
-      members: ['public function log']
+      members: ['private string $name;', 'public function log($msg) { echo $msg; }']
     },
     fields: [
       { name: 'name', type: 'Ident', description: 'Trait name' },
-      { name: 'members', type: 'Vec<ClassMember>', description: 'Methods' }
+      { name: 'members', type: 'Vec<ClassMember>', description: 'Methods and properties' }
     ]
   },
   {
@@ -438,12 +440,12 @@ export const astNodes: AstNode[] = [
     group: 'Control Flow',
     name: 'TryCatch',
     description: 'Try-catch-finally block',
-    phpExample: `<?php\ntry {\n  $x = 1 / 0;\n} catch (DivisionByZeroError $e) {\n  echo $e->getMessage();\n} finally {\n  echo $done;\n}`,
+    phpExample: `try {\n  $x = 1 / 0;\n} catch (DivisionByZeroError $e) {\n  echo $e->getMessage();\n} catch (Exception $e) {\n  echo "Error";\n} finally {\n  echo $done;\n}`,
     keywordInExample: 'try',
     fieldHighlights: {
       body: ['$x = 1 / 0'],
-      catches: ['catch (DivisionByZeroError $e)'],
-      finally: ['echo $done']
+      catches: ['catch (DivisionByZeroError $e) {\n  echo $e->getMessage();\n}', 'catch (Exception $e) {\n  echo "Error";\n}'],
+      finally: ['finally {\n  echo $done;\n}']
     },
     fields: [
       { name: 'body', type: 'Vec<Stmt>', description: 'Try block' },
@@ -455,10 +457,10 @@ export const astNodes: AstNode[] = [
     id: 'stmt-unset',
     name: 'Unset',
     description: 'Unset variables',
-    phpExample: `<?php\nunset($a, $b, $arr[$key]);`,
+    phpExample: `unset($a, $b, $arr[$key]);`,
     keywordInExample: 'unset',
     fieldHighlights: {
-      vars: ['$a', '$b', '$arr[$key]']
+      vars: ['$a,', '$b,', '$arr[$key]']
     },
     fields: [
       { name: 'vars', type: 'Vec<Expr>', description: 'Variables to unset' }
@@ -469,11 +471,11 @@ export const astNodes: AstNode[] = [
     group: 'Define Code',
     name: 'Use',
     description: 'Use (import) statement',
-    phpExample: `<?php\nuse App\\Models\\User;\nuse function Helper\\debug;`,
+    phpExample: `use App\\Models\\User;\nuse function Helper\\debug;\nuse const DB\\HOST;`,
     keywordInExample: 'use',
     fieldHighlights: {
-      kind: ['use function'],
-      uses: ['App\\\\Models\\\\User', 'Helper\\\\debug']
+      kind: ['function', 'const'],
+      uses: ['App\\Models\\User', 'Helper\\debug', 'DB\\HOST']
     },
     fields: [
       { name: 'kind', type: 'UseKind', description: 'Type of use (Normal, Function, Const)' },
@@ -485,11 +487,11 @@ export const astNodes: AstNode[] = [
     group: 'Control Flow',
     name: 'While',
     description: 'While loop',
-    phpExample: `<?php\nwhile ($x != 0) {\n  echo $x;\n  $x--;\n}`,
+    phpExample: `while ($x != 0) {\n  echo $x;\n  $x--;\n}`,
     keywordInExample: 'while',
     fieldHighlights: {
       condition: ['$x != 0'],
-      body: ['echo $x', '$x--']
+      body: ['echo $x;', '$x--;']
     },
     fields: [
       { name: 'condition', type: 'Expr', description: 'Loop condition' },
@@ -502,13 +504,17 @@ export const astNodes: AstNode[] = [
     group: 'Class/Object Operations',
     name: 'AnonymousClass',
     description: 'Anonymous class instance (inline class definition)',
-    phpExample: `<?php\n$obj = new class extends Base implements Countable {\n  public function method() {}\n};`,
+    phpExample: `new class extends Base implements Countable {\n  private string $value;\n\n  public function method() {}\n}`,
     keywordInExample: 'class',
     fieldHighlights: {
-      class: ['extends Base implements Countable', 'public function method']
+      extends: ['extends Base'],
+      implements: ['implements Countable'],
+      members: ['private string $value;', 'public function method() {}']
     },
     fields: [
-      { name: 'class', type: 'ClassDecl', description: 'Anonymous class declaration' }
+      { name: 'extends', type: 'Option<Name>', description: 'Parent class', optional: true },
+      { name: 'implements', type: 'Vec<Name>', description: 'Interfaces' },
+      { name: 'members', type: 'Vec<ClassMember>', description: 'Properties and methods' }
     ]
   },
   {
@@ -516,10 +522,10 @@ export const astNodes: AstNode[] = [
     group: 'Variables & Values',
     name: 'Array',
     description: 'Array literal',
-    phpExample: `<?php\n[1, 2, 3];\n[$key => $val, $key2 => $val2];\n[...$items];`,
+    phpExample: `[1, 2, 3];\n[$a => $x, $b => $y];\narray(...$items);`,
     keywordInExample: 'array',
     fieldHighlights: {
-      elements: ['1', '2', '3', '$key => $val', '$key2 => $val2', '...$items']
+      elements: ['1', '2', '3', '$a => $x', '$b => $y', '...$items']
     },
     fields: [
       { name: 'elements', type: 'Vec<ArrayElement>', description: 'Array elements' }
@@ -530,7 +536,7 @@ export const astNodes: AstNode[] = [
     group: 'Operations',
     name: 'ArrayAccess',
     description: 'Array element access',
-    phpExample: `<?php\n$arr[0];\n$arr[$key];\n$arr[];`,
+    phpExample: `$arr[0];\n$arr[$key];\n$arr[];`,
     fieldHighlights: {
       array: ['$arr'],
       index: ['0', '$key']
@@ -545,12 +551,16 @@ export const astNodes: AstNode[] = [
     group: 'Function/Method Calls',
     name: 'ArrowFunction',
     description: 'Arrow function (short closure, PHP 7.4+)',
-    phpExample: `<?php\n$square = fn($x) => $x * $x;\n$double = fn($n) => $n * 2;`,
+    phpExample: `#[Pure]\nstatic fn&(int $x): int => $x * $x;\nfn($a, $b): string => $a . $b;`,
     phpVersion: '7.4+',
-    keywordInExample: 'arrow',
+    keywordInExample: 'fn',
     fieldHighlights: {
-      params: ['$x', '$n'],
-      body: ['$x * $x', '$n * 2']
+      is_static: ['static'],
+      by_ref: ['&'],
+      params: ['int $x', '$a, $b'],
+      return_type: ['int', 'string'],
+      body: ['$x * $x', '$a . $b'],
+      attributes: ['#[Pure]']
     },
     fields: [
       { name: 'is_static', type: 'bool', description: 'Is static' },
@@ -566,11 +576,12 @@ export const astNodes: AstNode[] = [
     group: 'Operations',
     name: 'Assign',
     description: 'Assignment and compound assignments',
-    phpExample: `<?php\n$x = 10;\n$x += 5;\n$result ??= $default;`,
+    phpExample: `$x = 10;\n$x += 5;\n$ref =& $original;\n$result ??= $default;`,
     fieldHighlights: {
-      target: ['$x', '$result'],
-      op: ['+=', '??='],
-      value: ['10', '5', '$default']
+      target: ['$x', '$ref', '$result'],
+      op: ['+=', '=&', '??='],
+      value: ['10', '5', '$original', '$default'],
+      by_ref: ['=&']
     },
     fields: [
       { name: 'target', type: 'Expr', description: 'Assignment target' },
@@ -584,11 +595,10 @@ export const astNodes: AstNode[] = [
     group: 'Operations',
     name: 'Binary',
     description: 'Binary operation',
-    phpExample: `<?php\n$sum = $a + $b;\n$cmp = $x <=> $y;\n$obj instanceof MyClass;`,
-    keywordInExample: 'instanceof',
+    phpExample: `$sum = $a + $b;\n$cmp = $x <=> $y;\n$obj instanceof MyClass;`,
     fieldHighlights: {
       left: ['$a', '$x', '$obj'],
-      op: ['+', 'instanceof'],
+      op: ['+', '<=>', 'instanceof'],
       right: ['$b', '$y', 'MyClass']
     },
     fields: [
@@ -602,8 +612,8 @@ export const astNodes: AstNode[] = [
     group: 'Variables & Values',
     name: 'Bool',
     description: 'Boolean literal',
-    phpExample: `<?php\n$yes = true;\n$no = false;`,
-    keywordInExample: 'true',
+    phpExample: `$yes = true;\n$no = false;`,
+    keywordInExample: ['true', 'false'],
     fieldHighlights: {
       value: ['true', 'false']
     },
@@ -616,7 +626,7 @@ export const astNodes: AstNode[] = [
     group: 'Function/Method Calls',
     name: 'CallableCreate',
     description: 'Callable creation expression (first-class callables)',
-    phpExample: `<?php\n$func = strlen(...);\n$method = $obj->method(...);\n$static = MyClass::staticMethod(...);`,
+    phpExample: `$func = strlen(...);\n$method = $obj->method(...);\n$static = MyClass::staticMethod(...);`,
     phpVersion: '8.1+',
     fieldHighlights: {
       kind: ['strlen(...)', '$obj->method(...)', 'MyClass::staticMethod(...)']
@@ -630,8 +640,7 @@ export const astNodes: AstNode[] = [
     group: 'Operations',
     name: 'Cast',
     description: 'Type cast',
-    phpExample: `<?php\n(int)$x;\n(string)$val;\n(array)$obj;`,
-    keywordInExample: 'cast',
+    phpExample: `(int)$x;\n(string)$val;\n(array)$obj;`,
     fieldHighlights: {
       kind: ['(int)', '(string)', '(array)'],
       operand: ['$x', '$val', '$obj']
@@ -646,8 +655,7 @@ export const astNodes: AstNode[] = [
     group: 'Class/Object Operations',
     name: 'ClassConstAccess',
     description: 'Class constant access',
-    phpExample: `<?php\nMyClass::VERSION;\nMyClass::MY_CONST;`,
-    keywordInExample: 'const',
+    phpExample: `MyClass::VERSION;\nMyClass::MY_CONST;`,
     fieldHighlights: {
       class: ['MyClass'],
       member: ['VERSION', 'MY_CONST']
@@ -662,12 +670,11 @@ export const astNodes: AstNode[] = [
     group: 'Class/Object Operations',
     name: 'ClassConstAccessDynamic',
     description: 'Dynamic class constant access (Foo::{expr})',
-    phpExample: `<?php\n$const = $version;\nFoo::{$const};`,
+    phpExample: `$const = $version;\nFoo::{$const};`,
     phpVersion: '8.3+',
-    keywordInExample: 'const',
     fieldHighlights: {
       class: ['Foo'],
-      member: ['$const']
+      member: ['{$const}']
     },
     fields: [
       { name: 'class', type: 'Expr', description: 'Class name' },
@@ -679,7 +686,7 @@ export const astNodes: AstNode[] = [
     group: 'Class/Object Operations',
     name: 'Clone',
     description: 'Clone an object',
-    phpExample: `<?php\n$copy = clone $original;`,
+    phpExample: `$copy = clone $original;`,
     keywordInExample: 'clone',
     fieldHighlights: {
       object: ['$original']
@@ -693,16 +700,16 @@ export const astNodes: AstNode[] = [
     group: 'Class/Object Operations',
     name: 'CloneWith',
     description: 'Clone with property overrides (PHP 8.5+)',
-    phpExample: `<?php\n$obj2 = clone($obj, prop: $value);`,
+    phpExample: `clone($obj, id: $newId, status: "active");`,
     phpVersion: '8.5+',
     keywordInExample: 'clone',
     fieldHighlights: {
       object: ['$obj'],
-      properties: ['prop: $value']
+      properties: ['id: $newId', 'status: "active"']
     },
     fields: [
       { name: 'object', type: 'Expr', description: 'Object to clone' },
-      { name: 'properties', type: 'Expr', description: 'Property overrides' }
+      { name: 'properties', type: 'Vec<PropertyPair>', description: 'Property overrides' }
     ]
   },
   {
@@ -710,12 +717,16 @@ export const astNodes: AstNode[] = [
     group: 'Function/Method Calls',
     name: 'Closure',
     description: 'Anonymous function (closure)',
-    phpExample: `<?php\n$add = function($a, $b) use ($multiplier) {\n  return ($a + $b) * $multiplier;\n};`,
+    phpExample: `#[Pure]\nstatic function&(int $a, int $b) use (&$multiplier): float {\n  return ($a + $b) * $multiplier;\n}`,
     keywordInExample: 'function',
     fieldHighlights: {
-      params: ['$a', '$b'],
-      use_vars: ['$multiplier'],
-      body: ['return ($a + $b) * $multiplier']
+      is_static: ['static'],
+      by_ref: ['&'],
+      params: ['int $a', 'int $b'],
+      use_vars: ['use (&$multiplier)'],
+      return_type: ['float'],
+      body: ['return ($a + $b) * $multiplier;'],
+      attributes: ['#[Pure]']
     },
     fields: [
       { name: 'is_static', type: 'bool', description: 'Is static closure' },
@@ -732,7 +743,7 @@ export const astNodes: AstNode[] = [
     group: 'Other Expressions',
     name: 'Empty',
     description: 'Check if variable is empty',
-    phpExample: `<?php\nempty($var);\nif (empty($str)) {}`,
+    phpExample: `empty($var);\nif (empty($str)) {}`,
     keywordInExample: 'empty',
     fieldHighlights: {
       var: ['$var', '$str']
@@ -746,8 +757,8 @@ export const astNodes: AstNode[] = [
     group: 'Other Expressions',
     name: 'ErrorSuppress',
     description: 'Error suppression operator (@)',
-    phpExample: `<?php\n@file_get_contents($path);\n@$arr[$key];`,
-    keywordInExample: 'suppress',
+    phpExample: `@file_get_contents($path);\n@$arr[$key];`,
+    keywordInExample: '@',
     fieldHighlights: {
       operand: ['file_get_contents($path)', '$arr[$key]']
     },
@@ -760,7 +771,7 @@ export const astNodes: AstNode[] = [
     group: 'Other Expressions',
     name: 'Eval',
     description: 'Evaluate PHP code',
-    phpExample: `<?php\neval($code);`,
+    phpExample: `eval($code);`,
     keywordInExample: 'eval',
     fieldHighlights: {
       code: ['$code']
@@ -774,8 +785,8 @@ export const astNodes: AstNode[] = [
     group: 'Output/Communication',
     name: 'Exit',
     description: 'Exit/die construct',
-    phpExample: `<?php\nexit($message);\ndie(1);`,
-    keywordInExample: 'exit',
+    phpExample: `exit($message);\ndie(1);`,
+    keywordInExample: ['exit', 'die'],
     fieldHighlights: {
       value: ['$message', '1']
     },
@@ -788,8 +799,7 @@ export const astNodes: AstNode[] = [
     group: 'Variables & Values',
     name: 'Float',
     description: 'Float literal',
-    phpExample: `<?php\n$pi = 3.14;\n$exp = 1.5e3;`,
-    keywordInExample: 'float',
+    phpExample: `$pi = 3.14;\n$exp = 1.5e3;`,
     fieldHighlights: {
       value: ['3.14', '1.5e3']
     },
@@ -802,8 +812,7 @@ export const astNodes: AstNode[] = [
     group: 'Function/Method Calls',
     name: 'FunctionCall',
     description: 'Function call',
-    phpExample: `<?php\nstrlen($str);\narray_map(fn($x) => $x * 2, $arr);`,
-    keywordInExample: 'function',
+    phpExample: `strlen($str);\narray_map(fn($x) => $x * 2, $arr);`,
     fieldHighlights: {
       name: ['strlen', 'array_map'],
       args: ['$str', 'fn($x) => $x * 2', '$arr']
@@ -818,15 +827,15 @@ export const astNodes: AstNode[] = [
     group: 'Variables & Values',
     name: 'Heredoc',
     description: 'Heredoc string with interpolation',
-    phpExample: `<?php\n$name = $alice;\n$str = <<<EOT\nHello $name\nEOT;`,
-    keywordInExample: 'EOT',
+    phpExample: `$str = <<<EOT\n  Hello $name!\nEOT;\n\n$msg = <<<'EOD'\n  Static text\nEOD;`,
+    keywordInExample: '<<<',
     fieldHighlights: {
-      label: ['EOT'],
-      parts: ['$name']
+      label: ['EOT', 'EOD'],
+      parts: ['Hello ', '$name', '!', 'Static text']
     },
     fields: [
       { name: 'label', type: 'string', description: 'Heredoc label' },
-      { name: 'parts', type: 'Vec<StringPart>', description: 'String parts' }
+      { name: 'parts', type: 'Vec<StringPart>', description: 'String parts (text and variables)' }
     ]
   },
   {
@@ -834,7 +843,7 @@ export const astNodes: AstNode[] = [
     group: 'Variables & Values',
     name: 'Identifier',
     description: 'Bare name used as an expression (function name in a call, class name, etc.)',
-    phpExample: `<?php\nstrlen($str);\nMyClass::method();`,
+    phpExample: `strlen($str);\nMyClass::method();`,
     keywordInExample: 'strlen',
     fieldHighlights: {
       name: ['strlen', 'MyClass']
@@ -848,11 +857,10 @@ export const astNodes: AstNode[] = [
     group: 'Other Expressions',
     name: 'Include',
     description: 'Include/require files',
-    phpExample: `<?php\ninclude $header;\nrequire_once $config;`,
-    keywordInExample: 'include',
+    phpExample: `include $header;\ninclude_once $once;\nrequire $config;\nrequire_once $loader;`,
     fieldHighlights: {
-      kind: ['include', 'require_once'],
-      file: ['$header', '$config']
+      kind: ['include_once', 'include', 'require_once', 'require'],
+      file: ['$header', '$once', '$config', '$loader']
     },
     fields: [
       { name: 'kind', type: 'IncludeKind', description: 'Include/require/once variant' },
@@ -864,8 +872,7 @@ export const astNodes: AstNode[] = [
     group: 'Variables & Values',
     name: 'Int',
     description: 'Integer literal',
-    phpExample: `<?php\n$x = 42;\n$hex = 0xFF;\n$bin = 0b1010;`,
-    keywordInExample: 'int',
+    phpExample: `$x = 42;\n$hex = 0xFF;\n$bin = 0b1010;`,
     fieldHighlights: {
       value: ['42', '0xFF', '0b1010']
     },
@@ -878,10 +885,9 @@ export const astNodes: AstNode[] = [
     group: 'Variables & Values',
     name: 'InterpolatedString',
     description: 'Double-quoted string with variable interpolation',
-    phpExample: `<?php\n$name = $alice;\necho "Hello $name";\necho "Result: {$obj->prop}";`,
-    keywordInExample: 'echo',
+    phpExample: `"Hello $name";\n"Result: {$obj->prop}";`,
     fieldHighlights: {
-      parts: ['$name', '$obj->prop']
+      parts: ['Hello ', '$name', 'Result: ', '$obj->prop']
     },
     fields: [
       { name: 'parts', type: 'Vec<StringPart>', description: 'String parts (literals and expressions)' }
@@ -892,7 +898,7 @@ export const astNodes: AstNode[] = [
     group: 'Other Expressions',
     name: 'Isset',
     description: 'Check if variables are set',
-    phpExample: `<?php\nisset($var);\nisset($arr[$key], $obj->prop);`,
+    phpExample: `isset($var);\nisset($arr[$key], $obj->prop);`,
     keywordInExample: 'isset',
     fieldHighlights: {
       vars: ['$var', '$arr[$key]', '$obj->prop']
@@ -906,10 +912,10 @@ export const astNodes: AstNode[] = [
     group: 'Variables & Values',
     name: 'MagicConst',
     description: 'Magic constant (__LINE__, __FILE__, etc)',
-    phpExample: `<?php\necho __LINE__;\necho __FILE__;\necho __DIR__;`,
-    keywordInExample: '__LINE__',
+    phpExample: `__LINE__;\n__FILE__;\n__DIR__;\n__FUNCTION__;\n__CLASS__;\n__TRAIT__;\n__METHOD__;\n__NAMESPACE__;`,
+    keywordInExample: ['__LINE__', '__FILE__', '__DIR__', '__FUNCTION__', '__CLASS__', '__TRAIT__', '__METHOD__', '__NAMESPACE__'],
     fieldHighlights: {
-      kind: ['__LINE__', '__FILE__', '__DIR__']
+      kind: ['__LINE__', '__FILE__', '__DIR__', '__FUNCTION__', '__CLASS__', '__TRAIT__', '__METHOD__', '__NAMESPACE__']
     },
     fields: [
       { name: 'kind', type: 'MagicConstKind', description: 'Magic constant type' }
@@ -920,7 +926,7 @@ export const astNodes: AstNode[] = [
     group: 'Other Expressions',
     name: 'Match',
     description: 'Match expression (PHP 8.0+)',
-    phpExample: `<?php\n$result = match($status) {\n  STATUS_ACTIVE => $running,\n  STATUS_PAUSED => $paused,\n  default => $unknown\n};`,
+    phpExample: `$result = match($status) {\n  STATUS_ACTIVE => $running,\n  STATUS_PAUSED => $paused,\n  default => $unknown\n};`,
     phpVersion: '8.0+',
     keywordInExample: 'match',
     fieldHighlights: {
@@ -937,12 +943,11 @@ export const astNodes: AstNode[] = [
     group: 'Class/Object Operations',
     name: 'MethodCall',
     description: 'Object method call',
-    phpExample: `<?php\n$obj->method($arg);\n$obj->compute($x);`,
-    keywordInExample: 'method',
+    phpExample: `$obj->method($arg);\n$obj->compute($x, $y);`,
     fieldHighlights: {
       object: ['$obj'],
       method: ['method', 'compute'],
-      args: ['$arg', '$x']
+      args: ['$arg', '$x', '$y']
     },
     fields: [
       { name: 'object', type: 'Expr', description: 'Object' },
@@ -955,7 +960,7 @@ export const astNodes: AstNode[] = [
     group: 'Class/Object Operations',
     name: 'New',
     description: 'Create new object instance',
-    phpExample: `<?php\nnew DateTime($now);\nnew MyClass($arg);`,
+    phpExample: `new DateTime($now);\nnew MyClass($arg);`,
     keywordInExample: 'new',
     fieldHighlights: {
       class: ['DateTime', 'MyClass'],
@@ -971,8 +976,8 @@ export const astNodes: AstNode[] = [
     group: 'Variables & Values',
     name: 'Nowdoc',
     description: 'Nowdoc string (no interpolation)',
-    phpExample: `<?php\n$str = <<<'EOT'\nLiteral $text\nEOT;`,
-    keywordInExample: 'EOT',
+    phpExample: `$str = <<<'EOT'\nLiteral $text\nEOT;`,
+    keywordInExample: '<<<',
     fieldHighlights: {
       label: ['EOT'],
       value: ['Literal $text']
@@ -987,7 +992,7 @@ export const astNodes: AstNode[] = [
     group: 'Variables & Values',
     name: 'Null',
     description: 'Null literal',
-    phpExample: `<?php\n$value = null;`,
+    phpExample: `$value = null;`,
     keywordInExample: 'null',
     fields: []
   },
@@ -996,8 +1001,7 @@ export const astNodes: AstNode[] = [
     group: 'Operations',
     name: 'NullCoalesce',
     description: 'Null coalescing operator',
-    phpExample: `<?php\n$name = $var ?? $default;\n$value = $a ?? $b ?? $c;`,
-    keywordInExample: 'coalesce',
+    phpExample: `$name = $var ?? $default;\n$value = $a ?? $b ?? $c;`,
     fieldHighlights: {
       left: ['$var', '$a'],
       right: ['$default', '$b ?? $c']
@@ -1012,9 +1016,8 @@ export const astNodes: AstNode[] = [
     group: 'Class/Object Operations',
     name: 'NullsafeMethodCall',
     description: 'Nullsafe method call (PHP 8.0+)',
-    phpExample: `<?php\n$obj?->method($arg);\n$result = $user?->getProfile()?->getName();`,
+    phpExample: `$obj?->method($arg);\n$result = $user?->getProfile()?->getName();`,
     phpVersion: '8.0+',
-    keywordInExample: 'method',
     fieldHighlights: {
       object: ['$obj', '$user'],
       method: ['method', 'getProfile', 'getName'],
@@ -1031,9 +1034,8 @@ export const astNodes: AstNode[] = [
     group: 'Class/Object Operations',
     name: 'NullsafePropertyAccess',
     description: 'Nullsafe property access (PHP 8.0+)',
-    phpExample: `<?php\n$obj?->prop;\n$result = $user?->profile?->name;`,
+    phpExample: `$obj?->prop;\n$result = $user?->profile?->name;`,
     phpVersion: '8.0+',
-    keywordInExample: 'property',
     fieldHighlights: {
       object: ['$obj', '$user'],
       property: ['prop', 'profile', 'name']
@@ -1048,8 +1050,7 @@ export const astNodes: AstNode[] = [
     group: 'Other Expressions',
     name: 'Omit',
     description: 'Omitted array element (skipped slot)',
-    phpExample: `<?php\n[$a, , $c];\nlist($x, , $z) = [1, 2, 3];`,
-    keywordInExample: 'list',
+    phpExample: `[$a, , $c];\nlist($first, , $last) = ["John", "M", "Doe"];`,
     fields: []
   },
   {
@@ -1057,7 +1058,7 @@ export const astNodes: AstNode[] = [
     group: 'Operations',
     name: 'Parenthesized',
     description: 'Expression wrapped in parentheses',
-    phpExample: `<?php\n$result = ($a + $b) * $c;\n$value = ($x);`,
+    phpExample: `$result = ($a + $b) * $c;\n$value = ($x);`,
     fieldHighlights: {
       expr: ['$a + $b', '$x']
     },
@@ -1070,7 +1071,7 @@ export const astNodes: AstNode[] = [
     group: 'Output/Communication',
     name: 'Print',
     description: 'Print construct',
-    phpExample: `<?php\nprint $greeting;\nprint($name);`,
+    phpExample: `print $greeting;\nprint($name);`,
     keywordInExample: 'print',
     fieldHighlights: {
       value: ['$greeting', '$name']
@@ -1084,8 +1085,7 @@ export const astNodes: AstNode[] = [
     group: 'Class/Object Operations',
     name: 'PropertyAccess',
     description: 'Object property access',
-    phpExample: `<?php\n$obj->name;\n$obj->count;`,
-    keywordInExample: 'property',
+    phpExample: `$obj->name;\n$obj->count;`,
     fieldHighlights: {
       object: ['$obj'],
       property: ['name', 'count']
@@ -1100,8 +1100,7 @@ export const astNodes: AstNode[] = [
     group: 'Other Expressions',
     name: 'ShellExec',
     description: 'Shell execution (backticks)',
-    phpExample: `<?php\n$output = \`ls -la\`;\necho \`date\`;`,
-    keywordInExample: 'echo',
+    phpExample: `$output = \`ls -la\`;\necho \`date\`;`,
     fieldHighlights: {
       parts: ['ls -la', 'date']
     },
@@ -1114,8 +1113,7 @@ export const astNodes: AstNode[] = [
     group: 'Class/Object Operations',
     name: 'StaticDynMethodCall',
     description: 'Dynamic static method call (Class::$method(args))',
-    phpExample: `<?php\nMyClass::$method($arg);`,
-    keywordInExample: 'static',
+    phpExample: `MyClass::$method($arg);`,
     fieldHighlights: {
       class: ['MyClass'],
       method: ['$method'],
@@ -1132,8 +1130,7 @@ export const astNodes: AstNode[] = [
     group: 'Class/Object Operations',
     name: 'StaticMethodCall',
     description: 'Static method call',
-    phpExample: `<?php\nMyClass::method($arg);\nMyClass::compute($x);`,
-    keywordInExample: 'static',
+    phpExample: `MyClass::method($arg);\nMyClass::compute($x);`,
     fieldHighlights: {
       class: ['MyClass'],
       method: ['method', 'compute'],
@@ -1150,8 +1147,7 @@ export const astNodes: AstNode[] = [
     group: 'Class/Object Operations',
     name: 'StaticPropertyAccess',
     description: 'Static property access',
-    phpExample: `<?php\nMyClass::$property;\nMyClass::$count;`,
-    keywordInExample: 'static',
+    phpExample: `MyClass::$property;\nMyClass::$count;`,
     fieldHighlights: {
       class: ['MyClass'],
       member: ['$property', '$count']
@@ -1166,8 +1162,7 @@ export const astNodes: AstNode[] = [
     group: 'Class/Object Operations',
     name: 'StaticPropertyAccessDynamic',
     description: 'Dynamic static property access (A::$$b)',
-    phpExample: `<?php\n$prop = $name;\nMyClass::$$prop;`,
-    keywordInExample: 'static',
+    phpExample: `$prop = $name;\nMyClass::$$prop;`,
     fieldHighlights: {
       class: ['MyClass'],
       member: ['$$prop']
@@ -1182,7 +1177,7 @@ export const astNodes: AstNode[] = [
     group: 'Variables & Values',
     name: 'String',
     description: 'String literal (single-quoted or non-interpolated double-quoted)',
-    phpExample: `<?php\n$str = 'hello world';\n$str2 = "goodbye";`,
+    phpExample: `$str = 'hello world';\n$str2 = "goodbye";`,
     fieldHighlights: {
       value: ['hello world', 'goodbye']
     },
@@ -1195,8 +1190,7 @@ export const astNodes: AstNode[] = [
     group: 'Operations',
     name: 'Ternary',
     description: 'Ternary conditional operator',
-    phpExample: `<?php\n$result = $x != 0 ? $positive : $nonPositive;\n$short = $x ?: $default;`,
-    keywordInExample: 'ternary',
+    phpExample: `$result = $x != 0 ? $positive : $nonPositive;\n$short = $x ?: $default;`,
     fieldHighlights: {
       condition: ['$x != 0', '$x'],
       then_expr: ['$positive'],
@@ -1213,7 +1207,7 @@ export const astNodes: AstNode[] = [
     group: 'Other Expressions',
     name: 'ThrowExpr',
     description: 'Throw expression (PHP 8.0+)',
-    phpExample: `<?php\n$x = $value ?? throw new InvalidArgumentException($msg);`,
+    phpExample: `$x = $value ?? throw new InvalidArgumentException($msg);`,
     phpVersion: '8.0+',
     keywordInExample: 'throw',
     fieldHighlights: {
@@ -1228,10 +1222,9 @@ export const astNodes: AstNode[] = [
     group: 'Operations',
     name: 'UnaryPostfix',
     description: 'Postfix unary operation',
-    phpExample: `<?php\n$x++;\n$y--;`,
+    phpExample: `$x++;\n$y--;`,
     fieldHighlights: {
-      operand: ['$x', '$y'],
-      op: ['$x++', '$y--']
+      op: ['++', '--']
     },
     fields: [
       { name: 'operand', type: 'Expr', description: 'Operand' },
@@ -1243,10 +1236,9 @@ export const astNodes: AstNode[] = [
     group: 'Operations',
     name: 'UnaryPrefix',
     description: 'Prefix unary operation',
-    phpExample: `<?php\n$neg = -$x;\n$not = !$flag;\n$inc = ++$counter;`,
+    phpExample: `$neg = -$x;\n$not = !$flag;\n$inc = ++$counter;`,
     fieldHighlights: {
-      op: ['-$x', '!$flag', '++$counter'],
-      operand: ['$x', '$flag', '$counter']
+      op: ['-', '!', '++']
     },
     fields: [
       { name: 'op', type: 'UnaryPrefixOp', description: 'Operator (-, !, ++, --)' },
@@ -1258,8 +1250,7 @@ export const astNodes: AstNode[] = [
     group: 'Variables & Values',
     name: 'Variable',
     description: 'Variable reference',
-    phpExample: `<?php\n$name = $value;\necho $name;`,
-    keywordInExample: 'variable',
+    phpExample: `$name = $value;\necho $name;`,
     fieldHighlights: {
       name: ['$name', '$value']
     },
@@ -1272,10 +1263,9 @@ export const astNodes: AstNode[] = [
     group: 'Variables & Values',
     name: 'VariableVariable',
     description: 'Variable variable (dynamic variable names)',
-    phpExample: `<?php\n$var = $hello;\n$$var = $world;\necho $hello;`,
-    keywordInExample: 'variable',
+    phpExample: `$var = $hello;\n$$var = $world;\necho $hello;`,
     fieldHighlights: {
-      expr: ['$var', '$$var']
+      expr: ['$$var']
     },
     fields: [
       { name: 'expr', type: 'Expr', description: 'Expression to resolve to variable name' }
@@ -1286,7 +1276,7 @@ export const astNodes: AstNode[] = [
     group: 'Operations',
     name: 'Yield',
     description: 'Yield value from generator',
-    phpExample: `<?php\nfunction gen() {\n  yield 1;\n  yield $key => 2;\n  yield from $items;\n}`,
+    phpExample: `function gen() {\n  yield 1;\n  yield $key => 2;\n  yield from $items;\n}`,
     keywordInExample: 'yield',
     fieldHighlights: {
       key: ['$key'],
@@ -1305,12 +1295,13 @@ export const astNodes: AstNode[] = [
     group: 'Declarations',
     name: 'ClassConstDecl',
     description: 'Class constant',
-    phpExample: `<?php\nconst VERSION = 1;\nfinal protected const DEFAULT_VAL = 0;`,
+    phpExample: `class Config {\n  const VERSION: int = 1;\n  protected final const DEFAULT_VAL: int = 0;\n}`,
     keywordInExample: 'const',
     fieldHighlights: {
       name: ['VERSION', 'DEFAULT_VAL'],
       visibility: ['protected'],
       is_final: ['final'],
+      type_hint: ['int'],
       value: ['1', '0']
     },
     fields: [
@@ -1326,7 +1317,7 @@ export const astNodes: AstNode[] = [
     group: 'Declarations',
     name: 'EnumCase',
     description: 'Enum case',
-    phpExample: `<?php\nenum Color {\n  case Red;\n  case Green = GREEN_VALUE;\n}`,
+    phpExample: `enum Color {\n  case Red;\n  case Green = GREEN_VALUE;\n}`,
     keywordInExample: 'case',
     fieldHighlights: {
       name: ['Red', 'Green'],
@@ -1342,15 +1333,17 @@ export const astNodes: AstNode[] = [
     group: 'Declarations',
     name: 'MethodDecl',
     description: 'Class method',
-    phpExample: `<?php\npublic function getValue(): string { return $value; }\nabstract protected function validate();`,
-    keywordInExample: 'method',
+    phpExample: `class User {\n  public function &getValue(): string { return $this->value; }\n  abstract protected function validate();\n  final public static function create(int $id): self { return new User(); }\n}`,
     fieldHighlights: {
-      name: ['getValue', 'validate'],
+      name: ['getValue', 'validate', 'create'],
       visibility: ['public', 'protected'],
       is_abstract: ['abstract'],
-      params: [],
-      return_type: ['string'],
-      body: ['return $value']
+      is_static: ['static'],
+      is_final: ['final'],
+      by_ref: ['&'],
+      params: ['int $id'],
+      return_type: ['string', 'self'],
+      body: ['return $this->value;', 'return new User();']
     },
     fields: [
       { name: 'name', type: 'Ident', description: 'Method name' },
@@ -1369,14 +1362,19 @@ export const astNodes: AstNode[] = [
     group: 'Declarations',
     name: 'Param',
     description: 'Function/method parameter',
-    phpExample: `<?php\nfunction foo(string $name, int $age = 0, &$ref = null, ...$rest) {}`,
-    keywordInExample: 'function',
+    phpExample: `class User {\n  function __construct(\n    #[Trim] string $name,\n    protected private(set) string $email {\n      get => $this->_email;\n      set(mixed $v) { $this->_email = $v; }\n    },\n    public final readonly int $age = 0,\n    &$ref = null,\n    ...$rest\n  ) {}\n}`,
     fieldHighlights: {
-      name: ['$name', '$age', '$ref', '$rest'],
-      type_hint: ['string', 'int'],
+      name: ['$name', '$email', '$age', '$ref', '$rest'],
+      type_hint: ['string', 'int', 'mixed'],
       default: ['0', 'null'],
-      by_ref: ['&$ref'],
-      variadic: ['...$rest']
+      by_ref: ['&'],
+      variadic: ['...'],
+      visibility: ['protected', 'public'],
+      set_visibility: ['private(set)'],
+      is_readonly: ['readonly'],
+      is_final: ['final'],
+      attributes: ['#[Trim]'],
+      hooks: ['get => $this->_email;', 'set(mixed $v) { $this->_email = $v; }']
     },
     fields: [
       { name: 'name', type: 'Ident', description: 'Parameter name' },
@@ -1397,14 +1395,15 @@ export const astNodes: AstNode[] = [
     group: 'Declarations',
     name: 'PropertyDecl',
     description: 'Class property',
-    phpExample: `<?php\npublic string $name = $default;\nprivate readonly int $id;`,
-    keywordInExample: 'property',
+    phpExample: `class User {\n  public string $name = "John";\n  public static int $counter = 0;\n  protected readonly bool $verified;\n  public private(set) string $email;\n}`,
     fieldHighlights: {
-      name: ['$name', '$id'],
-      visibility: ['public', 'private'],
+      visibility: ['public', 'protected'],
+      is_static: ['static'],
+      type_hint: ['string', 'int', 'bool'],
+      name: ['$name', '$counter', '$verified', '$email'],
+      default: ['"John"', '0'],
       is_readonly: ['readonly'],
-      type_hint: ['string', 'int'],
-      default: ['$default']
+      set_visibility: ['private(set)']
     },
     fields: [
       { name: 'name', type: 'Ident', description: 'Property name' },
@@ -1421,13 +1420,14 @@ export const astNodes: AstNode[] = [
     group: 'Declarations',
     name: 'PropertyHook',
     description: 'Property hook - get/set (PHP 8.4+)',
-    phpExample: `<?php\npublic string $value {\n  get => strtoupper($this->_value);\n  set(string $v) { $this->_value = $v; }\n}`,
+    phpExample: `class User {\n  public string $value {\n    final get &=> $this->_value;\n    final set(string $newValue) { $this->_value = $newValue; }\n  }\n}`,
     phpVersion: '8.4+',
-    keywordInExample: 'hook',
     fieldHighlights: {
       kind: ['get', 'set'],
-      body: ['strtoupper($this->_value)', '$this->_value = $v'],
-      params: ['$v']
+      is_final: ['final'],
+      by_ref: ['&'],
+      params: ['string $newValue'],
+      body: ['$this->_value', '{ $this->_value = $newValue; }']
     },
     fields: [
       { name: 'kind', type: 'PropertyHookKind', description: 'Get or Set' },
@@ -1443,8 +1443,7 @@ export const astNodes: AstNode[] = [
     group: 'Types',
     name: 'BuiltinType',
     description: 'Built-in type keyword',
-    phpExample: `<?php\nfunction test(int $x, array $arr, mixed $value): string { }`,
-    keywordInExample: 'builtin',
+    phpExample: `function test(int $x, array $arr, mixed $value): string { }`,
     fieldHighlights: {
       type: ['int', 'array', 'mixed', 'string']
     },
@@ -1457,11 +1456,11 @@ export const astNodes: AstNode[] = [
     group: 'Types',
     name: 'Intersection',
     description: 'Intersection type (A&B, PHP 8.1+)',
-    phpExample: `<?php\nfunction process(Countable&ArrayAccess $data) { }`,
+    phpExample: `function process(Countable&ArrayAccess $data) { }`,
     phpVersion: '8.1+',
-    keywordInExample: 'intersection',
+    keywordInExample: '&',
     fieldHighlights: {
-      types: ['Countable&ArrayAccess']
+      types: ['Countable', 'ArrayAccess']
     },
     fields: [
       { name: 'types', type: 'Vec<TypeHint>', description: 'Intersection member types' }
@@ -1472,8 +1471,7 @@ export const astNodes: AstNode[] = [
     group: 'Types',
     name: 'Named',
     description: 'Named type (class/interface name)',
-    phpExample: `<?php\nfunction save(User $user): void { }`,
-    keywordInExample: 'named',
+    phpExample: `function save(User $user): void { }`,
     fieldHighlights: {
       name: ['User']
     },
@@ -1486,10 +1484,10 @@ export const astNodes: AstNode[] = [
     group: 'Types',
     name: 'Nullable',
     description: 'Nullable type (?T)',
-    phpExample: `<?php\nfunction getName(): ?string { return null; }`,
-    keywordInExample: 'nullable',
+    phpExample: `function getName(): ?string { return null; }`,
+    keywordInExample: '?',
     fieldHighlights: {
-      type: ['?string']
+      type: ['string']
     },
     fields: [
       { name: 'type', type: 'TypeHint', description: 'Wrapped type' }
@@ -1500,11 +1498,11 @@ export const astNodes: AstNode[] = [
     group: 'Types',
     name: 'Union',
     description: 'Union type (A|B, PHP 8.0+)',
-    phpExample: `<?php\nfunction getValue(): int|string|null { }`,
+    phpExample: `function getValue(): int|string|null { }`,
     phpVersion: '8.0+',
-    keywordInExample: 'union',
+    keywordInExample: '|',
     fieldHighlights: {
-      types: ['int|string|null']
+      types: ['int', 'string', 'null']
     },
     fields: [
       { name: 'types', type: 'Vec<TypeHint>', description: 'Union member types' }
@@ -1516,11 +1514,12 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'Arg',
     description: 'Function/method argument',
-    phpExample: `<?php\nfoo($a, $b, name: $c, ...$spread);`,
+    phpExample: `foo($a, $b, name: $c, &$ref, ...$spread);`,
     fieldHighlights: {
       name: ['name'],
-      value: ['$a', '$b', '$c', '$spread'],
-      unpack: ['...$spread']
+      value: ['$a', '$b', '$c', '$ref', '$spread'],
+      by_ref: ['&'],
+      unpack: ['...']
     },
     fields: [
       { name: 'name', type: 'Option<Name>', description: 'Named argument name', optional: true },
@@ -1534,11 +1533,12 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'ArrayElement',
     description: 'A single element in an array literal',
-    phpExample: `<?php\n[$val, $key => $val2, ...$spread];`,
+    phpExample: `[$val, $key => $val2, &$ref, ...$spread];`,
     fieldHighlights: {
       key: ['$key'],
-      value: ['$val', '$val2', '$spread'],
-      unpack: ['...$spread']
+      value: ['$val', '$val2', '$ref', '$spread'],
+      by_ref: ['&'],
+      unpack: ['...']
     },
     fields: [
       { name: 'key', type: 'Option<Expr>', description: 'Array key', optional: true },
@@ -1552,8 +1552,8 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'Attribute',
     description: 'Attribute/annotation',
-    phpExample: `<?php\n#[Route($path)]\n#[Deprecated($msg)]\nfunction handler() {}`,
-    keywordInExample: 'attribute',
+    phpExample: `#[Route($path)]\n#[Deprecated($msg)]\nfunction handler() {}`,
+    keywordInExample: '#',
     fieldHighlights: {
       name: ['Route', 'Deprecated'],
       args: ['$path', '$msg']
@@ -1568,12 +1568,12 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'CatchClause',
     description: 'A single catch in try-catch',
-    phpExample: `<?php\ntry {\n  throw new RuntimeException();\n} catch (RuntimeException $e) {\n  echo $e;\n}`,
+    phpExample: `try {\n  throw new Exception();\n} catch (RuntimeException $e) {\n  throw new LogException('error');\n}`,
     keywordInExample: 'catch',
     fieldHighlights: {
       types: ['RuntimeException'],
       var: ['$e'],
-      body: ['echo $e']
+      body: ['throw new LogException(\'error\');']
     },
     fields: [
       { name: 'types', type: 'Vec<Name>', description: 'Caught exception types' },
@@ -1586,10 +1586,11 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'ClosureUseVar',
     description: 'A variable captured by a closure',
-    phpExample: `<?php\n$multiplier = 3;\n$fn = function($x) use ($multiplier) {\n  return $x * $multiplier;\n};`,
+    phpExample: `$counter = 0;\n$fn = function() use (&$counter) {\n  $counter++;\n};`,
     keywordInExample: 'use',
     fieldHighlights: {
-      name: ['$multiplier']
+      name: ['&$counter'],
+      by_ref: ['&']
     },
     fields: [
       { name: 'name', type: 'string', description: 'Variable name' },
@@ -1601,11 +1602,12 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'ConstItem',
     description: 'A single constant in a const statement',
-    phpExample: `<?php\nconst MAX_SIZE = 100;\nconst DB_HOST = DB_DEFAULT_HOST;`,
+    phpExample: `const MAX_SIZE = 100;\n#[Deprecated]\nconst DB_HOST = DB_DEFAULT_HOST;`,
     keywordInExample: 'const',
     fieldHighlights: {
       name: ['MAX_SIZE', 'DB_HOST'],
-      value: ['100', 'DB_DEFAULT_HOST']
+      value: ['100', 'DB_DEFAULT_HOST'],
+      attributes: ['#[Deprecated]']
     },
     fields: [
       { name: 'name', type: 'Ident', description: 'Constant name' },
@@ -1618,11 +1620,11 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'ElseIfBranch',
     description: 'A single elseif branch in an if statement',
-    phpExample: `<?php\nif ($x == 1) {\n  echo $x;\n} elseif ($x == 2) {\n  echo 0;\n}`,
+    phpExample: `if ($x == 1) {\n  echo $x;\n} elseif ($x == 2) {\n  echo 0;\n}`,
     keywordInExample: 'elseif',
     fieldHighlights: {
       condition: ['$x == 2'],
-      body: ['echo 0']
+      body: ['echo 0;']
     },
     fields: [
       { name: 'condition', type: 'Expr', description: 'Branch condition' },
@@ -1634,10 +1636,9 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'MatchArm',
     description: 'A single arm in a match expression',
-    phpExample: `<?php\nmatch($x) {\n  1, 2 => $small,\n  default => $other\n};`,
-    keywordInExample: 'default',
+    phpExample: `match($x) {\n  1, 2 => $small,\n  default => $other\n};`,
     fieldHighlights: {
-      conditions: ['1', '2'],
+      conditions: ['1', '2', 'default'],
       body: ['$small', '$other']
     },
     fields: [
@@ -1650,11 +1651,9 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'Name',
     description: 'Namespace-qualified name',
-    phpExample: `<?php\nuse App\\Models\\User;\nclass Post extends BaseModel {}`,
-    keywordInExample: 'use',
+    phpExample: `use App\\Models\\User;\nclass Post extends \\App\\Models\\BaseModel implements Countable {}`,
     fieldHighlights: {
-      parts: ['App\\\\Models\\\\User', 'BaseModel'],
-      kind: ['Unqualified', 'Qualified', 'FullyQualified']
+      parts: ['App\\Models\\User', '\\App\\Models\\BaseModel', 'Countable']
     },
     fields: [
       { name: 'parts', type: 'Vec<string>', description: 'Name parts (e.g., ["App", "Models", "User"])' },
@@ -1666,10 +1665,10 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'Program',
     description: 'Root AST node containing all top-level statements',
-    phpExample: `<?php\n$x = 1;\necho $x;`,
+    phpExample: `$x = 1;\necho $x;`,
     keywordInExample: 'echo',
     fieldHighlights: {
-      stmts: ['$x = 1', 'echo $x']
+      stmts: ['$x = 1;', 'echo $x;']
     },
     fields: [
       { name: 'stmts', type: 'Vec<Stmt>', description: 'Top-level statements' }
@@ -1680,7 +1679,7 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'Span',
     description: 'Source code location (start and end byte offsets)',
-    phpExample: `<?php\n// Every AST node has a Span indicating where in the source it appears`,
+    phpExample: `// Every AST node has a Span indicating where in the source it appears`,
     fieldHighlights: {
       start: ['start'],
       end: ['end']
@@ -1695,7 +1694,7 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'StaticVar',
     description: 'A single static variable declaration',
-    phpExample: `<?php\nfunction counter() {\n  static $count = 0;\n  return ++$count;\n}`,
+    phpExample: `function counter() {\n  static $count = 0;\n  return ++$count;\n}`,
     keywordInExample: 'static',
     fieldHighlights: {
       name: ['$count'],
@@ -1711,7 +1710,7 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'StringPart',
     description: 'A part of an interpolated string (literal text or embedded expression)',
-    phpExample: `<?php\n$name = $alice;\necho "Hello $name, you are {$age} old";`,
+    phpExample: `$name = $alice;\necho "Hello $name, you are {$age} old";`,
     keywordInExample: 'echo',
     fieldHighlights: {
       kind: ['Hello ', '$name', '$age', ' old']
@@ -1725,8 +1724,8 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'SwitchCase',
     description: 'A single case in a switch statement',
-    phpExample: `<?php\nswitch ($x) {\n  case 1:\n    echo $x;\n    break;\n  default:\n    break;\n}`,
-    keywordInExample: 'case',
+    phpExample: `switch ($x) {\n  case 1:\n    echo $x;\n    break;\n  default:\n    break;\n}`,
+    keywordInExample: ['case', 'default'],
     fieldHighlights: {
       value: ['1'],
       body: ['echo $x', 'break']
@@ -1741,7 +1740,7 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'TraitUseDecl',
     description: 'use Trait; inside a class body',
-    phpExample: `<?php\nclass MyClass {\n  use TraitA, TraitB {\n    TraitA::foo insteadof TraitB;\n  }\n}`,
+    phpExample: `class MyClass {\n  use TraitA, TraitB {\n    TraitA::foo insteadof TraitB;\n  }\n}`,
     keywordInExample: 'use',
     fieldHighlights: {
       traits: ['TraitA', 'TraitB'],
@@ -1757,10 +1756,10 @@ export const astNodes: AstNode[] = [
     group: 'Components',
     name: 'UseItem',
     description: 'A single imported name in a use statement',
-    phpExample: `<?php\nuse App\\Models\\User;\nuse App\\Http\\Controller as Ctrl;`,
+    phpExample: `use App\\Models\\User;\nuse App\\Http\\Controller as Ctrl;`,
     keywordInExample: 'use',
     fieldHighlights: {
-      name: ['App\\\\Models\\\\User', 'App\\\\Http\\\\Controller'],
+      name: ['App\\Models\\User', 'App\\Http\\Controller'],
       alias: ['Ctrl']
     },
     fields: [

--- a/playground/src/data/ast-nodes.ts
+++ b/playground/src/data/ast-nodes.ts
@@ -7,7 +7,7 @@ export interface NodeField {
 
 export interface AstNode {
   id: string
-  category: 'statement' | 'expression' | 'declaration' | 'type' | 'helper'
+  group: string
   name: string
   description: string
   phpExample: string
@@ -21,7 +21,7 @@ export const astNodes: AstNode[] = [
   // ========== STATEMENTS ==========
   {
     id: 'stmt-block',
-    category: 'statement',
+    group: 'Control Flow',
     name: 'Block',
     description: 'Block of statements',
     phpExample: `<?php\n{\n  $x = 1;\n  echo $x;\n}`,
@@ -35,7 +35,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-break',
-    category: 'statement',
+    group: 'Control Flow',
     name: 'Break',
     description: 'Break from loop or switch',
     phpExample: `<?php\nwhile (true) {\n  if ($done) break 2;\n}`,
@@ -49,7 +49,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-class',
-    category: 'statement',
+    group: 'Define Code',
     name: 'Class',
     description: 'Class declaration',
     phpExample: `<?php\nclass Animal extends Base implements Countable {\n  public string $name;\n  public function speak(): void {}\n}`,
@@ -71,7 +71,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-const',
-    category: 'statement',
+    group: 'Define Code',
     name: 'Const',
     description: 'Global constant declaration',
     phpExample: `<?php\nconst MAX_SIZE = 100;\nconst DB_HOST = DB_DEFAULT_HOST;`,
@@ -85,7 +85,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-continue',
-    category: 'statement',
+    group: 'Control Flow',
     name: 'Continue',
     description: 'Continue to next iteration of loop',
     phpExample: `<?php\nfor ($i = 0; $i != 10; $i++) {\n  if ($i % 2 == 0) continue;\n  echo $i;\n}`,
@@ -99,7 +99,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-declare',
-    category: 'statement',
+    group: 'Define Code',
     name: 'Declare',
     description: 'Declare directives like strict_types',
     phpExample: `<?php\ndeclare(strict_types=1);\ndeclare(ticks=1) {}`,
@@ -115,7 +115,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-do-while',
-    category: 'statement',
+    group: 'Control Flow',
     name: 'DoWhile',
     description: 'Do-while loop (executes at least once)',
     phpExample: `<?php\ndo {\n  echo $x;\n  $x--;\n} while ($x != 0);`,
@@ -131,7 +131,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-echo',
-    category: 'statement',
+    group: 'Output/Communication',
     name: 'Echo',
     description: 'Output one or more values',
     phpExample: `<?php\necho $greeting, $name, PHP_EOL;`,
@@ -146,7 +146,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-enum',
-    category: 'statement',
+    group: 'Define Code',
     name: 'Enum',
     description: 'Enumeration declaration (PHP 8.1+)',
     phpExample: `<?php\nenum Status: string {\n  case Active = STATUS_ACTIVE;\n  case Inactive = STATUS_INACTIVE;\n}`,
@@ -166,7 +166,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-for',
-    category: 'statement',
+    group: 'Control Flow',
     name: 'For',
     description: 'For loop with init/condition/update',
     phpExample: `<?php\nfor ($i = 0; $i != 10; $i++) {\n  echo $i;\n}`,
@@ -186,7 +186,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-foreach',
-    category: 'statement',
+    group: 'Control Flow',
     name: 'Foreach',
     description: 'Foreach loop over an array or iterable',
     phpExample: `<?php\nforeach ($arr as $key => $value) {\n  echo $key;\n  echo $value;\n}`,
@@ -206,7 +206,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-function',
-    category: 'statement',
+    group: 'Define Code',
     name: 'Function',
     description: 'Function declaration',
     phpExample: `<?php\nfunction greet($name): string {\n  return $name;\n}`,
@@ -228,7 +228,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-global',
-    category: 'statement',
+    group: 'Define Code',
     name: 'Global',
     description: 'Declare global variables',
     phpExample: `<?php\n$x = 1;\n\nfunction test() {\n  global $x;\n  $x = 2;\n}`,
@@ -242,7 +242,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-goto',
-    category: 'statement',
+    group: 'Define Code',
     name: 'Goto',
     description: 'Go to label',
     phpExample: `<?php\ngoto end;\necho $skipped;\nend:\necho $done;`,
@@ -256,7 +256,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-halt-compiler',
-    category: 'statement',
+    group: 'Define Code',
     name: 'HaltCompiler',
     description: '__halt_compiler() — everything after is raw data ignored by PHP',
     phpExample: `<?php\n__halt_compiler();\nThis data is ignored by PHP.`,
@@ -270,7 +270,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-if',
-    category: 'statement',
+    group: 'Control Flow',
     name: 'If',
     description: 'Conditional statement with if/elseif/else branches',
     phpExample: `<?php\nif ($x == 1) {\n  echo $positive;\n} elseif ($x == 2) {\n  echo $negative;\n} else {\n  echo $zero;\n}`,
@@ -290,7 +290,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-inline-html',
-    category: 'statement',
+    group: 'Output/Communication',
     name: 'InlineHtml',
     description: 'Inline HTML outside <?php ... ?>',
     phpExample: `<?php echo $php; ?>\nThis is HTML`,
@@ -304,7 +304,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-interface',
-    category: 'statement',
+    group: 'Define Code',
     name: 'Interface',
     description: 'Interface declaration',
     phpExample: `<?php\ninterface Drawable extends Countable {\n  public function draw(): void;\n}`,
@@ -322,7 +322,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-label',
-    category: 'statement',
+    group: 'Define Code',
     name: 'Label',
     description: 'Label definition',
     phpExample: `<?php\nloop:\necho $label;\ngoto loop;`,
@@ -336,7 +336,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-namespace',
-    category: 'statement',
+    group: 'Define Code',
     name: 'Namespace',
     description: 'Namespace declaration',
     phpExample: `<?php\nnamespace App\\Controllers;\n\nclass Home {}`,
@@ -352,7 +352,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-nop',
-    category: 'statement',
+    group: 'Define Code',
     name: 'Nop',
     description: 'Empty statement (;)',
     phpExample: `<?php\n;`,
@@ -360,7 +360,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-return',
-    category: 'statement',
+    group: 'Control Flow',
     name: 'Return',
     description: 'Return from a function or method',
     phpExample: `<?php\nfunction add($a, $b) {\n  return $a + $b;\n}`,
@@ -375,7 +375,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-static-var',
-    category: 'statement',
+    group: 'Define Code',
     name: 'StaticVar',
     description: 'Static variable declaration',
     phpExample: `<?php\nfunction counter() {\n  static $count = 0;\n  return ++$count;\n}`,
@@ -389,7 +389,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-switch',
-    category: 'statement',
+    group: 'Control Flow',
     name: 'Switch',
     description: 'Switch statement with cases and default',
     phpExample: `<?php\nswitch ($x) {\n  case 1:\n    echo $x;\n    break;\n  default:\n    echo $default;\n}`,
@@ -405,7 +405,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-throw',
-    category: 'statement',
+    group: 'Control Flow',
     name: 'Throw',
     description: 'Throw an exception',
     phpExample: `<?php\nthrow new RuntimeException($message);`,
@@ -419,7 +419,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-trait',
-    category: 'statement',
+    group: 'Define Code',
     name: 'Trait',
     description: 'Trait declaration',
     phpExample: `<?php\ntrait Logger {\n  public function log($msg) { echo $msg; }\n}`,
@@ -435,7 +435,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-try-catch',
-    category: 'statement',
+    group: 'Control Flow',
     name: 'TryCatch',
     description: 'Try-catch-finally block',
     phpExample: `<?php\ntry {\n  $x = 1 / 0;\n} catch (DivisionByZeroError $e) {\n  echo $e->getMessage();\n} finally {\n  echo $done;\n}`,
@@ -453,7 +453,6 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-unset',
-    category: 'statement',
     name: 'Unset',
     description: 'Unset variables',
     phpExample: `<?php\nunset($a, $b, $arr[$key]);`,
@@ -467,7 +466,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-use',
-    category: 'statement',
+    group: 'Define Code',
     name: 'Use',
     description: 'Use (import) statement',
     phpExample: `<?php\nuse App\\Models\\User;\nuse function Helper\\debug;`,
@@ -483,7 +482,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'stmt-while',
-    category: 'statement',
+    group: 'Control Flow',
     name: 'While',
     description: 'While loop',
     phpExample: `<?php\nwhile ($x != 0) {\n  echo $x;\n  $x--;\n}`,
@@ -500,7 +499,7 @@ export const astNodes: AstNode[] = [
   // ========== EXPRESSIONS ==========
   {
     id: 'expr-anonymous-class',
-    category: 'expression',
+    group: 'Class/Object Operations',
     name: 'AnonymousClass',
     description: 'Anonymous class instance (inline class definition)',
     phpExample: `<?php\n$obj = new class extends Base implements Countable {\n  public function method() {}\n};`,
@@ -514,7 +513,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-array',
-    category: 'expression',
+    group: 'Variables & Values',
     name: 'Array',
     description: 'Array literal',
     phpExample: `<?php\n[1, 2, 3];\n[$key => $val, $key2 => $val2];\n[...$items];`,
@@ -528,7 +527,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-array-access',
-    category: 'expression',
+    group: 'Operations',
     name: 'ArrayAccess',
     description: 'Array element access',
     phpExample: `<?php\n$arr[0];\n$arr[$key];\n$arr[];`,
@@ -543,7 +542,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-arrow-function',
-    category: 'expression',
+    group: 'Function/Method Calls',
     name: 'ArrowFunction',
     description: 'Arrow function (short closure, PHP 7.4+)',
     phpExample: `<?php\n$square = fn($x) => $x * $x;\n$double = fn($n) => $n * 2;`,
@@ -564,7 +563,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-assign',
-    category: 'expression',
+    group: 'Operations',
     name: 'Assign',
     description: 'Assignment and compound assignments',
     phpExample: `<?php\n$x = 10;\n$x += 5;\n$result ??= $default;`,
@@ -582,7 +581,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-binary',
-    category: 'expression',
+    group: 'Operations',
     name: 'Binary',
     description: 'Binary operation',
     phpExample: `<?php\n$sum = $a + $b;\n$cmp = $x <=> $y;\n$obj instanceof MyClass;`,
@@ -600,7 +599,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-bool',
-    category: 'expression',
+    group: 'Variables & Values',
     name: 'Bool',
     description: 'Boolean literal',
     phpExample: `<?php\n$yes = true;\n$no = false;`,
@@ -614,7 +613,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-callable-create',
-    category: 'expression',
+    group: 'Function/Method Calls',
     name: 'CallableCreate',
     description: 'Callable creation expression (first-class callables)',
     phpExample: `<?php\n$func = strlen(...);\n$method = $obj->method(...);\n$static = MyClass::staticMethod(...);`,
@@ -628,7 +627,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-cast',
-    category: 'expression',
+    group: 'Operations',
     name: 'Cast',
     description: 'Type cast',
     phpExample: `<?php\n(int)$x;\n(string)$val;\n(array)$obj;`,
@@ -644,7 +643,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-class-const',
-    category: 'expression',
+    group: 'Class/Object Operations',
     name: 'ClassConstAccess',
     description: 'Class constant access',
     phpExample: `<?php\nMyClass::VERSION;\nMyClass::MY_CONST;`,
@@ -660,7 +659,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-class-const-dyn',
-    category: 'expression',
+    group: 'Class/Object Operations',
     name: 'ClassConstAccessDynamic',
     description: 'Dynamic class constant access (Foo::{expr})',
     phpExample: `<?php\n$const = $version;\nFoo::{$const};`,
@@ -677,7 +676,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-clone',
-    category: 'expression',
+    group: 'Class/Object Operations',
     name: 'Clone',
     description: 'Clone an object',
     phpExample: `<?php\n$copy = clone $original;`,
@@ -691,7 +690,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-clone-with',
-    category: 'expression',
+    group: 'Class/Object Operations',
     name: 'CloneWith',
     description: 'Clone with property overrides (PHP 8.5+)',
     phpExample: `<?php\n$obj2 = clone($obj, prop: $value);`,
@@ -708,7 +707,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-closure',
-    category: 'expression',
+    group: 'Function/Method Calls',
     name: 'Closure',
     description: 'Anonymous function (closure)',
     phpExample: `<?php\n$add = function($a, $b) use ($multiplier) {\n  return ($a + $b) * $multiplier;\n};`,
@@ -730,7 +729,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-empty',
-    category: 'expression',
+    group: 'Other Expressions',
     name: 'Empty',
     description: 'Check if variable is empty',
     phpExample: `<?php\nempty($var);\nif (empty($str)) {}`,
@@ -744,7 +743,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-error-suppress',
-    category: 'expression',
+    group: 'Other Expressions',
     name: 'ErrorSuppress',
     description: 'Error suppression operator (@)',
     phpExample: `<?php\n@file_get_contents($path);\n@$arr[$key];`,
@@ -758,7 +757,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-eval',
-    category: 'expression',
+    group: 'Other Expressions',
     name: 'Eval',
     description: 'Evaluate PHP code',
     phpExample: `<?php\neval($code);`,
@@ -772,7 +771,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-exit',
-    category: 'expression',
+    group: 'Output/Communication',
     name: 'Exit',
     description: 'Exit/die construct',
     phpExample: `<?php\nexit($message);\ndie(1);`,
@@ -786,7 +785,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-float',
-    category: 'expression',
+    group: 'Variables & Values',
     name: 'Float',
     description: 'Float literal',
     phpExample: `<?php\n$pi = 3.14;\n$exp = 1.5e3;`,
@@ -800,7 +799,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-function-call',
-    category: 'expression',
+    group: 'Function/Method Calls',
     name: 'FunctionCall',
     description: 'Function call',
     phpExample: `<?php\nstrlen($str);\narray_map(fn($x) => $x * 2, $arr);`,
@@ -816,7 +815,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-heredoc',
-    category: 'expression',
+    group: 'Variables & Values',
     name: 'Heredoc',
     description: 'Heredoc string with interpolation',
     phpExample: `<?php\n$name = $alice;\n$str = <<<EOT\nHello $name\nEOT;`,
@@ -832,7 +831,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-identifier',
-    category: 'expression',
+    group: 'Variables & Values',
     name: 'Identifier',
     description: 'Bare name used as an expression (function name in a call, class name, etc.)',
     phpExample: `<?php\nstrlen($str);\nMyClass::method();`,
@@ -846,7 +845,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-include',
-    category: 'expression',
+    group: 'Other Expressions',
     name: 'Include',
     description: 'Include/require files',
     phpExample: `<?php\ninclude $header;\nrequire_once $config;`,
@@ -862,7 +861,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-int',
-    category: 'expression',
+    group: 'Variables & Values',
     name: 'Int',
     description: 'Integer literal',
     phpExample: `<?php\n$x = 42;\n$hex = 0xFF;\n$bin = 0b1010;`,
@@ -876,7 +875,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-interpolated-string',
-    category: 'expression',
+    group: 'Variables & Values',
     name: 'InterpolatedString',
     description: 'Double-quoted string with variable interpolation',
     phpExample: `<?php\n$name = $alice;\necho "Hello $name";\necho "Result: {$obj->prop}";`,
@@ -890,7 +889,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-isset',
-    category: 'expression',
+    group: 'Other Expressions',
     name: 'Isset',
     description: 'Check if variables are set',
     phpExample: `<?php\nisset($var);\nisset($arr[$key], $obj->prop);`,
@@ -904,7 +903,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-magic-const',
-    category: 'expression',
+    group: 'Variables & Values',
     name: 'MagicConst',
     description: 'Magic constant (__LINE__, __FILE__, etc)',
     phpExample: `<?php\necho __LINE__;\necho __FILE__;\necho __DIR__;`,
@@ -918,7 +917,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-match',
-    category: 'expression',
+    group: 'Other Expressions',
     name: 'Match',
     description: 'Match expression (PHP 8.0+)',
     phpExample: `<?php\n$result = match($status) {\n  STATUS_ACTIVE => $running,\n  STATUS_PAUSED => $paused,\n  default => $unknown\n};`,
@@ -935,7 +934,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-method-call',
-    category: 'expression',
+    group: 'Class/Object Operations',
     name: 'MethodCall',
     description: 'Object method call',
     phpExample: `<?php\n$obj->method($arg);\n$obj->compute($x);`,
@@ -953,7 +952,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-new',
-    category: 'expression',
+    group: 'Class/Object Operations',
     name: 'New',
     description: 'Create new object instance',
     phpExample: `<?php\nnew DateTime($now);\nnew MyClass($arg);`,
@@ -969,7 +968,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-nowdoc',
-    category: 'expression',
+    group: 'Variables & Values',
     name: 'Nowdoc',
     description: 'Nowdoc string (no interpolation)',
     phpExample: `<?php\n$str = <<<'EOT'\nLiteral $text\nEOT;`,
@@ -985,7 +984,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-null',
-    category: 'expression',
+    group: 'Variables & Values',
     name: 'Null',
     description: 'Null literal',
     phpExample: `<?php\n$value = null;`,
@@ -994,7 +993,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-null-coalesce',
-    category: 'expression',
+    group: 'Operations',
     name: 'NullCoalesce',
     description: 'Null coalescing operator',
     phpExample: `<?php\n$name = $var ?? $default;\n$value = $a ?? $b ?? $c;`,
@@ -1010,7 +1009,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-nullsafe-method',
-    category: 'expression',
+    group: 'Class/Object Operations',
     name: 'NullsafeMethodCall',
     description: 'Nullsafe method call (PHP 8.0+)',
     phpExample: `<?php\n$obj?->method($arg);\n$result = $user?->getProfile()?->getName();`,
@@ -1029,7 +1028,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-nullsafe-property',
-    category: 'expression',
+    group: 'Class/Object Operations',
     name: 'NullsafePropertyAccess',
     description: 'Nullsafe property access (PHP 8.0+)',
     phpExample: `<?php\n$obj?->prop;\n$result = $user?->profile?->name;`,
@@ -1046,7 +1045,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-omit',
-    category: 'expression',
+    group: 'Other Expressions',
     name: 'Omit',
     description: 'Omitted array element (skipped slot)',
     phpExample: `<?php\n[$a, , $c];\nlist($x, , $z) = [1, 2, 3];`,
@@ -1055,7 +1054,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-parenthesized',
-    category: 'expression',
+    group: 'Operations',
     name: 'Parenthesized',
     description: 'Expression wrapped in parentheses',
     phpExample: `<?php\n$result = ($a + $b) * $c;\n$value = ($x);`,
@@ -1068,7 +1067,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-print',
-    category: 'expression',
+    group: 'Output/Communication',
     name: 'Print',
     description: 'Print construct',
     phpExample: `<?php\nprint $greeting;\nprint($name);`,
@@ -1082,7 +1081,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-property-access',
-    category: 'expression',
+    group: 'Class/Object Operations',
     name: 'PropertyAccess',
     description: 'Object property access',
     phpExample: `<?php\n$obj->name;\n$obj->count;`,
@@ -1098,7 +1097,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-shell-exec',
-    category: 'expression',
+    group: 'Other Expressions',
     name: 'ShellExec',
     description: 'Shell execution (backticks)',
     phpExample: `<?php\n$output = \`ls -la\`;\necho \`date\`;`,
@@ -1112,7 +1111,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-static-dyn-method',
-    category: 'expression',
+    group: 'Class/Object Operations',
     name: 'StaticDynMethodCall',
     description: 'Dynamic static method call (Class::$method(args))',
     phpExample: `<?php\nMyClass::$method($arg);`,
@@ -1130,7 +1129,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-static-method',
-    category: 'expression',
+    group: 'Class/Object Operations',
     name: 'StaticMethodCall',
     description: 'Static method call',
     phpExample: `<?php\nMyClass::method($arg);\nMyClass::compute($x);`,
@@ -1148,7 +1147,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-static-property',
-    category: 'expression',
+    group: 'Class/Object Operations',
     name: 'StaticPropertyAccess',
     description: 'Static property access',
     phpExample: `<?php\nMyClass::$property;\nMyClass::$count;`,
@@ -1164,7 +1163,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-static-prop-dyn',
-    category: 'expression',
+    group: 'Class/Object Operations',
     name: 'StaticPropertyAccessDynamic',
     description: 'Dynamic static property access (A::$$b)',
     phpExample: `<?php\n$prop = $name;\nMyClass::$$prop;`,
@@ -1180,7 +1179,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-string',
-    category: 'expression',
+    group: 'Variables & Values',
     name: 'String',
     description: 'String literal (single-quoted or non-interpolated double-quoted)',
     phpExample: `<?php\n$str = 'hello world';\n$str2 = "goodbye";`,
@@ -1193,7 +1192,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-ternary',
-    category: 'expression',
+    group: 'Operations',
     name: 'Ternary',
     description: 'Ternary conditional operator',
     phpExample: `<?php\n$result = $x != 0 ? $positive : $nonPositive;\n$short = $x ?: $default;`,
@@ -1211,7 +1210,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-throw',
-    category: 'expression',
+    group: 'Other Expressions',
     name: 'ThrowExpr',
     description: 'Throw expression (PHP 8.0+)',
     phpExample: `<?php\n$x = $value ?? throw new InvalidArgumentException($msg);`,
@@ -1226,7 +1225,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-unary-postfix',
-    category: 'expression',
+    group: 'Operations',
     name: 'UnaryPostfix',
     description: 'Postfix unary operation',
     phpExample: `<?php\n$x++;\n$y--;`,
@@ -1241,7 +1240,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-unary-prefix',
-    category: 'expression',
+    group: 'Operations',
     name: 'UnaryPrefix',
     description: 'Prefix unary operation',
     phpExample: `<?php\n$neg = -$x;\n$not = !$flag;\n$inc = ++$counter;`,
@@ -1256,7 +1255,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-variable',
-    category: 'expression',
+    group: 'Variables & Values',
     name: 'Variable',
     description: 'Variable reference',
     phpExample: `<?php\n$name = $value;\necho $name;`,
@@ -1270,7 +1269,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-variable-variable',
-    category: 'expression',
+    group: 'Variables & Values',
     name: 'VariableVariable',
     description: 'Variable variable (dynamic variable names)',
     phpExample: `<?php\n$var = $hello;\n$$var = $world;\necho $hello;`,
@@ -1284,7 +1283,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'expr-yield',
-    category: 'expression',
+    group: 'Operations',
     name: 'Yield',
     description: 'Yield value from generator',
     phpExample: `<?php\nfunction gen() {\n  yield 1;\n  yield $key => 2;\n  yield from $items;\n}`,
@@ -1303,7 +1302,7 @@ export const astNodes: AstNode[] = [
   // ========== DECLARATIONS ==========
   {
     id: 'decl-class-const',
-    category: 'declaration',
+    group: 'Declarations',
     name: 'ClassConstDecl',
     description: 'Class constant',
     phpExample: `<?php\nconst VERSION = 1;\nfinal protected const DEFAULT_VAL = 0;`,
@@ -1324,7 +1323,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'decl-enum-case',
-    category: 'declaration',
+    group: 'Declarations',
     name: 'EnumCase',
     description: 'Enum case',
     phpExample: `<?php\nenum Color {\n  case Red;\n  case Green = GREEN_VALUE;\n}`,
@@ -1340,7 +1339,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'decl-method',
-    category: 'declaration',
+    group: 'Declarations',
     name: 'MethodDecl',
     description: 'Class method',
     phpExample: `<?php\npublic function getValue(): string { return $value; }\nabstract protected function validate();`,
@@ -1367,7 +1366,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'decl-param',
-    category: 'declaration',
+    group: 'Declarations',
     name: 'Param',
     description: 'Function/method parameter',
     phpExample: `<?php\nfunction foo(string $name, int $age = 0, &$ref = null, ...$rest) {}`,
@@ -1395,7 +1394,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'decl-property',
-    category: 'declaration',
+    group: 'Declarations',
     name: 'PropertyDecl',
     description: 'Class property',
     phpExample: `<?php\npublic string $name = $default;\nprivate readonly int $id;`,
@@ -1419,7 +1418,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'decl-property-hook',
-    category: 'declaration',
+    group: 'Declarations',
     name: 'PropertyHook',
     description: 'Property hook - get/set (PHP 8.4+)',
     phpExample: `<?php\npublic string $value {\n  get => strtoupper($this->_value);\n  set(string $v) { $this->_value = $v; }\n}`,
@@ -1441,7 +1440,7 @@ export const astNodes: AstNode[] = [
   // ========== TYPES ==========
   {
     id: 'type-builtin',
-    category: 'type',
+    group: 'Types',
     name: 'BuiltinType',
     description: 'Built-in type keyword',
     phpExample: `<?php\nfunction test(int $x, array $arr, mixed $value): string { }`,
@@ -1455,7 +1454,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'type-intersection',
-    category: 'type',
+    group: 'Types',
     name: 'Intersection',
     description: 'Intersection type (A&B, PHP 8.1+)',
     phpExample: `<?php\nfunction process(Countable&ArrayAccess $data) { }`,
@@ -1470,7 +1469,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'type-named',
-    category: 'type',
+    group: 'Types',
     name: 'Named',
     description: 'Named type (class/interface name)',
     phpExample: `<?php\nfunction save(User $user): void { }`,
@@ -1484,7 +1483,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'type-nullable',
-    category: 'type',
+    group: 'Types',
     name: 'Nullable',
     description: 'Nullable type (?T)',
     phpExample: `<?php\nfunction getName(): ?string { return null; }`,
@@ -1498,7 +1497,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'type-union',
-    category: 'type',
+    group: 'Types',
     name: 'Union',
     description: 'Union type (A|B, PHP 8.0+)',
     phpExample: `<?php\nfunction getValue(): int|string|null { }`,
@@ -1514,7 +1513,7 @@ export const astNodes: AstNode[] = [
   // ========== HELPERS ==========
   {
     id: 'helper-arg',
-    category: 'helper',
+    group: 'Helpers',
     name: 'Arg',
     description: 'Function/method argument',
     phpExample: `<?php\nfoo($a, $b, name: $c, ...$spread);`,
@@ -1532,7 +1531,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-array-element',
-    category: 'helper',
+    group: 'Helpers',
     name: 'ArrayElement',
     description: 'A single element in an array literal',
     phpExample: `<?php\n[$val, $key => $val2, ...$spread];`,
@@ -1550,7 +1549,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-attribute',
-    category: 'helper',
+    group: 'Helpers',
     name: 'Attribute',
     description: 'Attribute/annotation',
     phpExample: `<?php\n#[Route($path)]\n#[Deprecated($msg)]\nfunction handler() {}`,
@@ -1566,7 +1565,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-catch-clause',
-    category: 'helper',
+    group: 'Helpers',
     name: 'CatchClause',
     description: 'A single catch in try-catch',
     phpExample: `<?php\ntry {\n  throw new RuntimeException();\n} catch (RuntimeException $e) {\n  echo $e;\n}`,
@@ -1584,7 +1583,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-closure-use-var',
-    category: 'helper',
+    group: 'Helpers',
     name: 'ClosureUseVar',
     description: 'A variable captured by a closure',
     phpExample: `<?php\n$multiplier = 3;\n$fn = function($x) use ($multiplier) {\n  return $x * $multiplier;\n};`,
@@ -1599,7 +1598,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-const-item',
-    category: 'helper',
+    group: 'Helpers',
     name: 'ConstItem',
     description: 'A single constant in a const statement',
     phpExample: `<?php\nconst MAX_SIZE = 100;\nconst DB_HOST = DB_DEFAULT_HOST;`,
@@ -1616,7 +1615,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-elseif-branch',
-    category: 'helper',
+    group: 'Helpers',
     name: 'ElseIfBranch',
     description: 'A single elseif branch in an if statement',
     phpExample: `<?php\nif ($x == 1) {\n  echo $x;\n} elseif ($x == 2) {\n  echo 0;\n}`,
@@ -1632,7 +1631,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-match-arm',
-    category: 'helper',
+    group: 'Helpers',
     name: 'MatchArm',
     description: 'A single arm in a match expression',
     phpExample: `<?php\nmatch($x) {\n  1, 2 => $small,\n  default => $other\n};`,
@@ -1648,7 +1647,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-name',
-    category: 'helper',
+    group: 'Helpers',
     name: 'Name',
     description: 'Namespace-qualified name',
     phpExample: `<?php\nuse App\\Models\\User;\nclass Post extends BaseModel {}`,
@@ -1664,7 +1663,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-program',
-    category: 'helper',
+    group: 'Helpers',
     name: 'Program',
     description: 'Root AST node containing all top-level statements',
     phpExample: `<?php\n$x = 1;\necho $x;`,
@@ -1678,7 +1677,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-span',
-    category: 'helper',
+    group: 'Helpers',
     name: 'Span',
     description: 'Source code location (start and end byte offsets)',
     phpExample: `<?php\n// Every AST node has a Span indicating where in the source it appears`,
@@ -1693,7 +1692,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-static-var',
-    category: 'helper',
+    group: 'Helpers',
     name: 'StaticVar',
     description: 'A single static variable declaration',
     phpExample: `<?php\nfunction counter() {\n  static $count = 0;\n  return ++$count;\n}`,
@@ -1709,7 +1708,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-string-part',
-    category: 'helper',
+    group: 'Helpers',
     name: 'StringPart',
     description: 'A part of an interpolated string (literal text or embedded expression)',
     phpExample: `<?php\n$name = $alice;\necho "Hello $name, you are {$age} old";`,
@@ -1723,7 +1722,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-switch-case',
-    category: 'helper',
+    group: 'Helpers',
     name: 'SwitchCase',
     description: 'A single case in a switch statement',
     phpExample: `<?php\nswitch ($x) {\n  case 1:\n    echo $x;\n    break;\n  default:\n    break;\n}`,
@@ -1739,7 +1738,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-trait-use-decl',
-    category: 'helper',
+    group: 'Helpers',
     name: 'TraitUseDecl',
     description: 'use Trait; inside a class body',
     phpExample: `<?php\nclass MyClass {\n  use TraitA, TraitB {\n    TraitA::foo insteadof TraitB;\n  }\n}`,
@@ -1755,7 +1754,7 @@ export const astNodes: AstNode[] = [
   },
   {
     id: 'helper-use-item',
-    category: 'helper',
+    group: 'Helpers',
     name: 'UseItem',
     description: 'A single imported name in a use statement',
     phpExample: `<?php\nuse App\\Models\\User;\nuse App\\Http\\Controller as Ctrl;`,

--- a/playground/src/data/ast-nodes.ts
+++ b/playground/src/data/ast-nodes.ts
@@ -24,11 +24,11 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'Echo',
     description: 'Output one or more values',
-    phpExample: `<?php\necho 'Hello', ' ', $name;`,
+    phpExample: `<?php\necho $greeting, $name, PHP_EOL;`,
     keywordInExample: 'echo',
     fieldHighlights: {
       keyword: ['echo'],
-      exprs: ['\'Hello\'', '\' \'', '$name']
+      exprs: ['$greeting', '$name', 'PHP_EOL']
     },
     fields: [
       { name: 'exprs', type: 'Vec<Expr>', description: 'Values to output' }
@@ -54,12 +54,13 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'If',
     description: 'Conditional statement with if/elseif/else branches',
-    phpExample: `<?php\nif ($x > 0) {\n  echo 'positive';\n} elseif ($x < 0) {\n  echo 'negative';\n} else {\n  echo 'zero';\n}`,
+    phpExample: `<?php\nif ($x == 1) {\n  echo $positive;\n} elseif ($x == 2) {\n  echo $negative;\n} else {\n  echo $zero;\n}`,
     keywordInExample: 'if',
     fieldHighlights: {
-      condition: ['$x > 0', '$x < 0'],
-      then_branch: ['\'positive\''],
-      else_branch: ['\'zero\'']
+      condition: ['$x == 1'],
+      then_branch: ['echo $positive'],
+      elseif_branches: ['elseif ($x == 2)'],
+      else_branch: ['echo $zero']
     },
     fields: [
       { name: 'condition', type: 'Expr', description: 'Condition to evaluate' },
@@ -73,10 +74,10 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'While',
     description: 'While loop',
-    phpExample: `<?php\nwhile ($x > 0) {\n  echo $x;\n  $x--;\n}`,
+    phpExample: `<?php\nwhile ($x != 0) {\n  echo $x;\n  $x--;\n}`,
     keywordInExample: 'while',
     fieldHighlights: {
-      condition: ['$x > 0'],
+      condition: ['$x != 0'],
       body: ['echo $x', '$x--']
     },
     fields: [
@@ -89,8 +90,14 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'For',
     description: 'For loop with init/condition/update',
-    phpExample: `<?php\nfor ($i = 0; $i < 10; $i++) {\n  echo $i;\n}`,
+    phpExample: `<?php\nfor ($i = 0; $i != 10; $i++) {\n  echo $i;\n}`,
     keywordInExample: 'for',
+    fieldHighlights: {
+      init: ['$i = 0'],
+      condition: ['$i != 10'],
+      update: ['$i++'],
+      body: ['echo $i']
+    },
     fields: [
       { name: 'init', type: 'Vec<Expr>', description: 'Initialization expressions' },
       { name: 'condition', type: 'Vec<Expr>', description: 'Loop conditions' },
@@ -103,8 +110,14 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'Foreach',
     description: 'Foreach loop over an array or iterable',
-    phpExample: `<?php\nforeach ($arr as $key => $value) {\n  echo $key . ': ' . $value;\n}`,
+    phpExample: `<?php\nforeach ($arr as $key => $value) {\n  echo $key;\n  echo $value;\n}`,
     keywordInExample: 'foreach',
+    fieldHighlights: {
+      expr: ['$arr'],
+      key: ['$key'],
+      value: ['$value'],
+      body: ['echo $key', 'echo $value']
+    },
     fields: [
       { name: 'expr', type: 'Expr', description: 'Expression to iterate' },
       { name: 'key', type: 'Option<Expr>', description: 'Key variable', optional: true },
@@ -117,8 +130,12 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'DoWhile',
     description: 'Do-while loop (executes at least once)',
-    phpExample: `<?php\ndo {\n  echo $x;\n  $x--;\n} while ($x > 0);`,
+    phpExample: `<?php\ndo {\n  echo $x;\n  $x--;\n} while ($x != 0);`,
     keywordInExample: 'do',
+    fieldHighlights: {
+      body: ['echo $x', '$x--'],
+      condition: ['$x != 0']
+    },
     fields: [
       { name: 'body', type: 'Stmt', description: 'Loop body' },
       { name: 'condition', type: 'Expr', description: 'Loop condition' }
@@ -129,8 +146,12 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'Switch',
     description: 'Switch statement with cases and default',
-    phpExample: `<?php\nswitch ($x) {\n  case 1:\n    echo 'one';\n    break;\n  default:\n    echo 'other';\n}`,
+    phpExample: `<?php\nswitch ($x) {\n  case 1:\n    echo $x;\n    break;\n  default:\n    echo $default;\n}`,
     keywordInExample: 'switch',
+    fieldHighlights: {
+      expr: ['$x'],
+      cases: ['case 1', 'default']
+    },
     fields: [
       { name: 'expr', type: 'Expr', description: 'Value to switch on' },
       { name: 'cases', type: 'Vec<SwitchCase>', description: 'Switch cases' }
@@ -143,6 +164,9 @@ export const astNodes: AstNode[] = [
     description: 'Break from loop or switch',
     phpExample: `<?php\nwhile (true) {\n  if ($done) break 2;\n}`,
     keywordInExample: 'break',
+    fieldHighlights: {
+      level: ['2']
+    },
     fields: [
       { name: 'level', type: 'Option<Expr>', description: 'Number of levels to break', optional: true }
     ]
@@ -152,8 +176,11 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'Continue',
     description: 'Continue to next iteration of loop',
-    phpExample: `<?php\nfor ($i = 0; $i < 10; $i++) {\n  if ($i % 2 == 0) continue;\n  echo $i;\n}`,
+    phpExample: `<?php\nfor ($i = 0; $i != 10; $i++) {\n  if ($i % 2 == 0) continue;\n  echo $i;\n}`,
     keywordInExample: 'continue',
+    fieldHighlights: {
+      level: ['continue']
+    },
     fields: [
       { name: 'level', type: 'Option<Expr>', description: 'Number of levels to continue', optional: true }
     ]
@@ -163,8 +190,14 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'Function',
     description: 'Function declaration',
-    phpExample: `<?php\nfunction greet($name): string {\n  return 'Hello, ' . $name;\n}`,
+    phpExample: `<?php\nfunction greet($name): string {\n  return $name;\n}`,
     keywordInExample: 'function',
+    fieldHighlights: {
+      name: ['greet'],
+      params: ['$name'],
+      return_type: ['string'],
+      body: ['return $name']
+    },
     fields: [
       { name: 'name', type: 'Ident', description: 'Function name' },
       { name: 'params', type: 'Vec<Param>', description: 'Function parameters' },
@@ -177,8 +210,14 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'Class',
     description: 'Class declaration',
-    phpExample: `<?php\nclass Animal {\n  public string $name;\n  public function speak(): void {}\n}`,
+    phpExample: `<?php\nclass Animal extends Base implements Countable {\n  public string $name;\n  public function speak(): void {}\n}`,
     keywordInExample: 'class',
+    fieldHighlights: {
+      name: ['Animal'],
+      extends: ['Base'],
+      implements: ['Countable'],
+      members: ['public string $name', 'public function speak']
+    },
     fields: [
       { name: 'name', type: 'Ident', description: 'Class name' },
       { name: 'extends', type: 'Option<Name>', description: 'Parent class', optional: true },
@@ -191,8 +230,13 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'Interface',
     description: 'Interface declaration',
-    phpExample: `<?php\ninterface Drawable {\n  public function draw(): void;\n}`,
+    phpExample: `<?php\ninterface Drawable extends Countable {\n  public function draw(): void;\n}`,
     keywordInExample: 'interface',
+    fieldHighlights: {
+      name: ['Drawable'],
+      extends: ['Countable'],
+      members: ['public function draw']
+    },
     fields: [
       { name: 'name', type: 'Ident', description: 'Interface name' },
       { name: 'extends', type: 'Vec<Name>', description: 'Parent interfaces' },
@@ -206,6 +250,10 @@ export const astNodes: AstNode[] = [
     description: 'Trait declaration',
     phpExample: `<?php\ntrait Logger {\n  public function log($msg) { echo $msg; }\n}`,
     keywordInExample: 'trait',
+    fieldHighlights: {
+      name: ['Logger'],
+      members: ['public function log']
+    },
     fields: [
       { name: 'name', type: 'Ident', description: 'Trait name' },
       { name: 'members', type: 'Vec<ClassMember>', description: 'Methods' }
@@ -216,9 +264,14 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'Enum',
     description: 'Enumeration declaration (PHP 8.1+)',
-    phpExample: `<?php\nenum Status: string {\n  case Active = 'active';\n  case Inactive = 'inactive';\n}`,
+    phpExample: `<?php\nenum Status: string {\n  case Active = STATUS_ACTIVE;\n  case Inactive = STATUS_INACTIVE;\n}`,
     phpVersion: '8.1+',
     keywordInExample: 'enum',
+    fieldHighlights: {
+      name: ['Status'],
+      scalar_type: ['string'],
+      members: ['case Active', 'case Inactive']
+    },
     fields: [
       { name: 'name', type: 'Ident', description: 'Enum name' },
       { name: 'scalar_type', type: 'Option<Name>', description: 'Backing type (int or string)', optional: true },
@@ -232,6 +285,10 @@ export const astNodes: AstNode[] = [
     description: 'Namespace declaration',
     phpExample: `<?php\nnamespace App\\Controllers;\n\nclass Home {}`,
     keywordInExample: 'namespace',
+    fieldHighlights: {
+      name: ['App\\\\Controllers'],
+      body: ['class Home']
+    },
     fields: [
       { name: 'name', type: 'Option<Name>', description: 'Namespace name', optional: true },
       { name: 'body', type: 'NamespaceBody', description: 'Namespace contents' }
@@ -244,6 +301,10 @@ export const astNodes: AstNode[] = [
     description: 'Use (import) statement',
     phpExample: `<?php\nuse App\\Models\\User;\nuse function Helper\\debug;`,
     keywordInExample: 'use',
+    fieldHighlights: {
+      kind: ['use function'],
+      uses: ['App\\\\Models\\\\User', 'Helper\\\\debug']
+    },
     fields: [
       { name: 'kind', type: 'UseKind', description: 'Type of use (Normal, Function, Const)' },
       { name: 'uses', type: 'Vec<UseItem>', description: 'Imported items' }
@@ -254,8 +315,11 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'Const',
     description: 'Global constant declaration',
-    phpExample: `<?php\nconst MAX_SIZE = 100;\nconst DB_HOST = 'localhost';`,
+    phpExample: `<?php\nconst MAX_SIZE = 100;\nconst DB_HOST = DB_DEFAULT_HOST;`,
     keywordInExample: 'const',
+    fieldHighlights: {
+      items: ['MAX_SIZE = 100', 'DB_HOST = DB_DEFAULT_HOST']
+    },
     fields: [
       { name: 'items', type: 'Vec<ConstItem>', description: 'Constant declarations' }
     ]
@@ -265,8 +329,11 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'Throw',
     description: 'Throw an exception',
-    phpExample: `<?php\nthrow new Exception('Something went wrong');`,
+    phpExample: `<?php\nthrow new RuntimeException($message);`,
     keywordInExample: 'throw',
+    fieldHighlights: {
+      exception: ['new RuntimeException($message)']
+    },
     fields: [
       { name: 'exception', type: 'Expr', description: 'Exception to throw' }
     ]
@@ -276,8 +343,13 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'TryCatch',
     description: 'Try-catch-finally block',
-    phpExample: `<?php\ntry {\n  $x = 1 / 0;\n} catch (DivisionByZeroError $e) {\n  echo $e->getMessage();\n} finally {\n  echo 'Done';\n}`,
+    phpExample: `<?php\ntry {\n  $x = 1 / 0;\n} catch (DivisionByZeroError $e) {\n  echo $e->getMessage();\n} finally {\n  echo $done;\n}`,
     keywordInExample: 'try',
+    fieldHighlights: {
+      body: ['$x = 1 / 0'],
+      catches: ['catch (DivisionByZeroError $e)'],
+      finally: ['echo $done']
+    },
     fields: [
       { name: 'body', type: 'Vec<Stmt>', description: 'Try block' },
       { name: 'catches', type: 'Vec<CatchClause>', description: 'Catch clauses' },
@@ -291,6 +363,9 @@ export const astNodes: AstNode[] = [
     description: 'Declare global variables',
     phpExample: `<?php\n$x = 1;\n\nfunction test() {\n  global $x;\n  $x = 2;\n}`,
     keywordInExample: 'global',
+    fieldHighlights: {
+      vars: ['$x']
+    },
     fields: [
       { name: 'vars', type: 'Vec<Expr>', description: 'Variables to declare global' }
     ]
@@ -302,6 +377,9 @@ export const astNodes: AstNode[] = [
     description: 'Static variable declaration',
     phpExample: `<?php\nfunction counter() {\n  static $count = 0;\n  return ++$count;\n}`,
     keywordInExample: 'static',
+    fieldHighlights: {
+      vars: ['$count = 0']
+    },
     fields: [
       { name: 'vars', type: 'Vec<StaticVar>', description: 'Static variables' }
     ]
@@ -313,6 +391,10 @@ export const astNodes: AstNode[] = [
     description: 'Declare directives like strict_types',
     phpExample: `<?php\ndeclare(strict_types=1);\ndeclare(ticks=1) {}`,
     keywordInExample: 'declare',
+    fieldHighlights: {
+      directives: ['strict_types=1', 'ticks=1'],
+      body: ['{}']
+    },
     fields: [
       { name: 'directives', type: 'Vec<(Name, Expr)>', description: 'Directives' },
       { name: 'body', type: 'Option<Stmt>', description: 'Declare body', optional: true }
@@ -325,6 +407,9 @@ export const astNodes: AstNode[] = [
     description: 'Unset variables',
     phpExample: `<?php\nunset($a, $b, $arr[$key]);`,
     keywordInExample: 'unset',
+    fieldHighlights: {
+      vars: ['$a', '$b', '$arr[$key]']
+    },
     fields: [
       { name: 'vars', type: 'Vec<Expr>', description: 'Variables to unset' }
     ]
@@ -334,8 +419,11 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'Goto',
     description: 'Go to label',
-    phpExample: `<?php\ngoto end;\necho 'skipped';\nend:\necho 'done';`,
+    phpExample: `<?php\ngoto end;\necho $skipped;\nend:\necho $done;`,
     keywordInExample: 'goto',
+    fieldHighlights: {
+      label: ['end']
+    },
     fields: [
       { name: 'label', type: 'Ident', description: 'Target label' }
     ]
@@ -345,8 +433,11 @@ export const astNodes: AstNode[] = [
     category: 'statement',
     name: 'Label',
     description: 'Label definition',
-    phpExample: `<?php\nloop:\necho 'label';\ngoto loop;`,
+    phpExample: `<?php\nloop:\necho $label;\ngoto loop;`,
     keywordInExample: 'label',
+    fieldHighlights: {
+      name: ['loop']
+    },
     fields: [
       { name: 'name', type: 'string', description: 'Label name' }
     ]
@@ -358,6 +449,9 @@ export const astNodes: AstNode[] = [
     description: 'Block of statements',
     phpExample: `<?php\n{\n  $x = 1;\n  echo $x;\n}`,
     keywordInExample: 'block',
+    fieldHighlights: {
+      stmts: ['$x = 1', 'echo $x']
+    },
     fields: [
       { name: 'stmts', type: 'Vec<Stmt>', description: 'Statements in block' }
     ]
@@ -372,12 +466,29 @@ export const astNodes: AstNode[] = [
     fields: []
   },
   {
+    id: 'stmt-halt-compiler',
+    category: 'statement',
+    name: 'HaltCompiler',
+    description: '__halt_compiler() — everything after is raw data ignored by PHP',
+    phpExample: `<?php\n__halt_compiler();\nThis data is ignored by PHP.`,
+    keywordInExample: '__halt_compiler',
+    fieldHighlights: {
+      data: ['This data is ignored by PHP.']
+    },
+    fields: [
+      { name: 'data', type: 'string', description: 'Raw data after __halt_compiler()' }
+    ]
+  },
+  {
     id: 'stmt-inline-html',
     category: 'statement',
     name: 'InlineHtml',
     description: 'Inline HTML outside <?php ... ?>',
-    phpExample: `<?php echo 'PHP'; ?>\nThis is HTML`,
+    phpExample: `<?php echo $php; ?>\nThis is HTML`,
     keywordInExample: 'InlineHtml',
+    fieldHighlights: {
+      html: ['This is HTML']
+    },
     fields: [
       { name: 'html', type: 'string', description: 'HTML content' }
     ]
@@ -389,8 +500,11 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'Variable',
     description: 'Variable reference',
-    phpExample: `<?php\n$name = 'Alice';\necho $name;`,
+    phpExample: `<?php\n$name = $value;\necho $name;`,
     keywordInExample: 'variable',
+    fieldHighlights: {
+      name: ['$name', '$value']
+    },
     fields: [
       { name: 'name', type: 'string', description: 'Variable name (without $)' }
     ]
@@ -400,10 +514,27 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'VariableVariable',
     description: 'Variable variable (dynamic variable names)',
-    phpExample: `<?php\n$var = 'hello';\n$$var = 'world';\necho $hello;\n$$$nested = 'deep';`,
+    phpExample: `<?php\n$var = $hello;\n$$var = $world;\necho $hello;`,
     keywordInExample: 'variable',
+    fieldHighlights: {
+      expr: ['$var', '$$var']
+    },
     fields: [
       { name: 'expr', type: 'Expr', description: 'Expression to resolve to variable name' }
+    ]
+  },
+  {
+    id: 'expr-identifier',
+    category: 'expression',
+    name: 'Identifier',
+    description: 'Bare name used as an expression (function name in a call, class name, etc.)',
+    phpExample: `<?php\nstrlen($str);\nMyClass::method();`,
+    keywordInExample: 'identifier',
+    fieldHighlights: {
+      name: ['strlen', 'MyClass']
+    },
+    fields: [
+      { name: 'name', type: 'string', description: 'Identifier name' }
     ]
   },
   {
@@ -413,6 +544,9 @@ export const astNodes: AstNode[] = [
     description: 'Integer literal',
     phpExample: `<?php\n$x = 42;\n$hex = 0xFF;\n$bin = 0b1010;`,
     keywordInExample: 'int',
+    fieldHighlights: {
+      value: ['42', '0xFF', '0b1010']
+    },
     fields: [
       { name: 'value', type: 'i64', description: 'Integer value' }
     ]
@@ -424,6 +558,9 @@ export const astNodes: AstNode[] = [
     description: 'Float literal',
     phpExample: `<?php\n$pi = 3.14;\n$exp = 1.5e3;`,
     keywordInExample: 'float',
+    fieldHighlights: {
+      value: ['3.14', '1.5e3']
+    },
     fields: [
       { name: 'value', type: 'f64', description: 'Float value' }
     ]
@@ -433,8 +570,11 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'String',
     description: 'String literal',
-    phpExample: `<?php\n$str = 'hello';\n$str2 = "world";`,
+    phpExample: `<?php\n$str = $hello;\n$str2 = $world;`,
     keywordInExample: 'string',
+    fieldHighlights: {
+      value: ['$str', '$str2']
+    },
     fields: [
       { name: 'value', type: 'string', description: 'String content' }
     ]
@@ -444,8 +584,11 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'InterpolatedString',
     description: 'Double-quoted string with variable interpolation',
-    phpExample: `<?php\n$name = 'Alice';\necho "Hello $name";\necho "Result: {$obj->prop}";`,
+    phpExample: `<?php\n$name = $alice;\necho "Hello $name";\necho "Result: {$obj->prop}";`,
     keywordInExample: 'interpolated',
+    fieldHighlights: {
+      parts: ['$name', '$obj->prop']
+    },
     fields: [
       { name: 'parts', type: 'Vec<StringPart>', description: 'String parts (literals and expressions)' }
     ]
@@ -455,8 +598,12 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'Heredoc',
     description: 'Heredoc string with interpolation',
-    phpExample: `<?php\n$name = 'Alice';\n$str = <<<EOT\nHello $name\nEOT;`,
+    phpExample: `<?php\n$name = $alice;\n$str = <<<EOT\nHello $name\nEOT;`,
     keywordInExample: 'heredoc',
+    fieldHighlights: {
+      label: ['EOT'],
+      parts: ['$name']
+    },
     fields: [
       { name: 'label', type: 'string', description: 'Heredoc label' },
       { name: 'parts', type: 'Vec<StringPart>', description: 'String parts' }
@@ -469,6 +616,10 @@ export const astNodes: AstNode[] = [
     description: 'Nowdoc string (no interpolation)',
     phpExample: `<?php\n$str = <<<'EOT'\nLiteral $text\nEOT;`,
     keywordInExample: 'nowdoc',
+    fieldHighlights: {
+      label: ['EOT'],
+      value: ['Literal $text']
+    },
     fields: [
       { name: 'label', type: 'string', description: 'Nowdoc label' },
       { name: 'value', type: 'string', description: 'String content' }
@@ -481,6 +632,9 @@ export const astNodes: AstNode[] = [
     description: 'Boolean literal',
     phpExample: `<?php\n$yes = true;\n$no = false;`,
     keywordInExample: 'true',
+    fieldHighlights: {
+      value: ['true', 'false']
+    },
     fields: [
       { name: 'value', type: 'bool', description: 'Boolean value' }
     ]
@@ -499,8 +653,13 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'Assign',
     description: 'Assignment and compound assignments',
-    phpExample: `<?php\n$x = 10;\n$x += 5;\n$str .= '!';\n$result ??= $default;`,
+    phpExample: `<?php\n$x = 10;\n$x += 5;\n$result ??= $default;`,
     keywordInExample: 'null',
+    fieldHighlights: {
+      target: ['$x', '$result'],
+      op: ['+=', '??='],
+      value: ['10', '5', '$default']
+    },
     fields: [
       { name: 'target', type: 'Expr', description: 'Assignment target' },
       { name: 'op', type: 'AssignOp', description: 'Assignment operator (=, +=, .=, etc)' },
@@ -514,6 +673,11 @@ export const astNodes: AstNode[] = [
     description: 'Binary operation',
     phpExample: `<?php\n$sum = $a + $b;\n$cmp = $x <=> $y;\n$obj instanceof MyClass;`,
     keywordInExample: 'binary',
+    fieldHighlights: {
+      left: ['$a', '$x', '$obj'],
+      op: ['+', 'instanceof'],
+      right: ['$b', '$y', 'MyClass']
+    },
     fields: [
       { name: 'left', type: 'Expr', description: 'Left operand' },
       { name: 'op', type: 'BinaryOp', description: 'Binary operator' },
@@ -527,6 +691,10 @@ export const astNodes: AstNode[] = [
     description: 'Prefix unary operation',
     phpExample: `<?php\n$neg = -$x;\n$not = !$flag;\n$inc = ++$counter;`,
     keywordInExample: 'unary',
+    fieldHighlights: {
+      op: ['-$x', '!$flag', '++$counter'],
+      operand: ['$x', '$flag', '$counter']
+    },
     fields: [
       { name: 'op', type: 'UnaryPrefixOp', description: 'Operator (-, !, ++, --)' },
       { name: 'operand', type: 'Expr', description: 'Operand' }
@@ -539,6 +707,10 @@ export const astNodes: AstNode[] = [
     description: 'Postfix unary operation',
     phpExample: `<?php\n$x++;\n$y--;`,
     keywordInExample: 'postfix',
+    fieldHighlights: {
+      operand: ['$x', '$y'],
+      op: ['$x++', '$y--']
+    },
     fields: [
       { name: 'operand', type: 'Expr', description: 'Operand' },
       { name: 'op', type: 'UnaryPostfixOp', description: 'Operator (++, --)' }
@@ -549,8 +721,13 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'Ternary',
     description: 'Ternary conditional operator',
-    phpExample: `<?php\n$result = $x > 0 ? 'positive' : 'non-positive';\n$short = $x ?: 'default';`,
+    phpExample: `<?php\n$result = $x != 0 ? $positive : $nonPositive;\n$short = $x ?: $default;`,
     keywordInExample: 'ternary',
+    fieldHighlights: {
+      condition: ['$x != 0', '$x'],
+      then_expr: ['$positive'],
+      else_expr: ['$nonPositive', '$default']
+    },
     fields: [
       { name: 'condition', type: 'Expr', description: 'Condition' },
       { name: 'then_expr', type: 'Option<Expr>', description: 'Then expression', optional: true },
@@ -564,6 +741,10 @@ export const astNodes: AstNode[] = [
     description: 'Null coalescing operator',
     phpExample: `<?php\n$name = $var ?? $default;\n$value = $a ?? $b ?? $c;`,
     keywordInExample: 'coalesce',
+    fieldHighlights: {
+      left: ['$var', '$a'],
+      right: ['$default', '$b ?? $c']
+    },
     fields: [
       { name: 'left', type: 'Expr', description: 'First expression' },
       { name: 'right', type: 'Expr', description: 'Default expression' }
@@ -574,11 +755,11 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'FunctionCall',
     description: 'Function call',
-    phpExample: `<?php\nstrlen('test');\narray_map(fn($x) => $x * 2, $arr);`,
+    phpExample: `<?php\nstrlen($str);\narray_map(fn($x) => $x * 2, $arr);`,
     keywordInExample: 'function',
     fieldHighlights: {
       name: ['strlen', 'array_map'],
-      args: ['\'test\'', 'fn($x) => $x * 2', '$arr']
+      args: ['$str', 'fn($x) => $x * 2', '$arr']
     },
     fields: [
       { name: 'name', type: 'Expr', description: 'Function name' },
@@ -590,10 +771,10 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'Array',
     description: 'Array literal',
-    phpExample: `<?php\n[1, 2, 3];\n['a' => 1, 'b' => 2];\n[...$items];`,
+    phpExample: `<?php\n[1, 2, 3];\n[$key => $val, $key2 => $val2];\n[...$items];`,
     keywordInExample: 'array',
     fieldHighlights: {
-      elements: ['1', '2', '3', '\'a\' => 1', '\'b\' => 2', '...$items']
+      elements: ['1', '2', '3', '$key => $val', '$key2 => $val2', '...$items']
     },
     fields: [
       { name: 'elements', type: 'Vec<ArrayElement>', description: 'Array elements' }
@@ -604,8 +785,12 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'ArrayAccess',
     description: 'Array element access',
-    phpExample: `<?php\n$arr[0];\n$arr['key'];\n$arr[];`,
+    phpExample: `<?php\n$arr[0];\n$arr[$key];\n$arr[];`,
     keywordInExample: 'access',
+    fieldHighlights: {
+      array: ['$arr'],
+      index: ['0', '$key']
+    },
     fields: [
       { name: 'array', type: 'Expr', description: 'Array expression' },
       { name: 'index', type: 'Option<Expr>', description: 'Index (None for append)', optional: true }
@@ -626,7 +811,11 @@ export const astNodes: AstNode[] = [
     name: 'Cast',
     description: 'Type cast',
     phpExample: `<?php\n(int)$x;\n(string)$val;\n(array)$obj;`,
-    keywordInExample: 'omit',
+    keywordInExample: 'cast',
+    fieldHighlights: {
+      kind: ['(int)', '(string)', '(array)'],
+      operand: ['$x', '$val', '$obj']
+    },
     fields: [
       { name: 'kind', type: 'CastKind', description: 'Cast type (int, string, array, etc)' },
       { name: 'operand', type: 'Expr', description: 'Expression to cast' }
@@ -639,6 +828,9 @@ export const astNodes: AstNode[] = [
     description: 'Expression wrapped in parentheses',
     phpExample: `<?php\n$result = ($a + $b) * $c;\n$value = ($x);`,
     keywordInExample: 'parens',
+    fieldHighlights: {
+      expr: ['$a + $b', '$x']
+    },
     fields: [
       { name: 'expr', type: 'Expr', description: 'Wrapped expression' }
     ]
@@ -648,8 +840,11 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'Isset',
     description: 'Check if variables are set',
-    phpExample: `<?php\nisset($var);\nisset($arr['key'], $obj->prop);`,
+    phpExample: `<?php\nisset($var);\nisset($arr[$key], $obj->prop);`,
     keywordInExample: 'isset',
+    fieldHighlights: {
+      vars: ['$var', '$arr[$key]', '$obj->prop']
+    },
     fields: [
       { name: 'vars', type: 'Vec<Expr>', description: 'Variables to check' }
     ]
@@ -661,6 +856,9 @@ export const astNodes: AstNode[] = [
     description: 'Check if variable is empty',
     phpExample: `<?php\nempty($var);\nif (empty($str)) {}`,
     keywordInExample: 'empty',
+    fieldHighlights: {
+      var: ['$var', '$str']
+    },
     fields: [
       { name: 'var', type: 'Expr', description: 'Variable to check' }
     ]
@@ -672,6 +870,9 @@ export const astNodes: AstNode[] = [
     description: 'Clone an object',
     phpExample: `<?php\n$copy = clone $original;`,
     keywordInExample: 'clone',
+    fieldHighlights: {
+      object: ['$original']
+    },
     fields: [
       { name: 'object', type: 'Expr', description: 'Object to clone' }
     ]
@@ -684,6 +885,10 @@ export const astNodes: AstNode[] = [
     phpExample: `<?php\n$obj2 = clone($obj, prop: $value);`,
     phpVersion: '8.5+',
     keywordInExample: 'clone',
+    fieldHighlights: {
+      object: ['$obj'],
+      properties: ['prop: $value']
+    },
     fields: [
       { name: 'object', type: 'Expr', description: 'Object to clone' },
       { name: 'properties', type: 'Expr', description: 'Property overrides' }
@@ -694,8 +899,12 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'New',
     description: 'Create new object instance',
-    phpExample: `<?php\nnew DateTime('now');\nnew MyClass($arg);`,
+    phpExample: `<?php\nnew DateTime($now);\nnew MyClass($arg);`,
     keywordInExample: 'new',
+    fieldHighlights: {
+      class: ['DateTime', 'MyClass'],
+      args: ['$now', '$arg']
+    },
     fields: [
       { name: 'class', type: 'Expr', description: 'Class name' },
       { name: 'args', type: 'Vec<Arg>', description: 'Constructor arguments' }
@@ -706,8 +915,11 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'AnonymousClass',
     description: 'Anonymous class instance (inline class definition)',
-    phpExample: `<?php\n$obj = new class extends Base implements Interface {\n  public function method() {}\n};`,
+    phpExample: `<?php\n$obj = new class extends Base implements Countable {\n  public function method() {}\n};`,
     keywordInExample: 'class',
+    fieldHighlights: {
+      class: ['extends Base implements Countable', 'public function method']
+    },
     fields: [
       { name: 'class', type: 'ClassDecl', description: 'Anonymous class declaration' }
     ]
@@ -717,8 +929,12 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'PropertyAccess',
     description: 'Object property access',
-    phpExample: `<?php\n$obj->name;\n$obj->{'dynamic'};`,
+    phpExample: `<?php\n$obj->name;\n$obj->count;`,
     keywordInExample: 'property',
+    fieldHighlights: {
+      object: ['$obj'],
+      property: ['name', 'count']
+    },
     fields: [
       { name: 'object', type: 'Expr', description: 'Object' },
       { name: 'property', type: 'Expr', description: 'Property name' }
@@ -732,6 +948,10 @@ export const astNodes: AstNode[] = [
     phpExample: `<?php\n$obj?->prop;\n$result = $user?->profile?->name;`,
     phpVersion: '8.0+',
     keywordInExample: 'property',
+    fieldHighlights: {
+      object: ['$obj', '$user'],
+      property: ['prop', 'profile', 'name']
+    },
     fields: [
       { name: 'object', type: 'Expr', description: 'Object' },
       { name: 'property', type: 'Expr', description: 'Property name' }
@@ -742,8 +962,13 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'MethodCall',
     description: 'Object method call',
-    phpExample: `<?php\n$obj->method($arg);\n$obj->{'dynamic'}();`,
+    phpExample: `<?php\n$obj->method($arg);\n$obj->compute($x);`,
     keywordInExample: 'method',
+    fieldHighlights: {
+      object: ['$obj'],
+      method: ['method', 'compute'],
+      args: ['$arg', '$x']
+    },
     fields: [
       { name: 'object', type: 'Expr', description: 'Object' },
       { name: 'method', type: 'Expr', description: 'Method name' },
@@ -758,6 +983,11 @@ export const astNodes: AstNode[] = [
     phpExample: `<?php\n$obj?->method($arg);\n$result = $user?->getProfile()?->getName();`,
     phpVersion: '8.0+',
     keywordInExample: 'method',
+    fieldHighlights: {
+      object: ['$obj', '$user'],
+      method: ['method', 'getProfile', 'getName'],
+      args: ['$arg']
+    },
     fields: [
       { name: 'object', type: 'Expr', description: 'Object' },
       { name: 'method', type: 'Expr', description: 'Method name' },
@@ -769,11 +999,31 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'StaticPropertyAccess',
     description: 'Static property access',
-    phpExample: `<?php\nMyClass::$property;`,
+    phpExample: `<?php\nMyClass::$property;\nMyClass::$count;`,
     keywordInExample: 'static',
+    fieldHighlights: {
+      class: ['MyClass'],
+      property: ['$property', '$count']
+    },
     fields: [
       { name: 'class', type: 'Expr', description: 'Class name' },
       { name: 'property', type: 'Expr', description: 'Property name' }
+    ]
+  },
+  {
+    id: 'expr-static-prop-dyn',
+    category: 'expression',
+    name: 'StaticPropertyAccessDynamic',
+    description: 'Dynamic static property access (A::$$b)',
+    phpExample: `<?php\n$prop = $name;\nMyClass::$$prop;`,
+    keywordInExample: 'static',
+    fieldHighlights: {
+      class: ['MyClass'],
+      member: ['$$prop']
+    },
+    fields: [
+      { name: 'class', type: 'Expr', description: 'Class name' },
+      { name: 'member', type: 'Expr', description: 'Dynamic property expression' }
     ]
   },
   {
@@ -781,11 +1031,34 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'StaticMethodCall',
     description: 'Static method call',
-    phpExample: `<?php\nMyClass::method($arg);\nMyClass::class;`,
+    phpExample: `<?php\nMyClass::method($arg);\nMyClass::compute($x);`,
     keywordInExample: 'static',
+    fieldHighlights: {
+      class: ['MyClass'],
+      method: ['method', 'compute'],
+      args: ['$arg', '$x']
+    },
     fields: [
       { name: 'class', type: 'Expr', description: 'Class name' },
       { name: 'method', type: 'Expr', description: 'Method name' },
+      { name: 'args', type: 'Vec<Arg>', description: 'Arguments' }
+    ]
+  },
+  {
+    id: 'expr-static-dyn-method',
+    category: 'expression',
+    name: 'StaticDynMethodCall',
+    description: 'Dynamic static method call (Class::$method(args))',
+    phpExample: `<?php\nMyClass::$method($arg);`,
+    keywordInExample: 'static',
+    fieldHighlights: {
+      class: ['MyClass'],
+      method: ['$method'],
+      args: ['$arg']
+    },
+    fields: [
+      { name: 'class', type: 'Expr', description: 'Class name' },
+      { name: 'method', type: 'Expr', description: 'Dynamic method name (variable)' },
       { name: 'args', type: 'Vec<Arg>', description: 'Arguments' }
     ]
   },
@@ -796,9 +1069,29 @@ export const astNodes: AstNode[] = [
     description: 'Class constant access',
     phpExample: `<?php\nMyClass::VERSION;\nMyClass::MY_CONST;`,
     keywordInExample: 'const',
+    fieldHighlights: {
+      class: ['MyClass'],
+      constant: ['VERSION', 'MY_CONST']
+    },
     fields: [
       { name: 'class', type: 'Expr', description: 'Class name' },
       { name: 'constant', type: 'Expr', description: 'Constant name' }
+    ]
+  },
+  {
+    id: 'expr-class-const-dyn',
+    category: 'expression',
+    name: 'ClassConstAccessDynamic',
+    description: 'Dynamic class constant access (Foo::{expr})',
+    phpExample: `<?php\n$const = $version;\nFoo::{$const};`,
+    keywordInExample: 'const',
+    fieldHighlights: {
+      class: ['Foo'],
+      member: ['$const']
+    },
+    fields: [
+      { name: 'class', type: 'Expr', description: 'Class name' },
+      { name: 'member', type: 'Expr', description: 'Dynamic member expression' }
     ]
   },
   {
@@ -808,6 +1101,11 @@ export const astNodes: AstNode[] = [
     description: 'Anonymous function (closure)',
     phpExample: `<?php\n$add = function($a, $b) use ($multiplier) {\n  return ($a + $b) * $multiplier;\n};`,
     keywordInExample: 'function',
+    fieldHighlights: {
+      params: ['$a', '$b'],
+      use_vars: ['$multiplier'],
+      body: ['return ($a + $b) * $multiplier']
+    },
     fields: [
       { name: 'is_static', type: 'bool', description: 'Is static closure' },
       { name: 'by_ref', type: 'bool', description: 'Returns by reference' },
@@ -822,9 +1120,13 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'ArrowFunction',
     description: 'Arrow function (short closure, PHP 7.4+)',
-    phpExample: `<?php\n$square = fn($x) => $x * $x;\n$filter = fn($item) => $item['active'] ?? false;`,
+    phpExample: `<?php\n$square = fn($x) => $x * $x;\n$double = fn($n) => $n * 2;`,
     phpVersion: '7.4+',
     keywordInExample: 'arrow',
+    fieldHighlights: {
+      params: ['$x', '$n'],
+      body: ['$x * $x', '$n * 2']
+    },
     fields: [
       { name: 'is_static', type: 'bool', description: 'Is static' },
       { name: 'by_ref', type: 'bool', description: 'Returns by reference' },
@@ -838,9 +1140,13 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'Match',
     description: 'Match expression (PHP 8.0+)',
-    phpExample: `<?php\n$result = match($status) {\n  'active' => 'Running',\n  'paused' => 'Paused',\n  default => 'Unknown'\n};`,
+    phpExample: `<?php\n$result = match($status) {\n  STATUS_ACTIVE => $running,\n  STATUS_PAUSED => $paused,\n  default => $unknown\n};`,
     phpVersion: '8.0+',
     keywordInExample: 'match',
+    fieldHighlights: {
+      subject: ['$status'],
+      arms: ['STATUS_ACTIVE => $running', 'STATUS_PAUSED => $paused', 'default => $unknown']
+    },
     fields: [
       { name: 'subject', type: 'Expr', description: 'Expression to match' },
       { name: 'arms', type: 'Vec<MatchArm>', description: 'Match arms' }
@@ -851,8 +1157,13 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'Yield',
     description: 'Yield value from generator',
-    phpExample: `<?php\nfunction gen() {\n  yield 1;\n  yield 'key' => 2;\n  yield from [3, 4];\n}`,
+    phpExample: `<?php\nfunction gen() {\n  yield 1;\n  yield $key => 2;\n  yield from $items;\n}`,
     keywordInExample: 'yield',
+    fieldHighlights: {
+      key: ['$key'],
+      value: ['1', '2'],
+      is_from: ['yield from']
+    },
     fields: [
       { name: 'key', type: 'Option<Expr>', description: 'Key for yield', optional: true },
       { name: 'value', type: 'Option<Expr>', description: 'Value to yield', optional: true },
@@ -866,6 +1177,9 @@ export const astNodes: AstNode[] = [
     description: 'Callable creation expression (first-class callables)',
     phpExample: `<?php\n$func = strlen(...);\n$method = $obj->method(...);\n$static = MyClass::staticMethod(...);`,
     keywordInExample: 'callable',
+    fieldHighlights: {
+      kind: ['strlen(...)', '$obj->method(...)', 'MyClass::staticMethod(...)']
+    },
     fields: [
       { name: 'kind', type: 'CallableCreateKind', description: 'Type of callable (function, method, static)' }
     ]
@@ -875,9 +1189,12 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'ThrowExpr',
     description: 'Throw expression (PHP 8.0+)',
-    phpExample: `<?php\n$x = $value ?? throw new InvalidArgumentException();`,
+    phpExample: `<?php\n$x = $value ?? throw new InvalidArgumentException($msg);`,
     phpVersion: '8.0+',
     keywordInExample: 'throw',
+    fieldHighlights: {
+      exception: ['new InvalidArgumentException($msg)']
+    },
     fields: [
       { name: 'exception', type: 'Expr', description: 'Exception to throw' }
     ]
@@ -887,8 +1204,11 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'Print',
     description: 'Print construct',
-    phpExample: `<?php\nprint 'Hello';\nprint($name);`,
+    phpExample: `<?php\nprint $greeting;\nprint($name);`,
     keywordInExample: 'print',
+    fieldHighlights: {
+      value: ['$greeting', '$name']
+    },
     fields: [
       { name: 'value', type: 'Expr', description: 'Value to print' }
     ]
@@ -898,8 +1218,11 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'ErrorSuppress',
     description: 'Error suppression operator (@)',
-    phpExample: `<?php\n@file_get_contents('missing.txt');\n@$arr['key'];`,
+    phpExample: `<?php\n@file_get_contents($path);\n@$arr[$key];`,
     keywordInExample: 'suppress',
+    fieldHighlights: {
+      operand: ['file_get_contents($path)', '$arr[$key]']
+    },
     fields: [
       { name: 'operand', type: 'Expr', description: 'Expression to suppress' }
     ]
@@ -909,8 +1232,12 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'Include',
     description: 'Include/require files',
-    phpExample: `<?php\ninclude 'header.php';\nrequire_once 'config.php';`,
+    phpExample: `<?php\ninclude $header;\nrequire_once $config;`,
     keywordInExample: 'include',
+    fieldHighlights: {
+      kind: ['include', 'require_once'],
+      file: ['$header', '$config']
+    },
     fields: [
       { name: 'kind', type: 'IncludeKind', description: 'Include/require/once variant' },
       { name: 'file', type: 'Expr', description: 'File path' }
@@ -921,8 +1248,11 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'Eval',
     description: 'Evaluate PHP code',
-    phpExample: `<?php\neval('echo "Hello";');`,
+    phpExample: `<?php\neval($code);`,
     keywordInExample: 'eval',
+    fieldHighlights: {
+      code: ['$code']
+    },
     fields: [
       { name: 'code', type: 'Expr', description: 'Code to evaluate' }
     ]
@@ -932,8 +1262,11 @@ export const astNodes: AstNode[] = [
     category: 'expression',
     name: 'Exit',
     description: 'Exit/die construct',
-    phpExample: `<?php\nexit('Error message');\ndie(1);`,
+    phpExample: `<?php\nexit($message);\ndie(1);`,
     keywordInExample: 'exit',
+    fieldHighlights: {
+      value: ['$message', '1']
+    },
     fields: [
       { name: 'value', type: 'Option<Expr>', description: 'Exit code or message', optional: true }
     ]
@@ -945,6 +1278,9 @@ export const astNodes: AstNode[] = [
     description: 'Magic constant (__LINE__, __FILE__, etc)',
     phpExample: `<?php\necho __LINE__;\necho __FILE__;\necho __DIR__;`,
     keywordInExample: 'magic',
+    fieldHighlights: {
+      kind: ['__LINE__', '__FILE__', '__DIR__']
+    },
     fields: [
       { name: 'kind', type: 'MagicConstKind', description: 'Magic constant type' }
     ]
@@ -956,6 +1292,9 @@ export const astNodes: AstNode[] = [
     description: 'Shell execution (backticks)',
     phpExample: `<?php\n$output = \`ls -la\`;\necho \`date\`;`,
     keywordInExample: 'shell',
+    fieldHighlights: {
+      parts: ['ls -la', 'date']
+    },
     fields: [
       { name: 'parts', type: 'Vec<StringPart>', description: 'Command parts' }
     ]
@@ -969,6 +1308,13 @@ export const astNodes: AstNode[] = [
     description: 'Function/method parameter',
     phpExample: `<?php\nfunction foo(string $name, int $age = 0, &$ref = null) {}`,
     keywordInExample: 'param',
+    fieldHighlights: {
+      name: ['$name', '$age', '$ref'],
+      type_hint: ['string', 'int'],
+      default: ['0', 'null'],
+      by_ref: ['&$ref'],
+      variadic: []
+    },
     fields: [
       { name: 'name', type: 'Ident', description: 'Parameter name' },
       { name: 'type_hint', type: 'Option<TypeHint>', description: 'Type hint', optional: true },
@@ -982,8 +1328,15 @@ export const astNodes: AstNode[] = [
     category: 'declaration',
     name: 'PropertyDecl',
     description: 'Class property',
-    phpExample: `<?php\npublic string $name = 'default';\nprivate readonly int $id;`,
+    phpExample: `<?php\npublic string $name = $default;\nprivate readonly int $id;`,
     keywordInExample: 'property',
+    fieldHighlights: {
+      name: ['$name', '$id'],
+      visibility: ['public', 'private'],
+      is_readonly: ['readonly'],
+      type_hint: ['string', 'int'],
+      default: ['$default']
+    },
     fields: [
       { name: 'name', type: 'Ident', description: 'Property name' },
       { name: 'visibility', type: 'Visibility', description: 'public/protected/private' },
@@ -998,8 +1351,16 @@ export const astNodes: AstNode[] = [
     category: 'declaration',
     name: 'MethodDecl',
     description: 'Class method',
-    phpExample: `<?php\npublic function getValue(): string { return 'value'; }\nabstract protected function validate();`,
+    phpExample: `<?php\npublic function getValue(): string { return $value; }\nabstract protected function validate();`,
     keywordInExample: 'method',
+    fieldHighlights: {
+      name: ['getValue', 'validate'],
+      visibility: ['public', 'protected'],
+      is_abstract: ['abstract'],
+      params: [],
+      return_type: ['string'],
+      body: ['return $value']
+    },
     fields: [
       { name: 'name', type: 'Ident', description: 'Method name' },
       { name: 'visibility', type: 'Option<Visibility>', description: 'Visibility', optional: true },
@@ -1019,6 +1380,11 @@ export const astNodes: AstNode[] = [
     phpExample: `<?php\npublic string $value {\n  get => strtoupper($this->_value);\n  set(string $v) { $this->_value = $v; }\n}`,
     phpVersion: '8.4+',
     keywordInExample: 'hook',
+    fieldHighlights: {
+      kind: ['get', 'set'],
+      body: ['strtoupper($this->_value)', '$this->_value = $v'],
+      params: ['$v']
+    },
     fields: [
       { name: 'kind', type: 'PropertyHookKind', description: 'Get or Set' },
       { name: 'body', type: 'PropertyHookBody', description: 'Hook implementation' },
@@ -1032,8 +1398,14 @@ export const astNodes: AstNode[] = [
     category: 'declaration',
     name: 'ClassConstDecl',
     description: 'Class constant',
-    phpExample: `<?php\nconst VERSION = '1.0';\nfinal protected const DEFAULT = 0;`,
+    phpExample: `<?php\nconst VERSION = 1;\nfinal protected const DEFAULT_VAL = 0;`,
     keywordInExample: 'const',
+    fieldHighlights: {
+      name: ['VERSION', 'DEFAULT_VAL'],
+      visibility: ['protected'],
+      is_final: ['final'],
+      value: ['1', '0']
+    },
     fields: [
       { name: 'name', type: 'Ident', description: 'Constant name' },
       { name: 'visibility', type: 'Option<Visibility>', description: 'Visibility', optional: true },
@@ -1047,8 +1419,12 @@ export const astNodes: AstNode[] = [
     category: 'declaration',
     name: 'EnumCase',
     description: 'Enum case',
-    phpExample: `<?php\nenum Color {\n  case Red;\n  case Green = 'green';\n}`,
+    phpExample: `<?php\nenum Color {\n  case Red;\n  case Green = GREEN_VALUE;\n}`,
     keywordInExample: 'case',
+    fieldHighlights: {
+      name: ['Red', 'Green'],
+      value: ['GREEN_VALUE']
+    },
     fields: [
       { name: 'name', type: 'Ident', description: 'Case name' },
       { name: 'value', type: 'Option<Expr>', description: 'Case value (backed enums)', optional: true }
@@ -1063,6 +1439,9 @@ export const astNodes: AstNode[] = [
     description: 'Nullable type (?T)',
     phpExample: `<?php\nfunction getName(): ?string { return null; }`,
     keywordInExample: 'nullable',
+    fieldHighlights: {
+      type: ['?string']
+    },
     fields: [
       { name: 'type', type: 'TypeHint', description: 'Wrapped type' }
     ]
@@ -1075,6 +1454,9 @@ export const astNodes: AstNode[] = [
     phpExample: `<?php\nfunction getValue(): int|string|null { }`,
     phpVersion: '8.0+',
     keywordInExample: 'union',
+    fieldHighlights: {
+      types: ['int|string|null']
+    },
     fields: [
       { name: 'types', type: 'Vec<TypeHint>', description: 'Union member types' }
     ]
@@ -1087,6 +1469,9 @@ export const astNodes: AstNode[] = [
     phpExample: `<?php\nfunction process(Countable&ArrayAccess $data) { }`,
     phpVersion: '8.1+',
     keywordInExample: 'intersection',
+    fieldHighlights: {
+      types: ['Countable&ArrayAccess']
+    },
     fields: [
       { name: 'types', type: 'Vec<TypeHint>', description: 'Intersection member types' }
     ]
@@ -1098,6 +1483,9 @@ export const astNodes: AstNode[] = [
     description: 'Named type (class/interface name)',
     phpExample: `<?php\nfunction save(User $user): void { }`,
     keywordInExample: 'named',
+    fieldHighlights: {
+      name: ['User']
+    },
     fields: [
       { name: 'name', type: 'Name', description: 'Type name (with namespace)' }
     ]
@@ -1109,6 +1497,9 @@ export const astNodes: AstNode[] = [
     description: 'Built-in type keyword',
     phpExample: `<?php\nfunction test(int $x, array $arr, mixed $value): string { }`,
     keywordInExample: 'builtin',
+    fieldHighlights: {
+      type: ['int', 'array', 'mixed', 'string']
+    },
     fields: [
       { name: 'type', type: 'string', description: 'Type keyword (int, string, mixed, etc)' }
     ]
@@ -1120,8 +1511,13 @@ export const astNodes: AstNode[] = [
     category: 'helper',
     name: 'Arg',
     description: 'Function/method argument',
-    phpExample: `<?php\nfoo($a, $b, name: $c, ...spread);`,
+    phpExample: `<?php\nfoo($a, $b, name: $c, ...$spread);`,
     keywordInExample: 'arg',
+    fieldHighlights: {
+      name: ['name'],
+      value: ['$a', '$b', '$c', '$spread'],
+      unpack: ['...$spread']
+    },
     fields: [
       { name: 'name', type: 'Option<Name>', description: 'Named argument name', optional: true },
       { name: 'value', type: 'Expr', description: 'Argument value' },
@@ -1134,8 +1530,12 @@ export const astNodes: AstNode[] = [
     category: 'helper',
     name: 'Attribute',
     description: 'Attribute/annotation',
-    phpExample: `<?php\n#[Route('/path')]\n#[Deprecated('Use newFunc')]\nfunction handler() {}`,
+    phpExample: `<?php\n#[Route($path)]\n#[Deprecated($msg)]\nfunction handler() {}`,
     keywordInExample: 'attribute',
+    fieldHighlights: {
+      name: ['Route', 'Deprecated'],
+      args: ['$path', '$msg']
+    },
     fields: [
       { name: 'name', type: 'Name', description: 'Attribute name' },
       { name: 'args', type: 'Vec<Arg>', description: 'Attribute arguments' }
@@ -1148,6 +1548,10 @@ export const astNodes: AstNode[] = [
     description: 'Source code location (start and end byte offsets)',
     phpExample: `<?php\n// Every AST node has a Span indicating where in the source it appears`,
     keywordInExample: 'span',
+    fieldHighlights: {
+      start: ['start'],
+      end: ['end']
+    },
     fields: [
       { name: 'start', type: 'u32', description: 'Start byte offset' },
       { name: 'end', type: 'u32', description: 'End byte offset' }
@@ -1160,9 +1564,207 @@ export const astNodes: AstNode[] = [
     description: 'Namespace-qualified name',
     phpExample: `<?php\nuse App\\Models\\User;\nclass Post extends BaseModel {}`,
     keywordInExample: 'name',
+    fieldHighlights: {
+      parts: ['App\\\\Models\\\\User', 'BaseModel'],
+      kind: ['use', 'extends']
+    },
     fields: [
       { name: 'parts', type: 'Vec<string>', description: 'Name parts (e.g., ["App", "Models", "User"])' },
       { name: 'kind', type: 'NameKind', description: 'Qualified, FullyQualified, Relative, etc' }
+    ]
+  },
+  {
+    id: 'helper-program',
+    category: 'helper',
+    name: 'Program',
+    description: 'Root AST node containing all top-level statements',
+    phpExample: `<?php\n$x = 1;\necho $x;`,
+    keywordInExample: 'program',
+    fieldHighlights: {
+      stmts: ['$x = 1', 'echo $x']
+    },
+    fields: [
+      { name: 'stmts', type: 'Vec<Stmt>', description: 'Top-level statements' }
+    ]
+  },
+  {
+    id: 'helper-elseif-branch',
+    category: 'helper',
+    name: 'ElseIfBranch',
+    description: 'A single elseif branch in an if statement',
+    phpExample: `<?php\nif ($x == 1) {\n  echo $x;\n} elseif ($x == 2) {\n  echo 0;\n}`,
+    keywordInExample: 'elseif',
+    fieldHighlights: {
+      condition: ['$x == 2'],
+      body: ['echo 0']
+    },
+    fields: [
+      { name: 'condition', type: 'Expr', description: 'Branch condition' },
+      { name: 'body', type: 'Stmt', description: 'Branch body' }
+    ]
+  },
+  {
+    id: 'helper-switch-case',
+    category: 'helper',
+    name: 'SwitchCase',
+    description: 'A single case in a switch statement',
+    phpExample: `<?php\nswitch ($x) {\n  case 1:\n    echo $x;\n    break;\n  default:\n    break;\n}`,
+    keywordInExample: 'case',
+    fieldHighlights: {
+      value: ['1'],
+      body: ['echo $x', 'break']
+    },
+    fields: [
+      { name: 'value', type: 'Option<Expr>', description: 'Case value (None = default)', optional: true },
+      { name: 'body', type: 'Vec<Stmt>', description: 'Case body' }
+    ]
+  },
+  {
+    id: 'helper-catch-clause',
+    category: 'helper',
+    name: 'CatchClause',
+    description: 'A single catch in try-catch',
+    phpExample: `<?php\ntry {\n  throw new RuntimeException();\n} catch (RuntimeException $e) {\n  echo $e;\n}`,
+    keywordInExample: 'catch',
+    fieldHighlights: {
+      types: ['RuntimeException'],
+      var: ['$e'],
+      body: ['echo $e']
+    },
+    fields: [
+      { name: 'types', type: 'Vec<Name>', description: 'Caught exception types' },
+      { name: 'var', type: 'Option<string>', description: 'Catch variable name', optional: true },
+      { name: 'body', type: 'Vec<Stmt>', description: 'Catch block' }
+    ]
+  },
+  {
+    id: 'helper-use-item',
+    category: 'helper',
+    name: 'UseItem',
+    description: 'A single imported name in a use statement',
+    phpExample: `<?php\nuse App\\Models\\User;\nuse App\\Http\\Controller as Ctrl;`,
+    keywordInExample: 'use',
+    fieldHighlights: {
+      name: ['App\\\\Models\\\\User', 'App\\\\Http\\\\Controller'],
+      alias: ['Ctrl']
+    },
+    fields: [
+      { name: 'name', type: 'Name', description: 'Imported name' },
+      { name: 'alias', type: 'Option<string>', description: 'Alias name', optional: true },
+      { name: 'kind', type: 'Option<UseKind>', description: 'Override kind for group use', optional: true }
+    ]
+  },
+  {
+    id: 'helper-const-item',
+    category: 'helper',
+    name: 'ConstItem',
+    description: 'A single constant in a const statement',
+    phpExample: `<?php\nconst MAX_SIZE = 100;\nconst DB_HOST = DB_DEFAULT_HOST;`,
+    keywordInExample: 'const',
+    fieldHighlights: {
+      name: ['MAX_SIZE', 'DB_HOST'],
+      value: ['100', 'DB_DEFAULT_HOST']
+    },
+    fields: [
+      { name: 'name', type: 'Ident', description: 'Constant name' },
+      { name: 'value', type: 'Expr', description: 'Constant value' },
+      { name: 'attributes', type: 'Vec<Attribute>', description: 'Attributes' }
+    ]
+  },
+  {
+    id: 'helper-static-var',
+    category: 'helper',
+    name: 'StaticVar',
+    description: 'A single static variable declaration',
+    phpExample: `<?php\nfunction counter() {\n  static $count = 0;\n  return ++$count;\n}`,
+    keywordInExample: 'static',
+    fieldHighlights: {
+      name: ['$count'],
+      default: ['0']
+    },
+    fields: [
+      { name: 'name', type: 'Ident', description: 'Variable name' },
+      { name: 'default', type: 'Option<Expr>', description: 'Default value', optional: true }
+    ]
+  },
+  {
+    id: 'helper-closure-use-var',
+    category: 'helper',
+    name: 'ClosureUseVar',
+    description: 'A variable captured by a closure',
+    phpExample: `<?php\n$multiplier = 3;\n$fn = function($x) use ($multiplier) {\n  return $x * $multiplier;\n};`,
+    keywordInExample: 'use',
+    fieldHighlights: {
+      name: ['$multiplier']
+    },
+    fields: [
+      { name: 'name', type: 'string', description: 'Variable name' },
+      { name: 'by_ref', type: 'bool', description: 'Captured by reference' }
+    ]
+  },
+  {
+    id: 'helper-array-element',
+    category: 'helper',
+    name: 'ArrayElement',
+    description: 'A single element in an array literal',
+    phpExample: `<?php\n[$val, $key => $val2, ...$spread];`,
+    keywordInExample: 'element',
+    fieldHighlights: {
+      key: ['$key'],
+      value: ['$val', '$val2', '$spread'],
+      unpack: ['...$spread']
+    },
+    fields: [
+      { name: 'key', type: 'Option<Expr>', description: 'Array key', optional: true },
+      { name: 'value', type: 'Expr', description: 'Array value' },
+      { name: 'unpack', type: 'bool', description: 'Spread element (...)' },
+      { name: 'by_ref', type: 'bool', description: 'By reference' }
+    ]
+  },
+  {
+    id: 'helper-match-arm',
+    category: 'helper',
+    name: 'MatchArm',
+    description: 'A single arm in a match expression',
+    phpExample: `<?php\nmatch($x) {\n  1, 2 => $small,\n  default => $other\n};`,
+    keywordInExample: 'arm',
+    fieldHighlights: {
+      conditions: ['1', '2'],
+      body: ['$small', '$other']
+    },
+    fields: [
+      { name: 'conditions', type: 'Option<Vec<Expr>>', description: 'Match conditions (None = default)', optional: true },
+      { name: 'body', type: 'Expr', description: 'Arm body expression' }
+    ]
+  },
+  {
+    id: 'helper-trait-use-decl',
+    category: 'helper',
+    name: 'TraitUseDecl',
+    description: 'use Trait; inside a class body',
+    phpExample: `<?php\nclass MyClass {\n  use TraitA, TraitB {\n    TraitA::foo insteadof TraitB;\n  }\n}`,
+    keywordInExample: 'use',
+    fieldHighlights: {
+      traits: ['TraitA', 'TraitB'],
+      adaptations: ['TraitA::foo insteadof TraitB']
+    },
+    fields: [
+      { name: 'traits', type: 'Vec<Name>', description: 'Used trait names' },
+      { name: 'adaptations', type: 'Vec<TraitAdaptation>', description: 'Conflict resolutions' }
+    ]
+  },
+  {
+    id: 'helper-string-part',
+    category: 'helper',
+    name: 'StringPart',
+    description: 'A part of an interpolated string (literal text or embedded expression)',
+    phpExample: `<?php\n$name = $alice;\necho "Hello $name, you are {$age} old";`,
+    keywordInExample: 'part',
+    fieldHighlights: {
+      kind: ['Hello ', '$name', '$age', ' old']
+    },
+    fields: [
+      { name: 'kind', type: 'Literal | Expr', description: 'Literal text or embedded expression' }
     ]
   }
 ]

--- a/playground/src/data/ast-nodes.ts
+++ b/playground/src/data/ast-nodes.ts
@@ -20,6 +20,114 @@ export interface AstNode {
 export const astNodes: AstNode[] = [
   // ========== STATEMENTS ==========
   {
+    id: 'stmt-block',
+    category: 'statement',
+    name: 'Block',
+    description: 'Block of statements',
+    phpExample: `<?php\n{\n  $x = 1;\n  echo $x;\n}`,
+    keywordInExample: 'block',
+    fieldHighlights: {
+      stmts: ['$x = 1', 'echo $x']
+    },
+    fields: [
+      { name: 'stmts', type: 'Vec<Stmt>', description: 'Statements in block' }
+    ]
+  },
+  {
+    id: 'stmt-break',
+    category: 'statement',
+    name: 'Break',
+    description: 'Break from loop or switch',
+    phpExample: `<?php\nwhile (true) {\n  if ($done) break 2;\n}`,
+    keywordInExample: 'break',
+    fieldHighlights: {
+      level: ['2']
+    },
+    fields: [
+      { name: 'level', type: 'Option<Expr>', description: 'Number of levels to break', optional: true }
+    ]
+  },
+  {
+    id: 'stmt-class',
+    category: 'statement',
+    name: 'Class',
+    description: 'Class declaration',
+    phpExample: `<?php\nclass Animal extends Base implements Countable {\n  public string $name;\n  public function speak(): void {}\n}`,
+    keywordInExample: 'class',
+    fieldHighlights: {
+      name: ['Animal'],
+      extends: ['Base'],
+      implements: ['Countable'],
+      members: ['public string $name', 'public function speak']
+    },
+    fields: [
+      { name: 'name', type: 'Ident', description: 'Class name' },
+      { name: 'extends', type: 'Option<Name>', description: 'Parent class', optional: true },
+      { name: 'implements', type: 'Vec<Name>', description: 'Interfaces' },
+      { name: 'members', type: 'Vec<ClassMember>', description: 'Properties, methods, constants' }
+    ]
+  },
+  {
+    id: 'stmt-const',
+    category: 'statement',
+    name: 'Const',
+    description: 'Global constant declaration',
+    phpExample: `<?php\nconst MAX_SIZE = 100;\nconst DB_HOST = DB_DEFAULT_HOST;`,
+    keywordInExample: 'const',
+    fieldHighlights: {
+      items: ['MAX_SIZE = 100', 'DB_HOST = DB_DEFAULT_HOST']
+    },
+    fields: [
+      { name: 'items', type: 'Vec<ConstItem>', description: 'Constant declarations' }
+    ]
+  },
+  {
+    id: 'stmt-continue',
+    category: 'statement',
+    name: 'Continue',
+    description: 'Continue to next iteration of loop',
+    phpExample: `<?php\nfor ($i = 0; $i != 10; $i++) {\n  if ($i % 2 == 0) continue;\n  echo $i;\n}`,
+    keywordInExample: 'continue',
+    fieldHighlights: {
+      level: ['continue']
+    },
+    fields: [
+      { name: 'level', type: 'Option<Expr>', description: 'Number of levels to continue', optional: true }
+    ]
+  },
+  {
+    id: 'stmt-declare',
+    category: 'statement',
+    name: 'Declare',
+    description: 'Declare directives like strict_types',
+    phpExample: `<?php\ndeclare(strict_types=1);\ndeclare(ticks=1) {}`,
+    keywordInExample: 'declare',
+    fieldHighlights: {
+      directives: ['strict_types=1', 'ticks=1'],
+      body: ['{}']
+    },
+    fields: [
+      { name: 'directives', type: 'Vec<(Name, Expr)>', description: 'Directives' },
+      { name: 'body', type: 'Option<Stmt>', description: 'Declare body', optional: true }
+    ]
+  },
+  {
+    id: 'stmt-do-while',
+    category: 'statement',
+    name: 'DoWhile',
+    description: 'Do-while loop (executes at least once)',
+    phpExample: `<?php\ndo {\n  echo $x;\n  $x--;\n} while ($x != 0);`,
+    keywordInExample: 'do',
+    fieldHighlights: {
+      body: ['echo $x', '$x--'],
+      condition: ['$x != 0']
+    },
+    fields: [
+      { name: 'body', type: 'Stmt', description: 'Loop body' },
+      { name: 'condition', type: 'Expr', description: 'Loop condition' }
+    ]
+  },
+  {
     id: 'stmt-echo',
     category: 'statement',
     name: 'Echo',
@@ -35,54 +143,22 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'stmt-return',
+    id: 'stmt-enum',
     category: 'statement',
-    name: 'Return',
-    description: 'Return from a function or method',
-    phpExample: `<?php\nfunction add($a, $b) {\n  return $a + $b;\n}`,
-    keywordInExample: 'return',
+    name: 'Enum',
+    description: 'Enumeration declaration (PHP 8.1+)',
+    phpExample: `<?php\nenum Status: string {\n  case Active = STATUS_ACTIVE;\n  case Inactive = STATUS_INACTIVE;\n}`,
+    phpVersion: '8.1+',
+    keywordInExample: 'enum',
     fieldHighlights: {
-      keyword: ['return'],
-      value: ['$a + $b']
+      name: ['Status'],
+      scalar_type: ['string'],
+      members: ['case Active', 'case Inactive']
     },
     fields: [
-      { name: 'value', type: 'Option<Expr>', description: 'Return value', optional: true }
-    ]
-  },
-  {
-    id: 'stmt-if',
-    category: 'statement',
-    name: 'If',
-    description: 'Conditional statement with if/elseif/else branches',
-    phpExample: `<?php\nif ($x == 1) {\n  echo $positive;\n} elseif ($x == 2) {\n  echo $negative;\n} else {\n  echo $zero;\n}`,
-    keywordInExample: 'if',
-    fieldHighlights: {
-      condition: ['$x == 1'],
-      then_branch: ['echo $positive'],
-      elseif_branches: ['elseif ($x == 2)'],
-      else_branch: ['echo $zero']
-    },
-    fields: [
-      { name: 'condition', type: 'Expr', description: 'Condition to evaluate' },
-      { name: 'then_branch', type: 'Stmt', description: 'Statement when condition is true' },
-      { name: 'elseif_branches', type: 'Vec<ElseIfBranch>', description: 'Elseif branches' },
-      { name: 'else_branch', type: 'Option<Stmt>', description: 'Else statement', optional: true }
-    ]
-  },
-  {
-    id: 'stmt-while',
-    category: 'statement',
-    name: 'While',
-    description: 'While loop',
-    phpExample: `<?php\nwhile ($x != 0) {\n  echo $x;\n  $x--;\n}`,
-    keywordInExample: 'while',
-    fieldHighlights: {
-      condition: ['$x != 0'],
-      body: ['echo $x', '$x--']
-    },
-    fields: [
-      { name: 'condition', type: 'Expr', description: 'Loop condition' },
-      { name: 'body', type: 'Stmt', description: 'Loop body' }
+      { name: 'name', type: 'Ident', description: 'Enum name' },
+      { name: 'scalar_type', type: 'Option<Name>', description: 'Backing type (int or string)', optional: true },
+      { name: 'members', type: 'Vec<EnumMember>', description: 'Cases and methods' }
     ]
   },
   {
@@ -126,66 +202,6 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'stmt-do-while',
-    category: 'statement',
-    name: 'DoWhile',
-    description: 'Do-while loop (executes at least once)',
-    phpExample: `<?php\ndo {\n  echo $x;\n  $x--;\n} while ($x != 0);`,
-    keywordInExample: 'do',
-    fieldHighlights: {
-      body: ['echo $x', '$x--'],
-      condition: ['$x != 0']
-    },
-    fields: [
-      { name: 'body', type: 'Stmt', description: 'Loop body' },
-      { name: 'condition', type: 'Expr', description: 'Loop condition' }
-    ]
-  },
-  {
-    id: 'stmt-switch',
-    category: 'statement',
-    name: 'Switch',
-    description: 'Switch statement with cases and default',
-    phpExample: `<?php\nswitch ($x) {\n  case 1:\n    echo $x;\n    break;\n  default:\n    echo $default;\n}`,
-    keywordInExample: 'switch',
-    fieldHighlights: {
-      expr: ['$x'],
-      cases: ['case 1', 'default']
-    },
-    fields: [
-      { name: 'expr', type: 'Expr', description: 'Value to switch on' },
-      { name: 'cases', type: 'Vec<SwitchCase>', description: 'Switch cases' }
-    ]
-  },
-  {
-    id: 'stmt-break',
-    category: 'statement',
-    name: 'Break',
-    description: 'Break from loop or switch',
-    phpExample: `<?php\nwhile (true) {\n  if ($done) break 2;\n}`,
-    keywordInExample: 'break',
-    fieldHighlights: {
-      level: ['2']
-    },
-    fields: [
-      { name: 'level', type: 'Option<Expr>', description: 'Number of levels to break', optional: true }
-    ]
-  },
-  {
-    id: 'stmt-continue',
-    category: 'statement',
-    name: 'Continue',
-    description: 'Continue to next iteration of loop',
-    phpExample: `<?php\nfor ($i = 0; $i != 10; $i++) {\n  if ($i % 2 == 0) continue;\n  echo $i;\n}`,
-    keywordInExample: 'continue',
-    fieldHighlights: {
-      level: ['continue']
-    },
-    fields: [
-      { name: 'level', type: 'Option<Expr>', description: 'Number of levels to continue', optional: true }
-    ]
-  },
-  {
     id: 'stmt-function',
     category: 'statement',
     name: 'Function',
@@ -206,23 +222,79 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'stmt-class',
+    id: 'stmt-global',
     category: 'statement',
-    name: 'Class',
-    description: 'Class declaration',
-    phpExample: `<?php\nclass Animal extends Base implements Countable {\n  public string $name;\n  public function speak(): void {}\n}`,
-    keywordInExample: 'class',
+    name: 'Global',
+    description: 'Declare global variables',
+    phpExample: `<?php\n$x = 1;\n\nfunction test() {\n  global $x;\n  $x = 2;\n}`,
+    keywordInExample: 'global',
     fieldHighlights: {
-      name: ['Animal'],
-      extends: ['Base'],
-      implements: ['Countable'],
-      members: ['public string $name', 'public function speak']
+      vars: ['$x']
     },
     fields: [
-      { name: 'name', type: 'Ident', description: 'Class name' },
-      { name: 'extends', type: 'Option<Name>', description: 'Parent class', optional: true },
-      { name: 'implements', type: 'Vec<Name>', description: 'Interfaces' },
-      { name: 'members', type: 'Vec<ClassMember>', description: 'Properties, methods, constants' }
+      { name: 'vars', type: 'Vec<Expr>', description: 'Variables to declare global' }
+    ]
+  },
+  {
+    id: 'stmt-goto',
+    category: 'statement',
+    name: 'Goto',
+    description: 'Go to label',
+    phpExample: `<?php\ngoto end;\necho $skipped;\nend:\necho $done;`,
+    keywordInExample: 'goto',
+    fieldHighlights: {
+      label: ['end']
+    },
+    fields: [
+      { name: 'label', type: 'Ident', description: 'Target label' }
+    ]
+  },
+  {
+    id: 'stmt-halt-compiler',
+    category: 'statement',
+    name: 'HaltCompiler',
+    description: '__halt_compiler() — everything after is raw data ignored by PHP',
+    phpExample: `<?php\n__halt_compiler();\nThis data is ignored by PHP.`,
+    keywordInExample: '__halt_compiler',
+    fieldHighlights: {
+      data: ['This data is ignored by PHP.']
+    },
+    fields: [
+      { name: 'data', type: 'string', description: 'Raw data after __halt_compiler()' }
+    ]
+  },
+  {
+    id: 'stmt-if',
+    category: 'statement',
+    name: 'If',
+    description: 'Conditional statement with if/elseif/else branches',
+    phpExample: `<?php\nif ($x == 1) {\n  echo $positive;\n} elseif ($x == 2) {\n  echo $negative;\n} else {\n  echo $zero;\n}`,
+    keywordInExample: 'if',
+    fieldHighlights: {
+      condition: ['$x == 1'],
+      then_branch: ['echo $positive'],
+      elseif_branches: ['elseif ($x == 2)'],
+      else_branch: ['echo $zero']
+    },
+    fields: [
+      { name: 'condition', type: 'Expr', description: 'Condition to evaluate' },
+      { name: 'then_branch', type: 'Stmt', description: 'Statement when condition is true' },
+      { name: 'elseif_branches', type: 'Vec<ElseIfBranch>', description: 'Elseif branches' },
+      { name: 'else_branch', type: 'Option<Stmt>', description: 'Else statement', optional: true }
+    ]
+  },
+  {
+    id: 'stmt-inline-html',
+    category: 'statement',
+    name: 'InlineHtml',
+    description: 'Inline HTML outside <?php ... ?>',
+    phpExample: `<?php echo $php; ?>\nThis is HTML`,
+    keywordInExample: 'InlineHtml',
+    fieldHighlights: {
+      html: ['This is HTML']
+    },
+    fields: [
+      { name: 'html', type: 'string', description: 'HTML content' }
     ]
   },
   {
@@ -244,38 +316,17 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'stmt-trait',
+    id: 'stmt-label',
     category: 'statement',
-    name: 'Trait',
-    description: 'Trait declaration',
-    phpExample: `<?php\ntrait Logger {\n  public function log($msg) { echo $msg; }\n}`,
-    keywordInExample: 'trait',
+    name: 'Label',
+    description: 'Label definition',
+    phpExample: `<?php\nloop:\necho $label;\ngoto loop;`,
+    keywordInExample: 'label',
     fieldHighlights: {
-      name: ['Logger'],
-      members: ['public function log']
+      name: ['loop']
     },
     fields: [
-      { name: 'name', type: 'Ident', description: 'Trait name' },
-      { name: 'members', type: 'Vec<ClassMember>', description: 'Methods' }
-    ]
-  },
-  {
-    id: 'stmt-enum',
-    category: 'statement',
-    name: 'Enum',
-    description: 'Enumeration declaration (PHP 8.1+)',
-    phpExample: `<?php\nenum Status: string {\n  case Active = STATUS_ACTIVE;\n  case Inactive = STATUS_INACTIVE;\n}`,
-    phpVersion: '8.1+',
-    keywordInExample: 'enum',
-    fieldHighlights: {
-      name: ['Status'],
-      scalar_type: ['string'],
-      members: ['case Active', 'case Inactive']
-    },
-    fields: [
-      { name: 'name', type: 'Ident', description: 'Enum name' },
-      { name: 'scalar_type', type: 'Option<Name>', description: 'Backing type (int or string)', optional: true },
-      { name: 'members', type: 'Vec<EnumMember>', description: 'Cases and methods' }
+      { name: 'name', type: 'string', description: 'Label name' }
     ]
   },
   {
@@ -295,33 +346,57 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'stmt-use',
+    id: 'stmt-nop',
     category: 'statement',
-    name: 'Use',
-    description: 'Use (import) statement',
-    phpExample: `<?php\nuse App\\Models\\User;\nuse function Helper\\debug;`,
-    keywordInExample: 'use',
+    name: 'Nop',
+    description: 'Empty statement (;)',
+    phpExample: `<?php\n;`,
+    keywordInExample: 'nop',
+    fields: []
+  },
+  {
+    id: 'stmt-return',
+    category: 'statement',
+    name: 'Return',
+    description: 'Return from a function or method',
+    phpExample: `<?php\nfunction add($a, $b) {\n  return $a + $b;\n}`,
+    keywordInExample: 'return',
     fieldHighlights: {
-      kind: ['use function'],
-      uses: ['App\\\\Models\\\\User', 'Helper\\\\debug']
+      keyword: ['return'],
+      value: ['$a + $b']
     },
     fields: [
-      { name: 'kind', type: 'UseKind', description: 'Type of use (Normal, Function, Const)' },
-      { name: 'uses', type: 'Vec<UseItem>', description: 'Imported items' }
+      { name: 'value', type: 'Option<Expr>', description: 'Return value', optional: true }
     ]
   },
   {
-    id: 'stmt-const',
+    id: 'stmt-static-var',
     category: 'statement',
-    name: 'Const',
-    description: 'Global constant declaration',
-    phpExample: `<?php\nconst MAX_SIZE = 100;\nconst DB_HOST = DB_DEFAULT_HOST;`,
-    keywordInExample: 'const',
+    name: 'StaticVar',
+    description: 'Static variable declaration',
+    phpExample: `<?php\nfunction counter() {\n  static $count = 0;\n  return ++$count;\n}`,
+    keywordInExample: 'static',
     fieldHighlights: {
-      items: ['MAX_SIZE = 100', 'DB_HOST = DB_DEFAULT_HOST']
+      vars: ['$count = 0']
     },
     fields: [
-      { name: 'items', type: 'Vec<ConstItem>', description: 'Constant declarations' }
+      { name: 'vars', type: 'Vec<StaticVar>', description: 'Static variables' }
+    ]
+  },
+  {
+    id: 'stmt-switch',
+    category: 'statement',
+    name: 'Switch',
+    description: 'Switch statement with cases and default',
+    phpExample: `<?php\nswitch ($x) {\n  case 1:\n    echo $x;\n    break;\n  default:\n    echo $default;\n}`,
+    keywordInExample: 'switch',
+    fieldHighlights: {
+      expr: ['$x'],
+      cases: ['case 1', 'default']
+    },
+    fields: [
+      { name: 'expr', type: 'Expr', description: 'Value to switch on' },
+      { name: 'cases', type: 'Vec<SwitchCase>', description: 'Switch cases' }
     ]
   },
   {
@@ -336,6 +411,22 @@ export const astNodes: AstNode[] = [
     },
     fields: [
       { name: 'exception', type: 'Expr', description: 'Exception to throw' }
+    ]
+  },
+  {
+    id: 'stmt-trait',
+    category: 'statement',
+    name: 'Trait',
+    description: 'Trait declaration',
+    phpExample: `<?php\ntrait Logger {\n  public function log($msg) { echo $msg; }\n}`,
+    keywordInExample: 'trait',
+    fieldHighlights: {
+      name: ['Logger'],
+      members: ['public function log']
+    },
+    fields: [
+      { name: 'name', type: 'Ident', description: 'Trait name' },
+      { name: 'members', type: 'Vec<ClassMember>', description: 'Methods' }
     ]
   },
   {
@@ -357,50 +448,6 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'stmt-global',
-    category: 'statement',
-    name: 'Global',
-    description: 'Declare global variables',
-    phpExample: `<?php\n$x = 1;\n\nfunction test() {\n  global $x;\n  $x = 2;\n}`,
-    keywordInExample: 'global',
-    fieldHighlights: {
-      vars: ['$x']
-    },
-    fields: [
-      { name: 'vars', type: 'Vec<Expr>', description: 'Variables to declare global' }
-    ]
-  },
-  {
-    id: 'stmt-static-var',
-    category: 'statement',
-    name: 'StaticVar',
-    description: 'Static variable declaration',
-    phpExample: `<?php\nfunction counter() {\n  static $count = 0;\n  return ++$count;\n}`,
-    keywordInExample: 'static',
-    fieldHighlights: {
-      vars: ['$count = 0']
-    },
-    fields: [
-      { name: 'vars', type: 'Vec<StaticVar>', description: 'Static variables' }
-    ]
-  },
-  {
-    id: 'stmt-declare',
-    category: 'statement',
-    name: 'Declare',
-    description: 'Declare directives like strict_types',
-    phpExample: `<?php\ndeclare(strict_types=1);\ndeclare(ticks=1) {}`,
-    keywordInExample: 'declare',
-    fieldHighlights: {
-      directives: ['strict_types=1', 'ticks=1'],
-      body: ['{}']
-    },
-    fields: [
-      { name: 'directives', type: 'Vec<(Name, Expr)>', description: 'Directives' },
-      { name: 'body', type: 'Option<Stmt>', description: 'Declare body', optional: true }
-    ]
-  },
-  {
     id: 'stmt-unset',
     category: 'statement',
     name: 'Unset',
@@ -415,238 +462,101 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'stmt-goto',
+    id: 'stmt-use',
     category: 'statement',
-    name: 'Goto',
-    description: 'Go to label',
-    phpExample: `<?php\ngoto end;\necho $skipped;\nend:\necho $done;`,
-    keywordInExample: 'goto',
+    name: 'Use',
+    description: 'Use (import) statement',
+    phpExample: `<?php\nuse App\\Models\\User;\nuse function Helper\\debug;`,
+    keywordInExample: 'use',
     fieldHighlights: {
-      label: ['end']
+      kind: ['use function'],
+      uses: ['App\\\\Models\\\\User', 'Helper\\\\debug']
     },
     fields: [
-      { name: 'label', type: 'Ident', description: 'Target label' }
+      { name: 'kind', type: 'UseKind', description: 'Type of use (Normal, Function, Const)' },
+      { name: 'uses', type: 'Vec<UseItem>', description: 'Imported items' }
     ]
   },
   {
-    id: 'stmt-label',
+    id: 'stmt-while',
     category: 'statement',
-    name: 'Label',
-    description: 'Label definition',
-    phpExample: `<?php\nloop:\necho $label;\ngoto loop;`,
-    keywordInExample: 'label',
+    name: 'While',
+    description: 'While loop',
+    phpExample: `<?php\nwhile ($x != 0) {\n  echo $x;\n  $x--;\n}`,
+    keywordInExample: 'while',
     fieldHighlights: {
-      name: ['loop']
+      condition: ['$x != 0'],
+      body: ['echo $x', '$x--']
     },
     fields: [
-      { name: 'name', type: 'string', description: 'Label name' }
+      { name: 'condition', type: 'Expr', description: 'Loop condition' },
+      { name: 'body', type: 'Stmt', description: 'Loop body' }
     ]
   },
-  {
-    id: 'stmt-block',
-    category: 'statement',
-    name: 'Block',
-    description: 'Block of statements',
-    phpExample: `<?php\n{\n  $x = 1;\n  echo $x;\n}`,
-    keywordInExample: 'block',
-    fieldHighlights: {
-      stmts: ['$x = 1', 'echo $x']
-    },
-    fields: [
-      { name: 'stmts', type: 'Vec<Stmt>', description: 'Statements in block' }
-    ]
-  },
-  {
-    id: 'stmt-nop',
-    category: 'statement',
-    name: 'Nop',
-    description: 'Empty statement (;)',
-    phpExample: `<?php\n;`,
-    keywordInExample: 'nop',
-    fields: []
-  },
-  {
-    id: 'stmt-halt-compiler',
-    category: 'statement',
-    name: 'HaltCompiler',
-    description: '__halt_compiler() — everything after is raw data ignored by PHP',
-    phpExample: `<?php\n__halt_compiler();\nThis data is ignored by PHP.`,
-    keywordInExample: '__halt_compiler',
-    fieldHighlights: {
-      data: ['This data is ignored by PHP.']
-    },
-    fields: [
-      { name: 'data', type: 'string', description: 'Raw data after __halt_compiler()' }
-    ]
-  },
-  {
-    id: 'stmt-inline-html',
-    category: 'statement',
-    name: 'InlineHtml',
-    description: 'Inline HTML outside <?php ... ?>',
-    phpExample: `<?php echo $php; ?>\nThis is HTML`,
-    keywordInExample: 'InlineHtml',
-    fieldHighlights: {
-      html: ['This is HTML']
-    },
-    fields: [
-      { name: 'html', type: 'string', description: 'HTML content' }
-    ]
-  },
-
   // ========== EXPRESSIONS ==========
   {
-    id: 'expr-variable',
+    id: 'expr-anonymous-class',
     category: 'expression',
-    name: 'Variable',
-    description: 'Variable reference',
-    phpExample: `<?php\n$name = $value;\necho $name;`,
-    keywordInExample: 'variable',
+    name: 'AnonymousClass',
+    description: 'Anonymous class instance (inline class definition)',
+    phpExample: `<?php\n$obj = new class extends Base implements Countable {\n  public function method() {}\n};`,
+    keywordInExample: 'class',
     fieldHighlights: {
-      name: ['$name', '$value']
+      class: ['extends Base implements Countable', 'public function method']
     },
     fields: [
-      { name: 'name', type: 'string', description: 'Variable name (without $)' }
+      { name: 'class', type: 'ClassDecl', description: 'Anonymous class declaration' }
     ]
   },
   {
-    id: 'expr-variable-variable',
+    id: 'expr-array',
     category: 'expression',
-    name: 'VariableVariable',
-    description: 'Variable variable (dynamic variable names)',
-    phpExample: `<?php\n$var = $hello;\n$$var = $world;\necho $hello;`,
-    keywordInExample: 'variable',
+    name: 'Array',
+    description: 'Array literal',
+    phpExample: `<?php\n[1, 2, 3];\n[$key => $val, $key2 => $val2];\n[...$items];`,
+    keywordInExample: 'array',
     fieldHighlights: {
-      expr: ['$var', '$$var']
+      elements: ['1', '2', '3', '$key => $val', '$key2 => $val2', '...$items']
     },
     fields: [
-      { name: 'expr', type: 'Expr', description: 'Expression to resolve to variable name' }
+      { name: 'elements', type: 'Vec<ArrayElement>', description: 'Array elements' }
     ]
   },
   {
-    id: 'expr-identifier',
+    id: 'expr-array-access',
     category: 'expression',
-    name: 'Identifier',
-    description: 'Bare name used as an expression (function name in a call, class name, etc.)',
-    phpExample: `<?php\nstrlen($str);\nMyClass::method();`,
-    keywordInExample: 'identifier',
+    name: 'ArrayAccess',
+    description: 'Array element access',
+    phpExample: `<?php\n$arr[0];\n$arr[$key];\n$arr[];`,
+    keywordInExample: 'access',
     fieldHighlights: {
-      name: ['strlen', 'MyClass']
+      array: ['$arr'],
+      index: ['0', '$key']
     },
     fields: [
-      { name: 'name', type: 'string', description: 'Identifier name' }
+      { name: 'array', type: 'Expr', description: 'Array expression' },
+      { name: 'index', type: 'Option<Expr>', description: 'Index (None for append)', optional: true }
     ]
   },
   {
-    id: 'expr-int',
+    id: 'expr-arrow-function',
     category: 'expression',
-    name: 'Int',
-    description: 'Integer literal',
-    phpExample: `<?php\n$x = 42;\n$hex = 0xFF;\n$bin = 0b1010;`,
-    keywordInExample: 'int',
+    name: 'ArrowFunction',
+    description: 'Arrow function (short closure, PHP 7.4+)',
+    phpExample: `<?php\n$square = fn($x) => $x * $x;\n$double = fn($n) => $n * 2;`,
+    phpVersion: '7.4+',
+    keywordInExample: 'arrow',
     fieldHighlights: {
-      value: ['42', '0xFF', '0b1010']
+      params: ['$x', '$n'],
+      body: ['$x * $x', '$n * 2']
     },
     fields: [
-      { name: 'value', type: 'i64', description: 'Integer value' }
+      { name: 'is_static', type: 'bool', description: 'Is static' },
+      { name: 'by_ref', type: 'bool', description: 'Returns by reference' },
+      { name: 'params', type: 'Vec<Param>', description: 'Parameters' },
+      { name: 'return_type', type: 'Option<TypeHint>', description: 'Return type', optional: true },
+      { name: 'body', type: 'Expr', description: 'Function body (expression)' }
     ]
-  },
-  {
-    id: 'expr-float',
-    category: 'expression',
-    name: 'Float',
-    description: 'Float literal',
-    phpExample: `<?php\n$pi = 3.14;\n$exp = 1.5e3;`,
-    keywordInExample: 'float',
-    fieldHighlights: {
-      value: ['3.14', '1.5e3']
-    },
-    fields: [
-      { name: 'value', type: 'f64', description: 'Float value' }
-    ]
-  },
-  {
-    id: 'expr-string',
-    category: 'expression',
-    name: 'String',
-    description: 'String literal',
-    phpExample: `<?php\n$str = $hello;\n$str2 = $world;`,
-    keywordInExample: 'string',
-    fieldHighlights: {
-      value: ['$str', '$str2']
-    },
-    fields: [
-      { name: 'value', type: 'string', description: 'String content' }
-    ]
-  },
-  {
-    id: 'expr-interpolated-string',
-    category: 'expression',
-    name: 'InterpolatedString',
-    description: 'Double-quoted string with variable interpolation',
-    phpExample: `<?php\n$name = $alice;\necho "Hello $name";\necho "Result: {$obj->prop}";`,
-    keywordInExample: 'interpolated',
-    fieldHighlights: {
-      parts: ['$name', '$obj->prop']
-    },
-    fields: [
-      { name: 'parts', type: 'Vec<StringPart>', description: 'String parts (literals and expressions)' }
-    ]
-  },
-  {
-    id: 'expr-heredoc',
-    category: 'expression',
-    name: 'Heredoc',
-    description: 'Heredoc string with interpolation',
-    phpExample: `<?php\n$name = $alice;\n$str = <<<EOT\nHello $name\nEOT;`,
-    keywordInExample: 'heredoc',
-    fieldHighlights: {
-      label: ['EOT'],
-      parts: ['$name']
-    },
-    fields: [
-      { name: 'label', type: 'string', description: 'Heredoc label' },
-      { name: 'parts', type: 'Vec<StringPart>', description: 'String parts' }
-    ]
-  },
-  {
-    id: 'expr-nowdoc',
-    category: 'expression',
-    name: 'Nowdoc',
-    description: 'Nowdoc string (no interpolation)',
-    phpExample: `<?php\n$str = <<<'EOT'\nLiteral $text\nEOT;`,
-    keywordInExample: 'nowdoc',
-    fieldHighlights: {
-      label: ['EOT'],
-      value: ['Literal $text']
-    },
-    fields: [
-      { name: 'label', type: 'string', description: 'Nowdoc label' },
-      { name: 'value', type: 'string', description: 'String content' }
-    ]
-  },
-  {
-    id: 'expr-bool',
-    category: 'expression',
-    name: 'Bool',
-    description: 'Boolean literal',
-    phpExample: `<?php\n$yes = true;\n$no = false;`,
-    keywordInExample: 'true',
-    fieldHighlights: {
-      value: ['true', 'false']
-    },
-    fields: [
-      { name: 'value', type: 'bool', description: 'Boolean value' }
-    ]
-  },
-  {
-    id: 'expr-null',
-    category: 'expression',
-    name: 'Null',
-    description: 'Null literal',
-    phpExample: `<?php\n$value = null;`,
-    keywordInExample: 'null',
-    fields: []
   },
   {
     id: 'expr-assign',
@@ -685,125 +595,32 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'expr-unary-prefix',
+    id: 'expr-bool',
     category: 'expression',
-    name: 'UnaryPrefix',
-    description: 'Prefix unary operation',
-    phpExample: `<?php\n$neg = -$x;\n$not = !$flag;\n$inc = ++$counter;`,
-    keywordInExample: 'unary',
+    name: 'Bool',
+    description: 'Boolean literal',
+    phpExample: `<?php\n$yes = true;\n$no = false;`,
+    keywordInExample: 'true',
     fieldHighlights: {
-      op: ['-$x', '!$flag', '++$counter'],
-      operand: ['$x', '$flag', '$counter']
+      value: ['true', 'false']
     },
     fields: [
-      { name: 'op', type: 'UnaryPrefixOp', description: 'Operator (-, !, ++, --)' },
-      { name: 'operand', type: 'Expr', description: 'Operand' }
+      { name: 'value', type: 'bool', description: 'Boolean value' }
     ]
   },
   {
-    id: 'expr-unary-postfix',
+    id: 'expr-callable-create',
     category: 'expression',
-    name: 'UnaryPostfix',
-    description: 'Postfix unary operation',
-    phpExample: `<?php\n$x++;\n$y--;`,
-    keywordInExample: 'postfix',
+    name: 'CallableCreate',
+    description: 'Callable creation expression (first-class callables)',
+    phpExample: `<?php\n$func = strlen(...);\n$method = $obj->method(...);\n$static = MyClass::staticMethod(...);`,
+    keywordInExample: 'callable',
     fieldHighlights: {
-      operand: ['$x', '$y'],
-      op: ['$x++', '$y--']
+      kind: ['strlen(...)', '$obj->method(...)', 'MyClass::staticMethod(...)']
     },
     fields: [
-      { name: 'operand', type: 'Expr', description: 'Operand' },
-      { name: 'op', type: 'UnaryPostfixOp', description: 'Operator (++, --)' }
+      { name: 'kind', type: 'CallableCreateKind', description: 'Type of callable (function, method, static)' }
     ]
-  },
-  {
-    id: 'expr-ternary',
-    category: 'expression',
-    name: 'Ternary',
-    description: 'Ternary conditional operator',
-    phpExample: `<?php\n$result = $x != 0 ? $positive : $nonPositive;\n$short = $x ?: $default;`,
-    keywordInExample: 'ternary',
-    fieldHighlights: {
-      condition: ['$x != 0', '$x'],
-      then_expr: ['$positive'],
-      else_expr: ['$nonPositive', '$default']
-    },
-    fields: [
-      { name: 'condition', type: 'Expr', description: 'Condition' },
-      { name: 'then_expr', type: 'Option<Expr>', description: 'Then expression', optional: true },
-      { name: 'else_expr', type: 'Expr', description: 'Else expression' }
-    ]
-  },
-  {
-    id: 'expr-null-coalesce',
-    category: 'expression',
-    name: 'NullCoalesce',
-    description: 'Null coalescing operator',
-    phpExample: `<?php\n$name = $var ?? $default;\n$value = $a ?? $b ?? $c;`,
-    keywordInExample: 'coalesce',
-    fieldHighlights: {
-      left: ['$var', '$a'],
-      right: ['$default', '$b ?? $c']
-    },
-    fields: [
-      { name: 'left', type: 'Expr', description: 'First expression' },
-      { name: 'right', type: 'Expr', description: 'Default expression' }
-    ]
-  },
-  {
-    id: 'expr-function-call',
-    category: 'expression',
-    name: 'FunctionCall',
-    description: 'Function call',
-    phpExample: `<?php\nstrlen($str);\narray_map(fn($x) => $x * 2, $arr);`,
-    keywordInExample: 'function',
-    fieldHighlights: {
-      name: ['strlen', 'array_map'],
-      args: ['$str', 'fn($x) => $x * 2', '$arr']
-    },
-    fields: [
-      { name: 'name', type: 'Expr', description: 'Function name' },
-      { name: 'args', type: 'Vec<Arg>', description: 'Arguments' }
-    ]
-  },
-  {
-    id: 'expr-array',
-    category: 'expression',
-    name: 'Array',
-    description: 'Array literal',
-    phpExample: `<?php\n[1, 2, 3];\n[$key => $val, $key2 => $val2];\n[...$items];`,
-    keywordInExample: 'array',
-    fieldHighlights: {
-      elements: ['1', '2', '3', '$key => $val', '$key2 => $val2', '...$items']
-    },
-    fields: [
-      { name: 'elements', type: 'Vec<ArrayElement>', description: 'Array elements' }
-    ]
-  },
-  {
-    id: 'expr-array-access',
-    category: 'expression',
-    name: 'ArrayAccess',
-    description: 'Array element access',
-    phpExample: `<?php\n$arr[0];\n$arr[$key];\n$arr[];`,
-    keywordInExample: 'access',
-    fieldHighlights: {
-      array: ['$arr'],
-      index: ['0', '$key']
-    },
-    fields: [
-      { name: 'array', type: 'Expr', description: 'Array expression' },
-      { name: 'index', type: 'Option<Expr>', description: 'Index (None for append)', optional: true }
-    ]
-  },
-  {
-    id: 'expr-omit',
-    category: 'expression',
-    name: 'Omit',
-    description: 'Omitted array element (skipped slot)',
-    phpExample: `<?php\n[$a, , $c];\nlist($x, , $z) = [1, 2, 3];`,
-    keywordInExample: 'omit',
-    fields: []
   },
   {
     id: 'expr-cast',
@@ -822,45 +639,35 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'expr-parenthesized',
+    id: 'expr-class-const',
     category: 'expression',
-    name: 'Parenthesized',
-    description: 'Expression wrapped in parentheses',
-    phpExample: `<?php\n$result = ($a + $b) * $c;\n$value = ($x);`,
-    keywordInExample: 'parens',
+    name: 'ClassConstAccess',
+    description: 'Class constant access',
+    phpExample: `<?php\nMyClass::VERSION;\nMyClass::MY_CONST;`,
+    keywordInExample: 'const',
     fieldHighlights: {
-      expr: ['$a + $b', '$x']
+      class: ['MyClass'],
+      constant: ['VERSION', 'MY_CONST']
     },
     fields: [
-      { name: 'expr', type: 'Expr', description: 'Wrapped expression' }
+      { name: 'class', type: 'Expr', description: 'Class name' },
+      { name: 'constant', type: 'Expr', description: 'Constant name' }
     ]
   },
   {
-    id: 'expr-isset',
+    id: 'expr-class-const-dyn',
     category: 'expression',
-    name: 'Isset',
-    description: 'Check if variables are set',
-    phpExample: `<?php\nisset($var);\nisset($arr[$key], $obj->prop);`,
-    keywordInExample: 'isset',
+    name: 'ClassConstAccessDynamic',
+    description: 'Dynamic class constant access (Foo::{expr})',
+    phpExample: `<?php\n$const = $version;\nFoo::{$const};`,
+    keywordInExample: 'const',
     fieldHighlights: {
-      vars: ['$var', '$arr[$key]', '$obj->prop']
+      class: ['Foo'],
+      member: ['$const']
     },
     fields: [
-      { name: 'vars', type: 'Vec<Expr>', description: 'Variables to check' }
-    ]
-  },
-  {
-    id: 'expr-empty',
-    category: 'expression',
-    name: 'Empty',
-    description: 'Check if variable is empty',
-    phpExample: `<?php\nempty($var);\nif (empty($str)) {}`,
-    keywordInExample: 'empty',
-    fieldHighlights: {
-      var: ['$var', '$str']
-    },
-    fields: [
-      { name: 'var', type: 'Expr', description: 'Variable to check' }
+      { name: 'class', type: 'Expr', description: 'Class name' },
+      { name: 'member', type: 'Expr', description: 'Dynamic member expression' }
     ]
   },
   {
@@ -895,66 +702,229 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'expr-new',
+    id: 'expr-closure',
     category: 'expression',
-    name: 'New',
-    description: 'Create new object instance',
-    phpExample: `<?php\nnew DateTime($now);\nnew MyClass($arg);`,
-    keywordInExample: 'new',
+    name: 'Closure',
+    description: 'Anonymous function (closure)',
+    phpExample: `<?php\n$add = function($a, $b) use ($multiplier) {\n  return ($a + $b) * $multiplier;\n};`,
+    keywordInExample: 'function',
     fieldHighlights: {
-      class: ['DateTime', 'MyClass'],
-      args: ['$now', '$arg']
+      params: ['$a', '$b'],
+      use_vars: ['$multiplier'],
+      body: ['return ($a + $b) * $multiplier']
     },
     fields: [
-      { name: 'class', type: 'Expr', description: 'Class name' },
-      { name: 'args', type: 'Vec<Arg>', description: 'Constructor arguments' }
+      { name: 'is_static', type: 'bool', description: 'Is static closure' },
+      { name: 'by_ref', type: 'bool', description: 'Returns by reference' },
+      { name: 'params', type: 'Vec<Param>', description: 'Parameters' },
+      { name: 'use_vars', type: 'Vec<ClosureUseVar>', description: 'Use variables' },
+      { name: 'return_type', type: 'Option<TypeHint>', description: 'Return type', optional: true },
+      { name: 'body', type: 'Vec<Stmt>', description: 'Function body' }
     ]
   },
   {
-    id: 'expr-anonymous-class',
+    id: 'expr-empty',
     category: 'expression',
-    name: 'AnonymousClass',
-    description: 'Anonymous class instance (inline class definition)',
-    phpExample: `<?php\n$obj = new class extends Base implements Countable {\n  public function method() {}\n};`,
-    keywordInExample: 'class',
+    name: 'Empty',
+    description: 'Check if variable is empty',
+    phpExample: `<?php\nempty($var);\nif (empty($str)) {}`,
+    keywordInExample: 'empty',
     fieldHighlights: {
-      class: ['extends Base implements Countable', 'public function method']
+      var: ['$var', '$str']
     },
     fields: [
-      { name: 'class', type: 'ClassDecl', description: 'Anonymous class declaration' }
+      { name: 'var', type: 'Expr', description: 'Variable to check' }
     ]
   },
   {
-    id: 'expr-property-access',
+    id: 'expr-error-suppress',
     category: 'expression',
-    name: 'PropertyAccess',
-    description: 'Object property access',
-    phpExample: `<?php\n$obj->name;\n$obj->count;`,
-    keywordInExample: 'property',
+    name: 'ErrorSuppress',
+    description: 'Error suppression operator (@)',
+    phpExample: `<?php\n@file_get_contents($path);\n@$arr[$key];`,
+    keywordInExample: 'suppress',
     fieldHighlights: {
-      object: ['$obj'],
-      property: ['name', 'count']
+      operand: ['file_get_contents($path)', '$arr[$key]']
     },
     fields: [
-      { name: 'object', type: 'Expr', description: 'Object' },
-      { name: 'property', type: 'Expr', description: 'Property name' }
+      { name: 'operand', type: 'Expr', description: 'Expression to suppress' }
     ]
   },
   {
-    id: 'expr-nullsafe-property',
+    id: 'expr-eval',
     category: 'expression',
-    name: 'NullsafePropertyAccess',
-    description: 'Nullsafe property access (PHP 8.0+)',
-    phpExample: `<?php\n$obj?->prop;\n$result = $user?->profile?->name;`,
+    name: 'Eval',
+    description: 'Evaluate PHP code',
+    phpExample: `<?php\neval($code);`,
+    keywordInExample: 'eval',
+    fieldHighlights: {
+      code: ['$code']
+    },
+    fields: [
+      { name: 'code', type: 'Expr', description: 'Code to evaluate' }
+    ]
+  },
+  {
+    id: 'expr-exit',
+    category: 'expression',
+    name: 'Exit',
+    description: 'Exit/die construct',
+    phpExample: `<?php\nexit($message);\ndie(1);`,
+    keywordInExample: 'exit',
+    fieldHighlights: {
+      value: ['$message', '1']
+    },
+    fields: [
+      { name: 'value', type: 'Option<Expr>', description: 'Exit code or message', optional: true }
+    ]
+  },
+  {
+    id: 'expr-float',
+    category: 'expression',
+    name: 'Float',
+    description: 'Float literal',
+    phpExample: `<?php\n$pi = 3.14;\n$exp = 1.5e3;`,
+    keywordInExample: 'float',
+    fieldHighlights: {
+      value: ['3.14', '1.5e3']
+    },
+    fields: [
+      { name: 'value', type: 'f64', description: 'Float value' }
+    ]
+  },
+  {
+    id: 'expr-function-call',
+    category: 'expression',
+    name: 'FunctionCall',
+    description: 'Function call',
+    phpExample: `<?php\nstrlen($str);\narray_map(fn($x) => $x * 2, $arr);`,
+    keywordInExample: 'function',
+    fieldHighlights: {
+      name: ['strlen', 'array_map'],
+      args: ['$str', 'fn($x) => $x * 2', '$arr']
+    },
+    fields: [
+      { name: 'name', type: 'Expr', description: 'Function name' },
+      { name: 'args', type: 'Vec<Arg>', description: 'Arguments' }
+    ]
+  },
+  {
+    id: 'expr-heredoc',
+    category: 'expression',
+    name: 'Heredoc',
+    description: 'Heredoc string with interpolation',
+    phpExample: `<?php\n$name = $alice;\n$str = <<<EOT\nHello $name\nEOT;`,
+    keywordInExample: 'heredoc',
+    fieldHighlights: {
+      label: ['EOT'],
+      parts: ['$name']
+    },
+    fields: [
+      { name: 'label', type: 'string', description: 'Heredoc label' },
+      { name: 'parts', type: 'Vec<StringPart>', description: 'String parts' }
+    ]
+  },
+  {
+    id: 'expr-identifier',
+    category: 'expression',
+    name: 'Identifier',
+    description: 'Bare name used as an expression (function name in a call, class name, etc.)',
+    phpExample: `<?php\nstrlen($str);\nMyClass::method();`,
+    keywordInExample: 'identifier',
+    fieldHighlights: {
+      name: ['strlen', 'MyClass']
+    },
+    fields: [
+      { name: 'name', type: 'string', description: 'Identifier name' }
+    ]
+  },
+  {
+    id: 'expr-include',
+    category: 'expression',
+    name: 'Include',
+    description: 'Include/require files',
+    phpExample: `<?php\ninclude $header;\nrequire_once $config;`,
+    keywordInExample: 'include',
+    fieldHighlights: {
+      kind: ['include', 'require_once'],
+      file: ['$header', '$config']
+    },
+    fields: [
+      { name: 'kind', type: 'IncludeKind', description: 'Include/require/once variant' },
+      { name: 'file', type: 'Expr', description: 'File path' }
+    ]
+  },
+  {
+    id: 'expr-int',
+    category: 'expression',
+    name: 'Int',
+    description: 'Integer literal',
+    phpExample: `<?php\n$x = 42;\n$hex = 0xFF;\n$bin = 0b1010;`,
+    keywordInExample: 'int',
+    fieldHighlights: {
+      value: ['42', '0xFF', '0b1010']
+    },
+    fields: [
+      { name: 'value', type: 'i64', description: 'Integer value' }
+    ]
+  },
+  {
+    id: 'expr-interpolated-string',
+    category: 'expression',
+    name: 'InterpolatedString',
+    description: 'Double-quoted string with variable interpolation',
+    phpExample: `<?php\n$name = $alice;\necho "Hello $name";\necho "Result: {$obj->prop}";`,
+    keywordInExample: 'interpolated',
+    fieldHighlights: {
+      parts: ['$name', '$obj->prop']
+    },
+    fields: [
+      { name: 'parts', type: 'Vec<StringPart>', description: 'String parts (literals and expressions)' }
+    ]
+  },
+  {
+    id: 'expr-isset',
+    category: 'expression',
+    name: 'Isset',
+    description: 'Check if variables are set',
+    phpExample: `<?php\nisset($var);\nisset($arr[$key], $obj->prop);`,
+    keywordInExample: 'isset',
+    fieldHighlights: {
+      vars: ['$var', '$arr[$key]', '$obj->prop']
+    },
+    fields: [
+      { name: 'vars', type: 'Vec<Expr>', description: 'Variables to check' }
+    ]
+  },
+  {
+    id: 'expr-magic-const',
+    category: 'expression',
+    name: 'MagicConst',
+    description: 'Magic constant (__LINE__, __FILE__, etc)',
+    phpExample: `<?php\necho __LINE__;\necho __FILE__;\necho __DIR__;`,
+    keywordInExample: 'magic',
+    fieldHighlights: {
+      kind: ['__LINE__', '__FILE__', '__DIR__']
+    },
+    fields: [
+      { name: 'kind', type: 'MagicConstKind', description: 'Magic constant type' }
+    ]
+  },
+  {
+    id: 'expr-match',
+    category: 'expression',
+    name: 'Match',
+    description: 'Match expression (PHP 8.0+)',
+    phpExample: `<?php\n$result = match($status) {\n  STATUS_ACTIVE => $running,\n  STATUS_PAUSED => $paused,\n  default => $unknown\n};`,
     phpVersion: '8.0+',
-    keywordInExample: 'property',
+    keywordInExample: 'match',
     fieldHighlights: {
-      object: ['$obj', '$user'],
-      property: ['prop', 'profile', 'name']
+      subject: ['$status'],
+      arms: ['STATUS_ACTIVE => $running', 'STATUS_PAUSED => $paused', 'default => $unknown']
     },
     fields: [
-      { name: 'object', type: 'Expr', description: 'Object' },
-      { name: 'property', type: 'Expr', description: 'Property name' }
+      { name: 'subject', type: 'Expr', description: 'Expression to match' },
+      { name: 'arms', type: 'Vec<MatchArm>', description: 'Match arms' }
     ]
   },
   {
@@ -976,6 +946,63 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
+    id: 'expr-new',
+    category: 'expression',
+    name: 'New',
+    description: 'Create new object instance',
+    phpExample: `<?php\nnew DateTime($now);\nnew MyClass($arg);`,
+    keywordInExample: 'new',
+    fieldHighlights: {
+      class: ['DateTime', 'MyClass'],
+      args: ['$now', '$arg']
+    },
+    fields: [
+      { name: 'class', type: 'Expr', description: 'Class name' },
+      { name: 'args', type: 'Vec<Arg>', description: 'Constructor arguments' }
+    ]
+  },
+  {
+    id: 'expr-nowdoc',
+    category: 'expression',
+    name: 'Nowdoc',
+    description: 'Nowdoc string (no interpolation)',
+    phpExample: `<?php\n$str = <<<'EOT'\nLiteral $text\nEOT;`,
+    keywordInExample: 'nowdoc',
+    fieldHighlights: {
+      label: ['EOT'],
+      value: ['Literal $text']
+    },
+    fields: [
+      { name: 'label', type: 'string', description: 'Nowdoc label' },
+      { name: 'value', type: 'string', description: 'String content' }
+    ]
+  },
+  {
+    id: 'expr-null',
+    category: 'expression',
+    name: 'Null',
+    description: 'Null literal',
+    phpExample: `<?php\n$value = null;`,
+    keywordInExample: 'null',
+    fields: []
+  },
+  {
+    id: 'expr-null-coalesce',
+    category: 'expression',
+    name: 'NullCoalesce',
+    description: 'Null coalescing operator',
+    phpExample: `<?php\n$name = $var ?? $default;\n$value = $a ?? $b ?? $c;`,
+    keywordInExample: 'coalesce',
+    fieldHighlights: {
+      left: ['$var', '$a'],
+      right: ['$default', '$b ?? $c']
+    },
+    fields: [
+      { name: 'left', type: 'Expr', description: 'First expression' },
+      { name: 'right', type: 'Expr', description: 'Default expression' }
+    ]
+  },
+  {
     id: 'expr-nullsafe-method',
     category: 'expression',
     name: 'NullsafeMethodCall',
@@ -990,6 +1017,126 @@ export const astNodes: AstNode[] = [
     },
     fields: [
       { name: 'object', type: 'Expr', description: 'Object' },
+      { name: 'method', type: 'Expr', description: 'Method name' },
+      { name: 'args', type: 'Vec<Arg>', description: 'Arguments' }
+    ]
+  },
+  {
+    id: 'expr-nullsafe-property',
+    category: 'expression',
+    name: 'NullsafePropertyAccess',
+    description: 'Nullsafe property access (PHP 8.0+)',
+    phpExample: `<?php\n$obj?->prop;\n$result = $user?->profile?->name;`,
+    phpVersion: '8.0+',
+    keywordInExample: 'property',
+    fieldHighlights: {
+      object: ['$obj', '$user'],
+      property: ['prop', 'profile', 'name']
+    },
+    fields: [
+      { name: 'object', type: 'Expr', description: 'Object' },
+      { name: 'property', type: 'Expr', description: 'Property name' }
+    ]
+  },
+  {
+    id: 'expr-omit',
+    category: 'expression',
+    name: 'Omit',
+    description: 'Omitted array element (skipped slot)',
+    phpExample: `<?php\n[$a, , $c];\nlist($x, , $z) = [1, 2, 3];`,
+    keywordInExample: 'omit',
+    fields: []
+  },
+  {
+    id: 'expr-parenthesized',
+    category: 'expression',
+    name: 'Parenthesized',
+    description: 'Expression wrapped in parentheses',
+    phpExample: `<?php\n$result = ($a + $b) * $c;\n$value = ($x);`,
+    keywordInExample: 'parens',
+    fieldHighlights: {
+      expr: ['$a + $b', '$x']
+    },
+    fields: [
+      { name: 'expr', type: 'Expr', description: 'Wrapped expression' }
+    ]
+  },
+  {
+    id: 'expr-print',
+    category: 'expression',
+    name: 'Print',
+    description: 'Print construct',
+    phpExample: `<?php\nprint $greeting;\nprint($name);`,
+    keywordInExample: 'print',
+    fieldHighlights: {
+      value: ['$greeting', '$name']
+    },
+    fields: [
+      { name: 'value', type: 'Expr', description: 'Value to print' }
+    ]
+  },
+  {
+    id: 'expr-property-access',
+    category: 'expression',
+    name: 'PropertyAccess',
+    description: 'Object property access',
+    phpExample: `<?php\n$obj->name;\n$obj->count;`,
+    keywordInExample: 'property',
+    fieldHighlights: {
+      object: ['$obj'],
+      property: ['name', 'count']
+    },
+    fields: [
+      { name: 'object', type: 'Expr', description: 'Object' },
+      { name: 'property', type: 'Expr', description: 'Property name' }
+    ]
+  },
+  {
+    id: 'expr-shell-exec',
+    category: 'expression',
+    name: 'ShellExec',
+    description: 'Shell execution (backticks)',
+    phpExample: `<?php\n$output = \`ls -la\`;\necho \`date\`;`,
+    keywordInExample: 'shell',
+    fieldHighlights: {
+      parts: ['ls -la', 'date']
+    },
+    fields: [
+      { name: 'parts', type: 'Vec<StringPart>', description: 'Command parts' }
+    ]
+  },
+  {
+    id: 'expr-static-dyn-method',
+    category: 'expression',
+    name: 'StaticDynMethodCall',
+    description: 'Dynamic static method call (Class::$method(args))',
+    phpExample: `<?php\nMyClass::$method($arg);`,
+    keywordInExample: 'static',
+    fieldHighlights: {
+      class: ['MyClass'],
+      method: ['$method'],
+      args: ['$arg']
+    },
+    fields: [
+      { name: 'class', type: 'Expr', description: 'Class name' },
+      { name: 'method', type: 'Expr', description: 'Dynamic method name (variable)' },
+      { name: 'args', type: 'Vec<Arg>', description: 'Arguments' }
+    ]
+  },
+  {
+    id: 'expr-static-method',
+    category: 'expression',
+    name: 'StaticMethodCall',
+    description: 'Static method call',
+    phpExample: `<?php\nMyClass::method($arg);\nMyClass::compute($x);`,
+    keywordInExample: 'static',
+    fieldHighlights: {
+      class: ['MyClass'],
+      method: ['method', 'compute'],
+      args: ['$arg', '$x']
+    },
+    fields: [
+      { name: 'class', type: 'Expr', description: 'Class name' },
       { name: 'method', type: 'Expr', description: 'Method name' },
       { name: 'args', type: 'Vec<Arg>', description: 'Arguments' }
     ]
@@ -1027,129 +1174,110 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'expr-static-method',
+    id: 'expr-string',
     category: 'expression',
-    name: 'StaticMethodCall',
-    description: 'Static method call',
-    phpExample: `<?php\nMyClass::method($arg);\nMyClass::compute($x);`,
-    keywordInExample: 'static',
+    name: 'String',
+    description: 'String literal',
+    phpExample: `<?php\n$str = $hello;\n$str2 = $world;`,
+    keywordInExample: 'string',
     fieldHighlights: {
-      class: ['MyClass'],
-      method: ['method', 'compute'],
-      args: ['$arg', '$x']
+      value: ['$str', '$str2']
     },
     fields: [
-      { name: 'class', type: 'Expr', description: 'Class name' },
-      { name: 'method', type: 'Expr', description: 'Method name' },
-      { name: 'args', type: 'Vec<Arg>', description: 'Arguments' }
+      { name: 'value', type: 'string', description: 'String content' }
     ]
   },
   {
-    id: 'expr-static-dyn-method',
+    id: 'expr-ternary',
     category: 'expression',
-    name: 'StaticDynMethodCall',
-    description: 'Dynamic static method call (Class::$method(args))',
-    phpExample: `<?php\nMyClass::$method($arg);`,
-    keywordInExample: 'static',
+    name: 'Ternary',
+    description: 'Ternary conditional operator',
+    phpExample: `<?php\n$result = $x != 0 ? $positive : $nonPositive;\n$short = $x ?: $default;`,
+    keywordInExample: 'ternary',
     fieldHighlights: {
-      class: ['MyClass'],
-      method: ['$method'],
-      args: ['$arg']
+      condition: ['$x != 0', '$x'],
+      then_expr: ['$positive'],
+      else_expr: ['$nonPositive', '$default']
     },
     fields: [
-      { name: 'class', type: 'Expr', description: 'Class name' },
-      { name: 'method', type: 'Expr', description: 'Dynamic method name (variable)' },
-      { name: 'args', type: 'Vec<Arg>', description: 'Arguments' }
+      { name: 'condition', type: 'Expr', description: 'Condition' },
+      { name: 'then_expr', type: 'Option<Expr>', description: 'Then expression', optional: true },
+      { name: 'else_expr', type: 'Expr', description: 'Else expression' }
     ]
   },
   {
-    id: 'expr-class-const',
+    id: 'expr-throw',
     category: 'expression',
-    name: 'ClassConstAccess',
-    description: 'Class constant access',
-    phpExample: `<?php\nMyClass::VERSION;\nMyClass::MY_CONST;`,
-    keywordInExample: 'const',
-    fieldHighlights: {
-      class: ['MyClass'],
-      constant: ['VERSION', 'MY_CONST']
-    },
-    fields: [
-      { name: 'class', type: 'Expr', description: 'Class name' },
-      { name: 'constant', type: 'Expr', description: 'Constant name' }
-    ]
-  },
-  {
-    id: 'expr-class-const-dyn',
-    category: 'expression',
-    name: 'ClassConstAccessDynamic',
-    description: 'Dynamic class constant access (Foo::{expr})',
-    phpExample: `<?php\n$const = $version;\nFoo::{$const};`,
-    keywordInExample: 'const',
-    fieldHighlights: {
-      class: ['Foo'],
-      member: ['$const']
-    },
-    fields: [
-      { name: 'class', type: 'Expr', description: 'Class name' },
-      { name: 'member', type: 'Expr', description: 'Dynamic member expression' }
-    ]
-  },
-  {
-    id: 'expr-closure',
-    category: 'expression',
-    name: 'Closure',
-    description: 'Anonymous function (closure)',
-    phpExample: `<?php\n$add = function($a, $b) use ($multiplier) {\n  return ($a + $b) * $multiplier;\n};`,
-    keywordInExample: 'function',
-    fieldHighlights: {
-      params: ['$a', '$b'],
-      use_vars: ['$multiplier'],
-      body: ['return ($a + $b) * $multiplier']
-    },
-    fields: [
-      { name: 'is_static', type: 'bool', description: 'Is static closure' },
-      { name: 'by_ref', type: 'bool', description: 'Returns by reference' },
-      { name: 'params', type: 'Vec<Param>', description: 'Parameters' },
-      { name: 'use_vars', type: 'Vec<ClosureUseVar>', description: 'Use variables' },
-      { name: 'return_type', type: 'Option<TypeHint>', description: 'Return type', optional: true },
-      { name: 'body', type: 'Vec<Stmt>', description: 'Function body' }
-    ]
-  },
-  {
-    id: 'expr-arrow-function',
-    category: 'expression',
-    name: 'ArrowFunction',
-    description: 'Arrow function (short closure, PHP 7.4+)',
-    phpExample: `<?php\n$square = fn($x) => $x * $x;\n$double = fn($n) => $n * 2;`,
-    phpVersion: '7.4+',
-    keywordInExample: 'arrow',
-    fieldHighlights: {
-      params: ['$x', '$n'],
-      body: ['$x * $x', '$n * 2']
-    },
-    fields: [
-      { name: 'is_static', type: 'bool', description: 'Is static' },
-      { name: 'by_ref', type: 'bool', description: 'Returns by reference' },
-      { name: 'params', type: 'Vec<Param>', description: 'Parameters' },
-      { name: 'return_type', type: 'Option<TypeHint>', description: 'Return type', optional: true },
-      { name: 'body', type: 'Expr', description: 'Function body (expression)' }
-    ]
-  },
-  {
-    id: 'expr-match',
-    category: 'expression',
-    name: 'Match',
-    description: 'Match expression (PHP 8.0+)',
-    phpExample: `<?php\n$result = match($status) {\n  STATUS_ACTIVE => $running,\n  STATUS_PAUSED => $paused,\n  default => $unknown\n};`,
+    name: 'ThrowExpr',
+    description: 'Throw expression (PHP 8.0+)',
+    phpExample: `<?php\n$x = $value ?? throw new InvalidArgumentException($msg);`,
     phpVersion: '8.0+',
-    keywordInExample: 'match',
+    keywordInExample: 'throw',
     fieldHighlights: {
-      subject: ['$status'],
-      arms: ['STATUS_ACTIVE => $running', 'STATUS_PAUSED => $paused', 'default => $unknown']
+      exception: ['new InvalidArgumentException($msg)']
     },
     fields: [
-      { name: 'subject', type: 'Expr', description: 'Expression to match' },
-      { name: 'arms', type: 'Vec<MatchArm>', description: 'Match arms' }
+      { name: 'exception', type: 'Expr', description: 'Exception to throw' }
+    ]
+  },
+  {
+    id: 'expr-unary-postfix',
+    category: 'expression',
+    name: 'UnaryPostfix',
+    description: 'Postfix unary operation',
+    phpExample: `<?php\n$x++;\n$y--;`,
+    keywordInExample: 'postfix',
+    fieldHighlights: {
+      operand: ['$x', '$y'],
+      op: ['$x++', '$y--']
+    },
+    fields: [
+      { name: 'operand', type: 'Expr', description: 'Operand' },
+      { name: 'op', type: 'UnaryPostfixOp', description: 'Operator (++, --)' }
+    ]
+  },
+  {
+    id: 'expr-unary-prefix',
+    category: 'expression',
+    name: 'UnaryPrefix',
+    description: 'Prefix unary operation',
+    phpExample: `<?php\n$neg = -$x;\n$not = !$flag;\n$inc = ++$counter;`,
+    keywordInExample: 'unary',
+    fieldHighlights: {
+      op: ['-$x', '!$flag', '++$counter'],
+      operand: ['$x', '$flag', '$counter']
+    },
+    fields: [
+      { name: 'op', type: 'UnaryPrefixOp', description: 'Operator (-, !, ++, --)' },
+      { name: 'operand', type: 'Expr', description: 'Operand' }
+    ]
+  },
+  {
+    id: 'expr-variable',
+    category: 'expression',
+    name: 'Variable',
+    description: 'Variable reference',
+    phpExample: `<?php\n$name = $value;\necho $name;`,
+    keywordInExample: 'variable',
+    fieldHighlights: {
+      name: ['$name', '$value']
+    },
+    fields: [
+      { name: 'name', type: 'string', description: 'Variable name (without $)' }
+    ]
+  },
+  {
+    id: 'expr-variable-variable',
+    category: 'expression',
+    name: 'VariableVariable',
+    description: 'Variable variable (dynamic variable names)',
+    phpExample: `<?php\n$var = $hello;\n$$var = $world;\necho $hello;`,
+    keywordInExample: 'variable',
+    fieldHighlights: {
+      expr: ['$var', '$$var']
+    },
+    fields: [
+      { name: 'expr', type: 'Expr', description: 'Expression to resolve to variable name' }
     ]
   },
   {
@@ -1170,137 +1298,70 @@ export const astNodes: AstNode[] = [
       { name: 'is_from', type: 'bool', description: 'Is yield from' }
     ]
   },
-  {
-    id: 'expr-callable-create',
-    category: 'expression',
-    name: 'CallableCreate',
-    description: 'Callable creation expression (first-class callables)',
-    phpExample: `<?php\n$func = strlen(...);\n$method = $obj->method(...);\n$static = MyClass::staticMethod(...);`,
-    keywordInExample: 'callable',
-    fieldHighlights: {
-      kind: ['strlen(...)', '$obj->method(...)', 'MyClass::staticMethod(...)']
-    },
-    fields: [
-      { name: 'kind', type: 'CallableCreateKind', description: 'Type of callable (function, method, static)' }
-    ]
-  },
-  {
-    id: 'expr-throw',
-    category: 'expression',
-    name: 'ThrowExpr',
-    description: 'Throw expression (PHP 8.0+)',
-    phpExample: `<?php\n$x = $value ?? throw new InvalidArgumentException($msg);`,
-    phpVersion: '8.0+',
-    keywordInExample: 'throw',
-    fieldHighlights: {
-      exception: ['new InvalidArgumentException($msg)']
-    },
-    fields: [
-      { name: 'exception', type: 'Expr', description: 'Exception to throw' }
-    ]
-  },
-  {
-    id: 'expr-print',
-    category: 'expression',
-    name: 'Print',
-    description: 'Print construct',
-    phpExample: `<?php\nprint $greeting;\nprint($name);`,
-    keywordInExample: 'print',
-    fieldHighlights: {
-      value: ['$greeting', '$name']
-    },
-    fields: [
-      { name: 'value', type: 'Expr', description: 'Value to print' }
-    ]
-  },
-  {
-    id: 'expr-error-suppress',
-    category: 'expression',
-    name: 'ErrorSuppress',
-    description: 'Error suppression operator (@)',
-    phpExample: `<?php\n@file_get_contents($path);\n@$arr[$key];`,
-    keywordInExample: 'suppress',
-    fieldHighlights: {
-      operand: ['file_get_contents($path)', '$arr[$key]']
-    },
-    fields: [
-      { name: 'operand', type: 'Expr', description: 'Expression to suppress' }
-    ]
-  },
-  {
-    id: 'expr-include',
-    category: 'expression',
-    name: 'Include',
-    description: 'Include/require files',
-    phpExample: `<?php\ninclude $header;\nrequire_once $config;`,
-    keywordInExample: 'include',
-    fieldHighlights: {
-      kind: ['include', 'require_once'],
-      file: ['$header', '$config']
-    },
-    fields: [
-      { name: 'kind', type: 'IncludeKind', description: 'Include/require/once variant' },
-      { name: 'file', type: 'Expr', description: 'File path' }
-    ]
-  },
-  {
-    id: 'expr-eval',
-    category: 'expression',
-    name: 'Eval',
-    description: 'Evaluate PHP code',
-    phpExample: `<?php\neval($code);`,
-    keywordInExample: 'eval',
-    fieldHighlights: {
-      code: ['$code']
-    },
-    fields: [
-      { name: 'code', type: 'Expr', description: 'Code to evaluate' }
-    ]
-  },
-  {
-    id: 'expr-exit',
-    category: 'expression',
-    name: 'Exit',
-    description: 'Exit/die construct',
-    phpExample: `<?php\nexit($message);\ndie(1);`,
-    keywordInExample: 'exit',
-    fieldHighlights: {
-      value: ['$message', '1']
-    },
-    fields: [
-      { name: 'value', type: 'Option<Expr>', description: 'Exit code or message', optional: true }
-    ]
-  },
-  {
-    id: 'expr-magic-const',
-    category: 'expression',
-    name: 'MagicConst',
-    description: 'Magic constant (__LINE__, __FILE__, etc)',
-    phpExample: `<?php\necho __LINE__;\necho __FILE__;\necho __DIR__;`,
-    keywordInExample: 'magic',
-    fieldHighlights: {
-      kind: ['__LINE__', '__FILE__', '__DIR__']
-    },
-    fields: [
-      { name: 'kind', type: 'MagicConstKind', description: 'Magic constant type' }
-    ]
-  },
-  {
-    id: 'expr-shell-exec',
-    category: 'expression',
-    name: 'ShellExec',
-    description: 'Shell execution (backticks)',
-    phpExample: `<?php\n$output = \`ls -la\`;\necho \`date\`;`,
-    keywordInExample: 'shell',
-    fieldHighlights: {
-      parts: ['ls -la', 'date']
-    },
-    fields: [
-      { name: 'parts', type: 'Vec<StringPart>', description: 'Command parts' }
-    ]
-  },
-
   // ========== DECLARATIONS ==========
+  {
+    id: 'decl-class-const',
+    category: 'declaration',
+    name: 'ClassConstDecl',
+    description: 'Class constant',
+    phpExample: `<?php\nconst VERSION = 1;\nfinal protected const DEFAULT_VAL = 0;`,
+    keywordInExample: 'const',
+    fieldHighlights: {
+      name: ['VERSION', 'DEFAULT_VAL'],
+      visibility: ['protected'],
+      is_final: ['final'],
+      value: ['1', '0']
+    },
+    fields: [
+      { name: 'name', type: 'Ident', description: 'Constant name' },
+      { name: 'visibility', type: 'Option<Visibility>', description: 'Visibility', optional: true },
+      { name: 'is_final', type: 'bool', description: 'Is final' },
+      { name: 'type_hint', type: 'Option<TypeHint>', description: 'Type hint', optional: true },
+      { name: 'value', type: 'Expr', description: 'Constant value' }
+    ]
+  },
+  {
+    id: 'decl-enum-case',
+    category: 'declaration',
+    name: 'EnumCase',
+    description: 'Enum case',
+    phpExample: `<?php\nenum Color {\n  case Red;\n  case Green = GREEN_VALUE;\n}`,
+    keywordInExample: 'case',
+    fieldHighlights: {
+      name: ['Red', 'Green'],
+      value: ['GREEN_VALUE']
+    },
+    fields: [
+      { name: 'name', type: 'Ident', description: 'Case name' },
+      { name: 'value', type: 'Option<Expr>', description: 'Case value (backed enums)', optional: true }
+    ]
+  },
+  {
+    id: 'decl-method',
+    category: 'declaration',
+    name: 'MethodDecl',
+    description: 'Class method',
+    phpExample: `<?php\npublic function getValue(): string { return $value; }\nabstract protected function validate();`,
+    keywordInExample: 'method',
+    fieldHighlights: {
+      name: ['getValue', 'validate'],
+      visibility: ['public', 'protected'],
+      is_abstract: ['abstract'],
+      params: [],
+      return_type: ['string'],
+      body: ['return $value']
+    },
+    fields: [
+      { name: 'name', type: 'Ident', description: 'Method name' },
+      { name: 'visibility', type: 'Option<Visibility>', description: 'Visibility', optional: true },
+      { name: 'is_static', type: 'bool', description: 'Is static' },
+      { name: 'is_abstract', type: 'bool', description: 'Is abstract' },
+      { name: 'is_final', type: 'bool', description: 'Is final' },
+      { name: 'params', type: 'Vec<Param>', description: 'Parameters' },
+      { name: 'return_type', type: 'Option<TypeHint>', description: 'Return type', optional: true },
+      { name: 'body', type: 'Option<Vec<Stmt>>', description: 'Method body', optional: true }
+    ]
+  },
   {
     id: 'decl-param',
     category: 'declaration',
@@ -1347,32 +1408,6 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'decl-method',
-    category: 'declaration',
-    name: 'MethodDecl',
-    description: 'Class method',
-    phpExample: `<?php\npublic function getValue(): string { return $value; }\nabstract protected function validate();`,
-    keywordInExample: 'method',
-    fieldHighlights: {
-      name: ['getValue', 'validate'],
-      visibility: ['public', 'protected'],
-      is_abstract: ['abstract'],
-      params: [],
-      return_type: ['string'],
-      body: ['return $value']
-    },
-    fields: [
-      { name: 'name', type: 'Ident', description: 'Method name' },
-      { name: 'visibility', type: 'Option<Visibility>', description: 'Visibility', optional: true },
-      { name: 'is_static', type: 'bool', description: 'Is static' },
-      { name: 'is_abstract', type: 'bool', description: 'Is abstract' },
-      { name: 'is_final', type: 'bool', description: 'Is final' },
-      { name: 'params', type: 'Vec<Param>', description: 'Parameters' },
-      { name: 'return_type', type: 'Option<TypeHint>', description: 'Return type', optional: true },
-      { name: 'body', type: 'Option<Vec<Stmt>>', description: 'Method body', optional: true }
-    ]
-  },
-  {
     id: 'decl-property-hook',
     category: 'declaration',
     name: 'PropertyHook',
@@ -1393,72 +1428,19 @@ export const astNodes: AstNode[] = [
       { name: 'params', type: 'Vec<Param>', description: 'Parameters (set only)' }
     ]
   },
-  {
-    id: 'decl-class-const',
-    category: 'declaration',
-    name: 'ClassConstDecl',
-    description: 'Class constant',
-    phpExample: `<?php\nconst VERSION = 1;\nfinal protected const DEFAULT_VAL = 0;`,
-    keywordInExample: 'const',
-    fieldHighlights: {
-      name: ['VERSION', 'DEFAULT_VAL'],
-      visibility: ['protected'],
-      is_final: ['final'],
-      value: ['1', '0']
-    },
-    fields: [
-      { name: 'name', type: 'Ident', description: 'Constant name' },
-      { name: 'visibility', type: 'Option<Visibility>', description: 'Visibility', optional: true },
-      { name: 'is_final', type: 'bool', description: 'Is final' },
-      { name: 'type_hint', type: 'Option<TypeHint>', description: 'Type hint', optional: true },
-      { name: 'value', type: 'Expr', description: 'Constant value' }
-    ]
-  },
-  {
-    id: 'decl-enum-case',
-    category: 'declaration',
-    name: 'EnumCase',
-    description: 'Enum case',
-    phpExample: `<?php\nenum Color {\n  case Red;\n  case Green = GREEN_VALUE;\n}`,
-    keywordInExample: 'case',
-    fieldHighlights: {
-      name: ['Red', 'Green'],
-      value: ['GREEN_VALUE']
-    },
-    fields: [
-      { name: 'name', type: 'Ident', description: 'Case name' },
-      { name: 'value', type: 'Option<Expr>', description: 'Case value (backed enums)', optional: true }
-    ]
-  },
-
   // ========== TYPES ==========
   {
-    id: 'type-nullable',
+    id: 'type-builtin',
     category: 'type',
-    name: 'Nullable',
-    description: 'Nullable type (?T)',
-    phpExample: `<?php\nfunction getName(): ?string { return null; }`,
-    keywordInExample: 'nullable',
+    name: 'BuiltinType',
+    description: 'Built-in type keyword',
+    phpExample: `<?php\nfunction test(int $x, array $arr, mixed $value): string { }`,
+    keywordInExample: 'builtin',
     fieldHighlights: {
-      type: ['?string']
+      type: ['int', 'array', 'mixed', 'string']
     },
     fields: [
-      { name: 'type', type: 'TypeHint', description: 'Wrapped type' }
-    ]
-  },
-  {
-    id: 'type-union',
-    category: 'type',
-    name: 'Union',
-    description: 'Union type (A|B, PHP 8.0+)',
-    phpExample: `<?php\nfunction getValue(): int|string|null { }`,
-    phpVersion: '8.0+',
-    keywordInExample: 'union',
-    fieldHighlights: {
-      types: ['int|string|null']
-    },
-    fields: [
-      { name: 'types', type: 'Vec<TypeHint>', description: 'Union member types' }
+      { name: 'type', type: 'string', description: 'Type keyword (int, string, mixed, etc)' }
     ]
   },
   {
@@ -1491,20 +1473,34 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'type-builtin',
+    id: 'type-nullable',
     category: 'type',
-    name: 'BuiltinType',
-    description: 'Built-in type keyword',
-    phpExample: `<?php\nfunction test(int $x, array $arr, mixed $value): string { }`,
-    keywordInExample: 'builtin',
+    name: 'Nullable',
+    description: 'Nullable type (?T)',
+    phpExample: `<?php\nfunction getName(): ?string { return null; }`,
+    keywordInExample: 'nullable',
     fieldHighlights: {
-      type: ['int', 'array', 'mixed', 'string']
+      type: ['?string']
     },
     fields: [
-      { name: 'type', type: 'string', description: 'Type keyword (int, string, mixed, etc)' }
+      { name: 'type', type: 'TypeHint', description: 'Wrapped type' }
     ]
   },
-
+  {
+    id: 'type-union',
+    category: 'type',
+    name: 'Union',
+    description: 'Union type (A|B, PHP 8.0+)',
+    phpExample: `<?php\nfunction getValue(): int|string|null { }`,
+    phpVersion: '8.0+',
+    keywordInExample: 'union',
+    fieldHighlights: {
+      types: ['int|string|null']
+    },
+    fields: [
+      { name: 'types', type: 'Vec<TypeHint>', description: 'Union member types' }
+    ]
+  },
   // ========== HELPERS ==========
   {
     id: 'helper-arg',
@@ -1526,6 +1522,25 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
+    id: 'helper-array-element',
+    category: 'helper',
+    name: 'ArrayElement',
+    description: 'A single element in an array literal',
+    phpExample: `<?php\n[$val, $key => $val2, ...$spread];`,
+    keywordInExample: 'element',
+    fieldHighlights: {
+      key: ['$key'],
+      value: ['$val', '$val2', '$spread'],
+      unpack: ['...$spread']
+    },
+    fields: [
+      { name: 'key', type: 'Option<Expr>', description: 'Array key', optional: true },
+      { name: 'value', type: 'Expr', description: 'Array value' },
+      { name: 'unpack', type: 'bool', description: 'Spread element (...)' },
+      { name: 'by_ref', type: 'bool', description: 'By reference' }
+    ]
+  },
+  {
     id: 'helper-attribute',
     category: 'helper',
     name: 'Attribute',
@@ -1542,19 +1557,85 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'helper-span',
+    id: 'helper-catch-clause',
     category: 'helper',
-    name: 'Span',
-    description: 'Source code location (start and end byte offsets)',
-    phpExample: `<?php\n// Every AST node has a Span indicating where in the source it appears`,
-    keywordInExample: 'span',
+    name: 'CatchClause',
+    description: 'A single catch in try-catch',
+    phpExample: `<?php\ntry {\n  throw new RuntimeException();\n} catch (RuntimeException $e) {\n  echo $e;\n}`,
+    keywordInExample: 'catch',
     fieldHighlights: {
-      start: ['start'],
-      end: ['end']
+      types: ['RuntimeException'],
+      var: ['$e'],
+      body: ['echo $e']
     },
     fields: [
-      { name: 'start', type: 'u32', description: 'Start byte offset' },
-      { name: 'end', type: 'u32', description: 'End byte offset' }
+      { name: 'types', type: 'Vec<Name>', description: 'Caught exception types' },
+      { name: 'var', type: 'Option<string>', description: 'Catch variable name', optional: true },
+      { name: 'body', type: 'Vec<Stmt>', description: 'Catch block' }
+    ]
+  },
+  {
+    id: 'helper-closure-use-var',
+    category: 'helper',
+    name: 'ClosureUseVar',
+    description: 'A variable captured by a closure',
+    phpExample: `<?php\n$multiplier = 3;\n$fn = function($x) use ($multiplier) {\n  return $x * $multiplier;\n};`,
+    keywordInExample: 'use',
+    fieldHighlights: {
+      name: ['$multiplier']
+    },
+    fields: [
+      { name: 'name', type: 'string', description: 'Variable name' },
+      { name: 'by_ref', type: 'bool', description: 'Captured by reference' }
+    ]
+  },
+  {
+    id: 'helper-const-item',
+    category: 'helper',
+    name: 'ConstItem',
+    description: 'A single constant in a const statement',
+    phpExample: `<?php\nconst MAX_SIZE = 100;\nconst DB_HOST = DB_DEFAULT_HOST;`,
+    keywordInExample: 'const',
+    fieldHighlights: {
+      name: ['MAX_SIZE', 'DB_HOST'],
+      value: ['100', 'DB_DEFAULT_HOST']
+    },
+    fields: [
+      { name: 'name', type: 'Ident', description: 'Constant name' },
+      { name: 'value', type: 'Expr', description: 'Constant value' },
+      { name: 'attributes', type: 'Vec<Attribute>', description: 'Attributes' }
+    ]
+  },
+  {
+    id: 'helper-elseif-branch',
+    category: 'helper',
+    name: 'ElseIfBranch',
+    description: 'A single elseif branch in an if statement',
+    phpExample: `<?php\nif ($x == 1) {\n  echo $x;\n} elseif ($x == 2) {\n  echo 0;\n}`,
+    keywordInExample: 'elseif',
+    fieldHighlights: {
+      condition: ['$x == 2'],
+      body: ['echo 0']
+    },
+    fields: [
+      { name: 'condition', type: 'Expr', description: 'Branch condition' },
+      { name: 'body', type: 'Stmt', description: 'Branch body' }
+    ]
+  },
+  {
+    id: 'helper-match-arm',
+    category: 'helper',
+    name: 'MatchArm',
+    description: 'A single arm in a match expression',
+    phpExample: `<?php\nmatch($x) {\n  1, 2 => $small,\n  default => $other\n};`,
+    keywordInExample: 'arm',
+    fieldHighlights: {
+      conditions: ['1', '2'],
+      body: ['$small', '$other']
+    },
+    fields: [
+      { name: 'conditions', type: 'Option<Vec<Expr>>', description: 'Match conditions (None = default)', optional: true },
+      { name: 'body', type: 'Expr', description: 'Arm body expression' }
     ]
   },
   {
@@ -1588,87 +1669,19 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'helper-elseif-branch',
+    id: 'helper-span',
     category: 'helper',
-    name: 'ElseIfBranch',
-    description: 'A single elseif branch in an if statement',
-    phpExample: `<?php\nif ($x == 1) {\n  echo $x;\n} elseif ($x == 2) {\n  echo 0;\n}`,
-    keywordInExample: 'elseif',
+    name: 'Span',
+    description: 'Source code location (start and end byte offsets)',
+    phpExample: `<?php\n// Every AST node has a Span indicating where in the source it appears`,
+    keywordInExample: 'span',
     fieldHighlights: {
-      condition: ['$x == 2'],
-      body: ['echo 0']
+      start: ['start'],
+      end: ['end']
     },
     fields: [
-      { name: 'condition', type: 'Expr', description: 'Branch condition' },
-      { name: 'body', type: 'Stmt', description: 'Branch body' }
-    ]
-  },
-  {
-    id: 'helper-switch-case',
-    category: 'helper',
-    name: 'SwitchCase',
-    description: 'A single case in a switch statement',
-    phpExample: `<?php\nswitch ($x) {\n  case 1:\n    echo $x;\n    break;\n  default:\n    break;\n}`,
-    keywordInExample: 'case',
-    fieldHighlights: {
-      value: ['1'],
-      body: ['echo $x', 'break']
-    },
-    fields: [
-      { name: 'value', type: 'Option<Expr>', description: 'Case value (None = default)', optional: true },
-      { name: 'body', type: 'Vec<Stmt>', description: 'Case body' }
-    ]
-  },
-  {
-    id: 'helper-catch-clause',
-    category: 'helper',
-    name: 'CatchClause',
-    description: 'A single catch in try-catch',
-    phpExample: `<?php\ntry {\n  throw new RuntimeException();\n} catch (RuntimeException $e) {\n  echo $e;\n}`,
-    keywordInExample: 'catch',
-    fieldHighlights: {
-      types: ['RuntimeException'],
-      var: ['$e'],
-      body: ['echo $e']
-    },
-    fields: [
-      { name: 'types', type: 'Vec<Name>', description: 'Caught exception types' },
-      { name: 'var', type: 'Option<string>', description: 'Catch variable name', optional: true },
-      { name: 'body', type: 'Vec<Stmt>', description: 'Catch block' }
-    ]
-  },
-  {
-    id: 'helper-use-item',
-    category: 'helper',
-    name: 'UseItem',
-    description: 'A single imported name in a use statement',
-    phpExample: `<?php\nuse App\\Models\\User;\nuse App\\Http\\Controller as Ctrl;`,
-    keywordInExample: 'use',
-    fieldHighlights: {
-      name: ['App\\\\Models\\\\User', 'App\\\\Http\\\\Controller'],
-      alias: ['Ctrl']
-    },
-    fields: [
-      { name: 'name', type: 'Name', description: 'Imported name' },
-      { name: 'alias', type: 'Option<string>', description: 'Alias name', optional: true },
-      { name: 'kind', type: 'Option<UseKind>', description: 'Override kind for group use', optional: true }
-    ]
-  },
-  {
-    id: 'helper-const-item',
-    category: 'helper',
-    name: 'ConstItem',
-    description: 'A single constant in a const statement',
-    phpExample: `<?php\nconst MAX_SIZE = 100;\nconst DB_HOST = DB_DEFAULT_HOST;`,
-    keywordInExample: 'const',
-    fieldHighlights: {
-      name: ['MAX_SIZE', 'DB_HOST'],
-      value: ['100', 'DB_DEFAULT_HOST']
-    },
-    fields: [
-      { name: 'name', type: 'Ident', description: 'Constant name' },
-      { name: 'value', type: 'Expr', description: 'Constant value' },
-      { name: 'attributes', type: 'Vec<Attribute>', description: 'Attributes' }
+      { name: 'start', type: 'u32', description: 'Start byte offset' },
+      { name: 'end', type: 'u32', description: 'End byte offset' }
     ]
   },
   {
@@ -1688,53 +1701,33 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'helper-closure-use-var',
+    id: 'helper-string-part',
     category: 'helper',
-    name: 'ClosureUseVar',
-    description: 'A variable captured by a closure',
-    phpExample: `<?php\n$multiplier = 3;\n$fn = function($x) use ($multiplier) {\n  return $x * $multiplier;\n};`,
-    keywordInExample: 'use',
+    name: 'StringPart',
+    description: 'A part of an interpolated string (literal text or embedded expression)',
+    phpExample: `<?php\n$name = $alice;\necho "Hello $name, you are {$age} old";`,
+    keywordInExample: 'part',
     fieldHighlights: {
-      name: ['$multiplier']
+      kind: ['Hello ', '$name', '$age', ' old']
     },
     fields: [
-      { name: 'name', type: 'string', description: 'Variable name' },
-      { name: 'by_ref', type: 'bool', description: 'Captured by reference' }
+      { name: 'kind', type: 'Literal | Expr', description: 'Literal text or embedded expression' }
     ]
   },
   {
-    id: 'helper-array-element',
+    id: 'helper-switch-case',
     category: 'helper',
-    name: 'ArrayElement',
-    description: 'A single element in an array literal',
-    phpExample: `<?php\n[$val, $key => $val2, ...$spread];`,
-    keywordInExample: 'element',
+    name: 'SwitchCase',
+    description: 'A single case in a switch statement',
+    phpExample: `<?php\nswitch ($x) {\n  case 1:\n    echo $x;\n    break;\n  default:\n    break;\n}`,
+    keywordInExample: 'case',
     fieldHighlights: {
-      key: ['$key'],
-      value: ['$val', '$val2', '$spread'],
-      unpack: ['...$spread']
+      value: ['1'],
+      body: ['echo $x', 'break']
     },
     fields: [
-      { name: 'key', type: 'Option<Expr>', description: 'Array key', optional: true },
-      { name: 'value', type: 'Expr', description: 'Array value' },
-      { name: 'unpack', type: 'bool', description: 'Spread element (...)' },
-      { name: 'by_ref', type: 'bool', description: 'By reference' }
-    ]
-  },
-  {
-    id: 'helper-match-arm',
-    category: 'helper',
-    name: 'MatchArm',
-    description: 'A single arm in a match expression',
-    phpExample: `<?php\nmatch($x) {\n  1, 2 => $small,\n  default => $other\n};`,
-    keywordInExample: 'arm',
-    fieldHighlights: {
-      conditions: ['1', '2'],
-      body: ['$small', '$other']
-    },
-    fields: [
-      { name: 'conditions', type: 'Option<Vec<Expr>>', description: 'Match conditions (None = default)', optional: true },
-      { name: 'body', type: 'Expr', description: 'Arm body expression' }
+      { name: 'value', type: 'Option<Expr>', description: 'Case value (None = default)', optional: true },
+      { name: 'body', type: 'Vec<Stmt>', description: 'Case body' }
     ]
   },
   {
@@ -1754,17 +1747,20 @@ export const astNodes: AstNode[] = [
     ]
   },
   {
-    id: 'helper-string-part',
+    id: 'helper-use-item',
     category: 'helper',
-    name: 'StringPart',
-    description: 'A part of an interpolated string (literal text or embedded expression)',
-    phpExample: `<?php\n$name = $alice;\necho "Hello $name, you are {$age} old";`,
-    keywordInExample: 'part',
+    name: 'UseItem',
+    description: 'A single imported name in a use statement',
+    phpExample: `<?php\nuse App\\Models\\User;\nuse App\\Http\\Controller as Ctrl;`,
+    keywordInExample: 'use',
     fieldHighlights: {
-      kind: ['Hello ', '$name', '$age', ' old']
+      name: ['App\\\\Models\\\\User', 'App\\\\Http\\\\Controller'],
+      alias: ['Ctrl']
     },
     fields: [
-      { name: 'kind', type: 'Literal | Expr', description: 'Literal text or embedded expression' }
+      { name: 'name', type: 'Name', description: 'Imported name' },
+      { name: 'alias', type: 'Option<string>', description: 'Alias name', optional: true },
+      { name: 'kind', type: 'Option<UseKind>', description: 'Override kind for group use', optional: true }
     ]
-  }
+  },
 ]

--- a/playground/src/styles/index.css
+++ b/playground/src/styles/index.css
@@ -130,6 +130,7 @@ body::after {
   cursor: pointer;
   transition: color 0.15s, background 0.15s;
   border-radius: var(--radius);
+  text-decoration: none;
 }
 
 .nav-tab:hover {
@@ -257,6 +258,12 @@ body::after {
 }
 
 .editor-wrap .cm-editor { height: 100%; }
+
+.cm-highlight-span {
+  background: rgba(232, 148, 58, 0.3);
+  box-shadow: inset 0 0 0 1px rgba(232, 148, 58, 0.4);
+  border-radius: 2px;
+}
 
 /* ── Output panels ──────────────────────────────────────────────────────── */
 .panel {

--- a/playground/src/styles/index.css
+++ b/playground/src/styles/index.css
@@ -602,19 +602,33 @@ body::after {
   box-shadow: 0 0 0 2px var(--accent-dim);
 }
 
-.docs-category-tabs {
+.docs-group-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.group-filter-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-2);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.group-filter-buttons {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
-.category-tab {
+.group-filter-btn {
   appearance: none;
   background: var(--bg-elevated);
   border: 1px solid var(--border);
   color: var(--text-3);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 500;
   padding: 6px 12px;
   border-radius: var(--radius);
@@ -622,15 +636,35 @@ body::after {
   transition: all 0.12s;
 }
 
-.category-tab:hover {
+.group-filter-btn:hover {
   border-color: var(--accent-muted);
   color: var(--text);
 }
 
-.category-tab.active {
+.group-filter-btn.active {
   background: rgba(232, 148, 58, 0.15);
   border-color: rgba(232, 148, 58, 0.4);
   color: var(--accent);
+}
+
+.docs-reset-filters-btn {
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 0;
+  cursor: pointer;
+  transition: color 0.12s;
+  text-decoration: underline;
+  text-decoration-color: var(--text-3);
+  text-underline-offset: 3px;
+}
+
+.docs-reset-filters-btn:hover {
+  color: var(--accent);
+  text-decoration-color: var(--accent);
 }
 
 .docs-results {
@@ -671,11 +705,34 @@ body::after {
   border-color: var(--accent);
 }
 
+.docs-grouped {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.docs-group-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.docs-group-title {
+  font-family: var(--font-display);
+  font-size: 20px;
+  font-weight: 500;
+  color: var(--accent);
+  margin: 0;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+  letter-spacing: -0.01em;
+}
+
 .node-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
   gap: 16px;
-  margin-bottom: 32px;
+  margin-bottom: 0;
 }
 
 /* ── Node Card ──────────────────────────────────────────────────────────── */

--- a/playground/src/styles/index.css
+++ b/playground/src/styles/index.css
@@ -705,29 +705,6 @@ body::after {
   border-color: var(--accent);
 }
 
-.docs-grouped {
-  display: flex;
-  flex-direction: column;
-  gap: 40px;
-}
-
-.docs-group-section {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.docs-group-title {
-  font-family: var(--font-display);
-  font-size: 20px;
-  font-weight: 500;
-  color: var(--accent);
-  margin: 0;
-  padding-bottom: 8px;
-  border-bottom: 1px solid var(--border);
-  letter-spacing: -0.01em;
-}
-
 .node-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));

--- a/playground/src/styles/index.css
+++ b/playground/src/styles/index.css
@@ -811,6 +811,41 @@ body::after {
   padding-top: 12px;
 }
 
+.node-keyword {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding: 8px;
+  background: rgba(232, 148, 58, 0.08);
+  border: 1px solid rgba(232, 148, 58, 0.2);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.node-keyword:hover {
+  background: rgba(232, 148, 58, 0.15);
+  border-color: rgba(232, 148, 58, 0.35);
+}
+
+.keyword-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+.keyword-code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+  background: transparent;
+  padding: 0;
+}
+
 .fields-title {
   font-family: var(--font-mono);
   font-size: 11px;
@@ -837,14 +872,16 @@ body::after {
   align-items: baseline;
   gap: 6px;
   cursor: pointer;
-  transition: background 0.15s, color 0.15s;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
   padding: 4px;
   border-radius: var(--radius);
   margin: -4px;
+  border: 1px solid transparent;
 }
 
 .field-item:hover {
   background: rgba(232, 148, 58, 0.08);
+  border-color: rgba(232, 148, 58, 0.25);
 }
 
 .field-item:hover .field-name {
@@ -991,6 +1028,11 @@ body::after {
 .docs-detail-card .node-card {
   border: none;
   background: transparent;
+}
+
+.docs-detail-card .example-code {
+  max-height: none;
+  overflow-y: visible;
 }
 
 .docs-nav-prev,

--- a/playground/src/styles/index.css
+++ b/playground/src/styles/index.css
@@ -210,9 +210,32 @@ body::after {
 /* ── Workspace ──────────────────────────────────────────────────────────── */
 .workspace {
   display: flex;
+  flex-direction: column;
   flex: 1;
   overflow: hidden;
   position: relative;
+}
+
+.workspace-panes {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.workspace-errors {
+  flex-shrink: 0;
+  border-top: 1px solid var(--border);
+  max-height: 40%;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.workspace-error-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
 }
 
 .pane {

--- a/playground/src/styles/index.css
+++ b/playground/src/styles/index.css
@@ -647,26 +647,6 @@ body::after {
   color: var(--accent);
 }
 
-.docs-reset-filters-btn {
-  appearance: none;
-  background: transparent;
-  border: none;
-  color: var(--text-3);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  padding: 0;
-  cursor: pointer;
-  transition: color 0.12s;
-  text-decoration: underline;
-  text-decoration-color: var(--text-3);
-  text-underline-offset: 3px;
-}
-
-.docs-reset-filters-btn:hover {
-  color: var(--accent);
-  text-decoration-color: var(--accent);
-}
-
 .docs-results {
   min-height: 200px;
 }

--- a/playground/src/styles/index.css
+++ b/playground/src/styles/index.css
@@ -380,7 +380,7 @@ body::after {
 .jt-kw    { color: var(--accent); }
 .jt-null  { color: var(--text-3); }
 
-/* Collapsible tree node toggle (all compound nodes) */
+/* Collapsible tree node toggle (AST nodes and arrays only) */
 .jt-toggle {
   cursor: pointer;
   color: var(--text-2);
@@ -393,23 +393,23 @@ body::after {
 .jt-toggle--open { color: var(--text-3); }
 .jt-toggle--open:hover { color: var(--accent); }
 
-/* Span-specific collapsed style */
-.jt-span {
+/* Enum variant type label (always visible, never toggled) */
+.jt-variant {
   color: var(--accent);
-  cursor: pointer;
+}
+
+/* Span — always compact inline, hover shows source range highlight */
+.jt-span {
+  color: var(--text-2);
+  cursor: crosshair;
   user-select: none;
-  border-bottom: 1px dashed rgba(232, 148, 58, .45);
-  transition: color 0.1s, border-color 0.1s;
+  border-bottom: 1px dashed rgba(232, 148, 58, .4);
+  transition: color 0.1s, border-bottom-color 0.1s;
 }
 
 .jt-span:hover {
-  color: var(--text);
-  border-bottom-color: rgba(240, 230, 216, .45);
-}
-
-.jt-span--on {
   color: var(--accent);
-  border-bottom-style: solid;
+  border-bottom-color: rgba(232, 148, 58, .8);
 }
 
 /* Formatted / AST code output */
@@ -672,6 +672,10 @@ body::after {
   background: linear-gradient(135deg, var(--bg-elevated) 0%, rgba(232, 148, 58, 0.02) 100%);
 }
 
+.node-card--clickable {
+  cursor: pointer;
+}
+
 .node-header {
   display: flex;
   align-items: flex-start;
@@ -686,12 +690,6 @@ body::after {
   color: var(--accent);
   margin: 0;
   line-height: 1.4;
-  cursor: pointer;
-  transition: opacity 0.15s;
-}
-
-.node-name:hover {
-  opacity: 0.8;
 }
 
 .node-meta {
@@ -715,26 +713,25 @@ body::after {
 
 .node-visualize-btn {
   appearance: none;
-  background: transparent;
-  border: 1px solid rgba(232, 148, 58, 0.3);
+  background: var(--accent-dim);
+  border: 1px solid var(--border);
   color: var(--accent);
-  font-size: 13px;
+  font-family: var(--font-mono);
+  font-size: 12px;
   font-weight: 600;
-  width: 28px;
-  height: 28px;
+  padding: 8px 12px;
   border-radius: var(--radius);
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  transition: all 0.12s;
-  flex-shrink: 0;
+  gap: 6px;
+  white-space: nowrap;
+  transition: all 0.2s;
 }
 
 .node-visualize-btn:hover {
-  background: rgba(232, 148, 58, 0.15);
+  background: var(--accent-glow);
   border-color: var(--accent);
-  transform: scale(1.05);
 }
 
 .node-description {
@@ -870,18 +867,6 @@ body::after {
   text-decoration: none;
 }
 
-/* ── Node name link ──────────────────────────────────────────────────────── */
-.node-name-link {
-  display: block;
-  text-decoration: none;
-  color: inherit;
-  transition: all 0.2s;
-}
-
-.node-name-link:hover {
-  color: var(--accent);
-}
-
 /* ── Docs detail page ────────────────────────────────────────────────────── */
 .page-docs-detail {
   display: flex;
@@ -895,10 +880,28 @@ body::after {
 .docs-detail-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 16px 24px;
+  padding: 12px 24px;
   border-bottom: 1px solid var(--border);
   gap: 12px;
+  flex-wrap: wrap;
+}
+
+.docs-detail-nav-inline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+}
+
+.docs-nav-placeholder {
+  display: inline-block;
+}
+
+.docs-detail-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
 }
 
 .docs-back-link {
@@ -953,23 +956,19 @@ body::after {
   background: transparent;
 }
 
-.docs-detail-nav {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 16px 24px;
-  border-top: 1px solid var(--border);
-  background: var(--bg-panel);
-}
-
 .docs-nav-prev,
 .docs-nav-next {
-  padding: 8px 12px;
+  padding: 6px 10px;
   color: var(--text-2);
   text-decoration: none;
   border-radius: var(--radius);
   transition: all 0.2s;
   border: 1px solid var(--border);
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 180px;
 }
 
 .docs-nav-prev:hover,
@@ -977,14 +976,6 @@ body::after {
   color: var(--text);
   background: var(--bg-elevated);
   border-color: var(--accent);
-}
-
-.docs-nav-prev {
-  margin-right: auto;
-}
-
-.docs-nav-next {
-  margin-left: auto;
 }
 
 /* ── Responsive ─────────────────────────────────────────────────────────── */


### PR DESCRIPTION
- Remove default underlines from nav tabs
- Make PHP version selection filter AST nodes in docs
- Add AST node span highlighting in original source when hovering in AST tree
  - Extracts spans from all AST nodes, not just span objects
  - Highlights the corresponding code in the editor pane
- Pass version context to both docs pages for version-aware rendering