### PR TITLE
feat(printer): preserve blank lines from source

### DIFF
--- a/crates/php-printer/src/printer/decls.rs
+++ b/crates/php-printer/src/printer/decls.rs
@@ -119,7 +119,13 @@ impl<'src> Printer<'src> {
             self.indent();
             for (i, member) in members.iter().enumerate() {
                 if i > 0 && !self.has_comments_before(member.span.start) {
-                    self.newline();
+                    // Always at least one blank line between members; preserve more from source.
+                    let blank = self
+                        .blank_lines_between(members[i - 1].span.end, member.span.start)
+                        .max(1);
+                    for _ in 0..blank {
+                        self.newline();
+                    }
                 }
                 self.flush_leading_comments(member.span.start);
                 self.write_indent();

--- a/crates/php-printer/src/printer/decls.rs
+++ b/crates/php-printer/src/printer/decls.rs
@@ -410,10 +410,14 @@ impl<'src> Printer<'src> {
             self.newline();
             self.indent();
             for (i, member) in enum_decl.members.iter().enumerate() {
-                self.flush_leading_comments(member.span.start);
-                if i > 0 {
-                    self.newline();
+                if i > 0 && !self.has_comments_before(member.span.start) {
+                    let prev_end = enum_decl.members[i - 1].span.end;
+                    let blank = self.blank_lines_between(prev_end, member.span.start).max(1);
+                    for _ in 0..blank {
+                        self.newline();
+                    }
                 }
+                self.flush_leading_comments(member.span.start);
                 self.write_indent();
                 self.print_enum_member(member);
                 self.newline();

--- a/crates/php-printer/src/printer/mod.rs
+++ b/crates/php-printer/src/printer/mod.rs
@@ -290,6 +290,12 @@ impl<'src> Printer<'src> {
             // When transitioning out of HTML mode the <?php + newline + indent
             // is emitted by print_stmt_inner, so skip the normal separators here.
             if i > 0 && !self.in_html_mode {
+                let decl_min =
+                    if helpers::is_declaration(&stmt.kind) && self.blank_lines_upper_bound > 0 {
+                        1
+                    } else {
+                        0
+                    };
                 let blank = if !self.source.is_empty() {
                     let prev_end = stmts[i - 1].span.end;
                     // Stop at the first pending comment before this statement so that
@@ -297,19 +303,9 @@ impl<'src> Printer<'src> {
                     let scan_to = self
                         .first_pending_comment_before(stmt.span.start)
                         .unwrap_or(stmt.span.start);
-                    let from_source = self.blank_lines_between(prev_end, scan_to);
-                    // Declarations always get at least one blank line for visual separation.
-                    from_source.max(if helpers::is_declaration(&stmt.kind) {
-                        1
-                    } else {
-                        0
-                    })
+                    self.blank_lines_between(prev_end, scan_to).max(decl_min)
                 } else {
-                    if helpers::is_declaration(&stmt.kind) {
-                        1
-                    } else {
-                        0
-                    }
+                    decl_min
                 };
                 self.newline();
                 for _ in 0..blank {

--- a/crates/php-printer/src/printer/mod.rs
+++ b/crates/php-printer/src/printer/mod.rs
@@ -10,6 +10,8 @@ use php_ast::Comment;
 pub struct PrinterConfig {
     pub indent: Indent,
     pub newline: &'static str,
+    /// Maximum blank lines preserved between statements. 0 normalizes all blank lines away.
+    pub blank_lines_upper_bound: usize,
 }
 
 /// Indentation style.
@@ -23,6 +25,7 @@ impl Default for PrinterConfig {
         Self {
             indent: Indent::Spaces(4),
             newline: "\n",
+            blank_lines_upper_bound: 1,
         }
     }
 }
@@ -54,7 +57,9 @@ pub(crate) struct Printer<'src> {
     indent_level: usize,
     indent_str: &'static str,
     nl: &'static str,
+    blank_lines_upper_bound: usize,
     pub(crate) depth: usize,
+    source: &'src str,
     comments: &'src [Comment<'src>],
     comment_cursor: usize,
     /// True when the printer is currently outside a PHP block (file started with HTML).
@@ -72,7 +77,7 @@ impl<'src> Printer<'src> {
 
     pub fn with_comments(
         config: &PrinterConfig,
-        _source: &'src str,
+        source: &'src str,
         comments: &'src [Comment<'src>],
     ) -> Self {
         let indent_str = match config.indent {
@@ -84,7 +89,9 @@ impl<'src> Printer<'src> {
             indent_level: 0,
             indent_str,
             nl: config.newline,
+            blank_lines_upper_bound: config.blank_lines_upper_bound,
             depth: 0,
+            source,
             comments,
             comment_cursor: 0,
             in_html_mode: false,
@@ -128,6 +135,30 @@ impl<'src> Printer<'src> {
 
     pub(crate) fn dedent(&mut self) {
         self.indent_level = self.indent_level.saturating_sub(1);
+    }
+
+    /// Count blank lines in source between two byte offsets, capped at `blank_lines_upper_bound`.
+    /// Returns 0 when no source is available (e.g. `pretty_print` without source).
+    pub(crate) fn blank_lines_between(&self, from: u32, to: u32) -> usize {
+        if self.source.is_empty() || from >= to {
+            return 0;
+        }
+        let from = from as usize;
+        let to = (to as usize).min(self.source.len());
+        let newlines = self.source.as_bytes()[from..to]
+            .iter()
+            .filter(|&&b| b == b'\n')
+            .count();
+        newlines.saturating_sub(1).min(self.blank_lines_upper_bound)
+    }
+
+    /// Return the start offset of the first not-yet-emitted comment whose span
+    /// starts before `before_offset`, or `None` if there is no such comment.
+    pub(crate) fn first_pending_comment_before(&self, before_offset: u32) -> Option<u32> {
+        self.comments[self.comment_cursor..]
+            .iter()
+            .find(|c| c.span.start < before_offset)
+            .map(|c| c.span.start)
     }
 
     // =========================================================================
@@ -259,8 +290,29 @@ impl<'src> Printer<'src> {
             // When transitioning out of HTML mode the <?php + newline + indent
             // is emitted by print_stmt_inner, so skip the normal separators here.
             if i > 0 && !self.in_html_mode {
+                let blank = if !self.source.is_empty() {
+                    let prev_end = stmts[i - 1].span.end;
+                    // Stop at the first pending comment before this statement so that
+                    // newlines inside the comment text aren't mistaken for blank lines.
+                    let scan_to = self
+                        .first_pending_comment_before(stmt.span.start)
+                        .unwrap_or(stmt.span.start);
+                    let from_source = self.blank_lines_between(prev_end, scan_to);
+                    // Declarations always get at least one blank line for visual separation.
+                    from_source.max(if helpers::is_declaration(&stmt.kind) {
+                        1
+                    } else {
+                        0
+                    })
+                } else {
+                    if helpers::is_declaration(&stmt.kind) {
+                        1
+                    } else {
+                        0
+                    }
+                };
                 self.newline();
-                if helpers::is_declaration(&stmt.kind) {
+                for _ in 0..blank {
                     self.newline();
                 }
             }

--- a/crates/php-printer/src/printer/stmts.rs
+++ b/crates/php-printer/src/printer/stmts.rs
@@ -139,7 +139,17 @@ impl<'src> Printer<'src> {
                 }
                 self.newline();
                 self.indent();
-                for case in sw.cases.iter() {
+                for (i, case) in sw.cases.iter().enumerate() {
+                    if i > 0 {
+                        let prev_end = sw.cases[i - 1].span.end;
+                        let scan_to = self
+                            .first_pending_comment_before(case.span.start)
+                            .unwrap_or(case.span.start);
+                        let blank = self.blank_lines_between(prev_end, scan_to);
+                        for _ in 0..blank {
+                            self.newline();
+                        }
+                    }
                     self.flush_leading_comments(case.span.start);
                     self.write_indent();
                     if let Some(val) = &case.value {

--- a/crates/php-printer/tests/fixtures/blank_line_before_comment_preserved.phpt
+++ b/crates/php-printer/tests/fixtures/blank_line_before_comment_preserved.phpt
@@ -1,0 +1,12 @@
+===source===
+<?php
+$a = 1;
+
+// comment after blank line
+$b = 2;
+===print===
+<?php
+$a = 1;
+
+// comment after blank line
+$b = 2;

--- a/crates/php-printer/tests/fixtures/blank_lines_capped_to_one.phpt
+++ b/crates/php-printer/tests/fixtures/blank_lines_capped_to_one.phpt
@@ -1,0 +1,19 @@
+===source===
+<?php
+echo 1;
+
+
+
+echo 2;
+
+
+
+
+echo 3;
+===print===
+<?php
+echo 1;
+
+echo 2;
+
+echo 3;

--- a/crates/php-printer/tests/fixtures/blank_lines_class_members_capped.phpt
+++ b/crates/php-printer/tests/fixtures/blank_lines_class_members_capped.phpt
@@ -1,0 +1,21 @@
+===source===
+<?php
+class Foo
+{
+
+
+    public function bar(): void {}
+
+
+    public function baz(): void {}
+}
+===print===
+<?php
+class Foo
+{
+    public function bar(): void
+    {}
+
+    public function baz(): void
+    {}
+}

--- a/crates/php-printer/tests/fixtures/blank_lines_in_function_body.phpt
+++ b/crates/php-printer/tests/fixtures/blank_lines_in_function_body.phpt
@@ -1,0 +1,20 @@
+===source===
+<?php
+function foo()
+{
+    echo 1;
+
+    echo 2;
+
+    echo 3;
+}
+===print===
+<?php
+function foo()
+{
+    echo 1;
+
+    echo 2;
+
+    echo 3;
+}

--- a/crates/php-printer/tests/fixtures/blank_lines_no_source_fallback.phpt
+++ b/crates/php-printer/tests/fixtures/blank_lines_no_source_fallback.phpt
@@ -1,0 +1,12 @@
+===config===
+no_source=true
+===source===
+<?php
+echo 1;
+function foo() {}
+===print===
+<?php
+echo 1;
+
+function foo()
+{}

--- a/crates/php-printer/tests/fixtures/blank_lines_upper_bound_two.phpt
+++ b/crates/php-printer/tests/fixtures/blank_lines_upper_bound_two.phpt
@@ -1,0 +1,21 @@
+===config===
+blank_lines_upper_bound=2
+===source===
+<?php
+echo 1;
+
+
+
+echo 2;
+
+
+echo 3;
+===print===
+<?php
+echo 1;
+
+
+echo 2;
+
+
+echo 3;

--- a/crates/php-printer/tests/fixtures/blank_lines_upper_bound_zero.phpt
+++ b/crates/php-printer/tests/fixtures/blank_lines_upper_bound_zero.phpt
@@ -1,0 +1,15 @@
+===config===
+blank_lines_upper_bound=0
+===source===
+<?php
+echo 1;
+
+echo 2;
+
+function foo() {}
+===print===
+<?php
+echo 1;
+echo 2;
+function foo()
+{}

--- a/crates/php-printer/tests/fixtures/docstring_edge_cases.phpt
+++ b/crates/php-printer/tests/fixtures/docstring_edge_cases.phpt
@@ -63,42 +63,52 @@ EOS;
 <<<EOS
 Hello World
 EOS;
+
 // Heredoc with variable interpolation
 <<<EOS
 Hello $name
 EOS;
+
 // Heredoc with property access
 <<<EOS
 {$obj->prop}
 EOS;
+
 // Heredoc with carriage return in content
 <<<EOS
 Line1\rLine2
 EOS;
+
 // Heredoc with tab
 <<<EOS
 Col1	Col2
 EOS;
+
 // Heredoc with escaped dollar
 <<<EOS
 Price: \$100
 EOS;
+
 // Heredoc with escaped backslash
 <<<EOS
 Path: \\file.txt
 EOS;
+
 // Heredoc with complex expression
 <<<EOS
 {$arr[0]->method()}
 EOS;
+
 // Nowdoc with special characters
 <<<'EOS'
 $var won't be interpolated
 EOS;
+
 // Empty heredoc
 <<<EOS
 
 EOS;
+
 // Heredoc with multiple lines and variables
 <<<EOS
 Line1: $a

--- a/crates/php-printer/tests/fixtures/enum_blank_lines.phpt
+++ b/crates/php-printer/tests/fixtures/enum_blank_lines.phpt
@@ -1,0 +1,27 @@
+===source===
+<?php
+enum Status: string
+{
+    case Active = 'active';
+
+
+    case Inactive = 'inactive';
+
+    public function label(): string
+    {
+        return $this->value;
+    }
+}
+===print===
+<?php
+enum Status: string
+{
+    case Active = 'active';
+
+    case Inactive = 'inactive';
+
+    public function label(): string
+    {
+        return $this->value;
+    }
+}

--- a/crates/php-printer/tests/fixtures/no_blank_line_before_comment.phpt
+++ b/crates/php-printer/tests/fixtures/no_blank_line_before_comment.phpt
@@ -1,0 +1,10 @@
+===source===
+<?php
+$a = 1;
+// comment without preceding blank line
+$b = 2;
+===print===
+<?php
+$a = 1;
+// comment without preceding blank line
+$b = 2;

--- a/crates/php-printer/tests/fixtures/switch_blank_lines.phpt
+++ b/crates/php-printer/tests/fixtures/switch_blank_lines.phpt
@@ -1,0 +1,26 @@
+===source===
+<?php
+switch ($action) {
+    case 'create':
+        doA();
+        doB();
+
+    case 'update':
+        doC();
+
+    default:
+        doD();
+}
+===print===
+<?php
+switch ($action) {
+    case 'create':
+        doA();
+        doB();
+
+    case 'update':
+        doC();
+
+    default:
+        doD();
+}

--- a/crates/php-printer/tests/printer.rs
+++ b/crates/php-printer/tests/printer.rs
@@ -1,35 +1,49 @@
-use php_printer::pretty_print_with_comments;
+use php_printer::{pretty_print_with_comments_and_config, PrinterConfig};
 use rayon::prelude::*;
 use std::sync::Mutex;
-
-fn pp(src: &str) -> String {
-    let arena = bumpalo::Bump::new();
-    let result = php_rs_parser::parse(&arena, src);
-    pretty_print_with_comments(&result.program, result.source, &result.comments)
-}
 
 /// Parse a printer fixture file.
 ///
 /// Format:
 /// ```text
+/// ===config===          (optional)
+/// blank_lines_upper_bound=0
+/// no_source=true
 /// ===source===
 /// <?php ...
 /// ===print===
 /// expected output
 /// ```
 struct PrinterFixture {
+    /// Raw config block (without the `===config===\n` header), empty string if absent.
+    raw_config: String,
     source: String,
     expected: String,
+    config: PrinterConfig,
+    /// When true, source is not passed to the printer (tests the no-source fallback).
+    no_source: bool,
 }
 
 fn parse_printer_fixture(content: &str) -> PrinterFixture {
-    let after_source = content
+    let (raw_config, rest) = if let Some(after) = content.strip_prefix("===config===\n") {
+        let end = after
+            .find("===source===\n")
+            .expect("fixture must have ===source===");
+        (
+            after[..end].trim_end_matches('\n').to_string(),
+            &after[end..],
+        )
+    } else {
+        (String::new(), content)
+    };
+
+    let after_source = rest
         .strip_prefix("===source===\n")
-        .expect("fixture must start with ===source===");
+        .expect("fixture must have ===source===");
 
     let print_pos = after_source
         .find("===print===\n")
-        .expect("fixture must have ===print=== section");
+        .expect("fixture must have ===print===");
 
     let source = after_source[..print_pos]
         .strip_suffix('\n')
@@ -37,9 +51,22 @@ fn parse_printer_fixture(content: &str) -> PrinterFixture {
     let expected = &after_source[print_pos + "===print===\n".len()..];
     let expected = expected.strip_suffix('\n').unwrap_or(expected);
 
+    let mut config = PrinterConfig::default();
+    let mut no_source = false;
+    for line in raw_config.lines() {
+        if let Some(val) = line.strip_prefix("blank_lines_upper_bound=") {
+            config.blank_lines_upper_bound = val.parse().expect("invalid blank_lines_upper_bound");
+        } else if line == "no_source=true" {
+            no_source = true;
+        }
+    }
+
     PrinterFixture {
+        raw_config,
         source: source.to_string(),
         expected: expected.to_string(),
+        config,
+        no_source,
     }
 }
 
@@ -78,12 +105,30 @@ fn fixtures() {
         let content = std::fs::read_to_string(path).unwrap();
         let fixture = parse_printer_fixture(&content);
 
-        let actual = pp(&fixture.source);
+        let actual = {
+            let arena = bumpalo::Bump::new();
+            let result = php_rs_parser::parse(&arena, &fixture.source);
+            if fixture.no_source {
+                php_printer::pretty_print_with_config(&result.program, &fixture.config)
+            } else {
+                pretty_print_with_comments_and_config(
+                    &result.program,
+                    result.source,
+                    &result.comments,
+                    &fixture.config,
+                )
+            }
+        };
 
         if update {
+            let config_block = if fixture.raw_config.is_empty() {
+                String::new()
+            } else {
+                format!("===config===\n{}\n", fixture.raw_config)
+            };
             let new_content = format!(
-                "===source===\n{}\n===print===\n{}\n",
-                fixture.source, actual
+                "{}===source===\n{}\n===print===\n{}\n",
+                config_block, fixture.source, actual
             );
             std::fs::write(path, new_content).unwrap();
         } else {
@@ -99,11 +144,28 @@ fn fixtures() {
         // Also verify round-trip stability
         let arena1 = bumpalo::Bump::new();
         let result1 = php_rs_parser::parse(&arena1, &fixture.source);
-        let first = pretty_print_with_comments(&result1.program, result1.source, &result1.comments);
+        let first = if fixture.no_source {
+            php_printer::pretty_print_with_config(&result1.program, &fixture.config)
+        } else {
+            pretty_print_with_comments_and_config(
+                &result1.program,
+                result1.source,
+                &result1.comments,
+                &fixture.config,
+            )
+        };
         let arena2 = bumpalo::Bump::new();
         let result2 = php_rs_parser::parse(&arena2, &first);
-        let second =
-            pretty_print_with_comments(&result2.program, result2.source, &result2.comments);
+        let second = if fixture.no_source {
+            php_printer::pretty_print_with_config(&result2.program, &fixture.config)
+        } else {
+            pretty_print_with_comments_and_config(
+                &result2.program,
+                result2.source,
+                &result2.comments,
+                &fixture.config,
+            )
+        };
         if first != second {
             failures.lock().unwrap().push(format!(
                 "round-trip mismatch in {rel}\nfirst:  {first}\nsecond: {second}"


### PR DESCRIPTION
## Summary

- Add `blank_lines_upper_bound` to `PrinterConfig` (default `1`) — controls how many blank lines the printer preserves between nodes
- Store the source string in `Printer` (was discarded as `_source`) and use it to count blank lines via span offsets, matching how `rustfmt` and other formatters approach this
- Apply to statements, class members, enum members, and switch cases
- Blank line counting stops at the first pending comment before a node to avoid counting newlines inside comment text as blank lines
- When no source is available (`pretty_print` without source), fall back to the previous heuristic: one blank line before declarations, none elsewhere
- Setting `blank_lines_upper_bound = 0` normalises all blank lines away, including before declarations
- Fix comment-before-blank-line ordering bug in enum bodies

## Coverage

Fixture runner extended with an optional `===config===` section supporting `blank_lines_upper_bound=N` and `no_source=true`, enabling all edge cases to be expressed as `.phpt` files:

- Blank lines inside function bodies preserved
- Multiple blank lines capped to `upper_bound` (default 1)
- Class members with excess blank lines capped
- Blank line before a comment preserved; absent blank line stays absent
- `blank_lines_upper_bound=0` normalises everything including declarations
- `blank_lines_upper_bound=2` preserves up to two blank lines
- No-source fallback adds one blank line before declarations
- Switch cases with blank lines between arms
- Enum members with varying blank line counts