### PR TITLE
chore: release 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2026-05-12
+
+### Changed
+
+- Printer state management simplified with duplicate code eliminated (`php-printer`).
+
+### Fixed
+
+- CI validation script no longer prepends `<?php` header when validating pretty-printed output — header already included by `pretty_print()` (`php-parser`).
+- PHPDoc parser package name corrected in CI and release workflows (`phpdoc-parser`).
+
+---
+
 ## [0.11.0] - 2026-05-11
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -26,11 +26,11 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.11.0" }
-php-lexer = { path = "crates/php-lexer", version = "0.11.0" }
-php-rs-parser = { path = "crates/php-parser", version = "0.11.0" }
-phpdoc-parser = { path = "crates/phpdoc-parser", version = "0.11.0" }
-php-printer = { path = "crates/php-printer", version = "0.11.0" }
+php-ast = { path = "crates/php-ast", version = "0.11.1" }
+php-lexer = { path = "crates/php-lexer", version = "0.11.1" }
+php-rs-parser = { path = "crates/php-parser", version = "0.11.1" }
+phpdoc-parser = { path = "crates/phpdoc-parser", version = "0.11.1" }
+php-printer = { path = "crates/php-printer", version = "0.11.1" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

Release 0.11.1 with printer refactor and bug fixes.

### Changes

- Printer state management simplified with duplicate code eliminated
- CI validation script corrected to not prepend `<?php` header
- PHPDoc parser package name fixed in CI and release workflows

### What's included

- Refactor commit: e60db84
- Fix commit: 24f73be
- Fix commit: 176a5af