### PR TITLE
fix: add php-phpdoc to CI test run and release publish sequence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           key: ${{ matrix.php-version }}
 
       - name: Run tests
-        run: cargo test --lib && cargo test --test integration
+        run: cargo test --lib && cargo test --test integration && cargo test --test fixtures -p php-phpdoc
 
   printer:
     name: Printer Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,14 @@ jobs:
       - name: Wait for crates.io to index php-lexer
         run: sleep 20
 
+      - name: Publish php-phpdoc
+        run: cargo publish -p php-phpdoc --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for crates.io to index php-phpdoc
+        run: sleep 20
+
       - name: Publish php-rs-parser
         run: cargo publish -p php-rs-parser --locked
         env:


### PR DESCRIPTION
## Summary

Two CI gaps introduced when `php-phpdoc` was added as a new crate:

- **`ci.yml`**: The `test` job ran `cargo test --lib` (covers unit tests for all crates) and `cargo test --test integration` (parser-specific). The phpdoc fixture integration test (`--test fixtures -p php-phpdoc`) was never executed in CI.

- **`release.yml`**: `php-phpdoc` was missing from the publish sequence entirely. Since `php-rs-parser` now re-exports `php_phpdoc`, attempting to publish `php-rs-parser` would fail because `php-phpdoc` wouldn't exist on crates.io yet. Added `php-phpdoc` between `php-lexer` and `php-rs-parser` to match dependency order.