### PR TITLE
feat(php-ast): add Fold trait for arena-to-arena AST transformation

### DIFF
--- a/crates/php-ast/src/ast/exprs.rs
+++ b/crates/php-ast/src/ast/exprs.rs
@@ -53,6 +53,17 @@ impl<'arena, 'src> NameStr<'arena, 'src> {
         }
     }
 
+    /// Returns the source slice if this value was borrowed from the source buffer, otherwise `None`.
+    /// Used by the fold infrastructure to preserve source-borrowed strings without re-allocation.
+    #[doc(hidden)]
+    #[inline]
+    pub fn __into_src_str(self) -> Option<&'src str> {
+        match self.0 {
+            NameStrInner::Src(s) => Some(s),
+            NameStrInner::Arena(_) => None,
+        }
+    }
+
     #[inline]
     pub fn as_str(&self) -> &str {
         match self.0 {

--- a/crates/php-ast/src/fold.rs
+++ b/crates/php-ast/src/fold.rs
@@ -1,0 +1,1209 @@
+//! Arena-to-arena AST transformation via the [`Fold`] trait.
+//!
+//! # Overview
+//!
+//! [`Fold`] is the transformation counterpart of [`crate::visitor::Visitor`].
+//! Where `Visitor` walks a tree read-only, `Fold` rebuilds it — reading from an
+//! input node (in any arena `'_`) and writing into a caller-supplied output arena
+//! `'new`.  This is the only sound design for arena-allocated ASTs: in-place
+//! mutation (`VisitorMut`) would let you write a `&'new Expr` into a slot that
+//! requires a `&'old Expr`, silently breaking the arena lifetime invariant.
+//!
+//! # Lifetimes
+//!
+//! * `'src` — the source-text lifetime, bound on the `Fold` trait.  `&'src str`
+//!   slices that point directly into the original PHP source are passed through
+//!   unchanged across the fold; they are never re-allocated.
+//! * `'new` — the output arena lifetime; a generic on each method so one
+//!   `impl Fold<'src>` can fold into different arenas over its lifetime.
+//! * `'_` — the input arena lifetime, intentionally erased.  The fold never
+//!   reads back through output-arena pointers, so the input and output arenas
+//!   are fully independent.
+//!
+//! # Arena-allocated strings
+//!
+//! Several AST nodes store `&'arena str` values that were *not* borrowed from
+//! the source buffer — for example string literals, [`StmtKind::Label`], and
+//! [`ExprKind::Nowdoc`] values.  The identity fold re-allocates these via
+//! `arena.alloc_str(s)` so the output nodes are self-contained within the
+//! new arena.  Source-borrowed [`NameStr`] values (`NameStr::__src`) are
+//! preserved as-is without copying.
+//!
+//! # Usage
+//!
+//! ```
+//! use bumpalo::Bump;
+//! use php_ast::fold::{Fold, fold_program};
+//! use php_ast::ast::*;
+//!
+//! /// An identity fold — rebuilds the AST without changes.
+//! struct Identity;
+//! impl<'src> Fold<'src> for Identity {}
+//!
+//! // Fold `program` (in `src_arena`) into `out_arena`:
+//! // let folded = Identity.fold_program(&out_arena, &program);
+//! ```
+//!
+//! To transform specific nodes, override the corresponding method and call the
+//! free `fold_*` function for the default recursion:
+//!
+//! ```
+//! use bumpalo::Bump;
+//! use php_ast::fold::{Fold, fold_expr};
+//! use php_ast::ast::*;
+//!
+//! struct NegateInts;
+//!
+//! impl<'src> Fold<'src> for NegateInts {
+//!     fn fold_expr<'new>(&mut self, arena: &'new Bump, expr: &Expr<'_, 'src>) -> Expr<'new, 'src> {
+//!         if let ExprKind::Int(n) = expr.kind {
+//!             return Expr { kind: ExprKind::Int(-n), span: expr.span };
+//!         }
+//!         fold_expr(self, arena, expr)
+//!     }
+//! }
+//! ```
+
+use bumpalo::Bump;
+
+use crate::ast::*;
+
+// =============================================================================
+// Fold trait
+// =============================================================================
+
+/// Trait for arena-to-arena PHP AST transformation.
+///
+/// All methods have identity-fold default implementations that call the
+/// corresponding free `fold_*` function.  Override only the node types you want
+/// to change; the rest recurse automatically.
+///
+/// See the [module documentation](self) for design rationale and lifetime notes.
+pub trait Fold<'src> {
+    fn fold_program<'new>(
+        &mut self,
+        arena: &'new Bump,
+        program: &Program<'_, 'src>,
+    ) -> Program<'new, 'src> {
+        fold_program(self, arena, program)
+    }
+
+    fn fold_stmt<'new>(&mut self, arena: &'new Bump, stmt: &Stmt<'_, 'src>) -> Stmt<'new, 'src> {
+        fold_stmt(self, arena, stmt)
+    }
+
+    fn fold_expr<'new>(&mut self, arena: &'new Bump, expr: &Expr<'_, 'src>) -> Expr<'new, 'src> {
+        fold_expr(self, arena, expr)
+    }
+
+    fn fold_param<'new>(
+        &mut self,
+        arena: &'new Bump,
+        param: &Param<'_, 'src>,
+    ) -> Param<'new, 'src> {
+        fold_param(self, arena, param)
+    }
+
+    fn fold_arg<'new>(&mut self, arena: &'new Bump, arg: &Arg<'_, 'src>) -> Arg<'new, 'src> {
+        fold_arg(self, arena, arg)
+    }
+
+    fn fold_class_member<'new>(
+        &mut self,
+        arena: &'new Bump,
+        member: &ClassMember<'_, 'src>,
+    ) -> ClassMember<'new, 'src> {
+        fold_class_member(self, arena, member)
+    }
+
+    fn fold_enum_member<'new>(
+        &mut self,
+        arena: &'new Bump,
+        member: &EnumMember<'_, 'src>,
+    ) -> EnumMember<'new, 'src> {
+        fold_enum_member(self, arena, member)
+    }
+
+    fn fold_property_hook<'new>(
+        &mut self,
+        arena: &'new Bump,
+        hook: &PropertyHook<'_, 'src>,
+    ) -> PropertyHook<'new, 'src> {
+        fold_property_hook(self, arena, hook)
+    }
+
+    fn fold_type_hint<'new>(
+        &mut self,
+        arena: &'new Bump,
+        type_hint: &TypeHint<'_, 'src>,
+    ) -> TypeHint<'new, 'src> {
+        fold_type_hint(self, arena, type_hint)
+    }
+
+    fn fold_attribute<'new>(
+        &mut self,
+        arena: &'new Bump,
+        attribute: &Attribute<'_, 'src>,
+    ) -> Attribute<'new, 'src> {
+        fold_attribute(self, arena, attribute)
+    }
+
+    fn fold_catch_clause<'new>(
+        &mut self,
+        arena: &'new Bump,
+        catch: &CatchClause<'_, 'src>,
+    ) -> CatchClause<'new, 'src> {
+        fold_catch_clause(self, arena, catch)
+    }
+
+    fn fold_match_arm<'new>(
+        &mut self,
+        arena: &'new Bump,
+        arm: &MatchArm<'_, 'src>,
+    ) -> MatchArm<'new, 'src> {
+        fold_match_arm(self, arena, arm)
+    }
+
+    fn fold_closure_use_var(&mut self, var: &ClosureUseVar<'src>) -> ClosureUseVar<'src> {
+        var.clone()
+    }
+
+    fn fold_trait_use<'new>(
+        &mut self,
+        arena: &'new Bump,
+        trait_use: &TraitUseDecl<'_, 'src>,
+    ) -> TraitUseDecl<'new, 'src> {
+        fold_trait_use(self, arena, trait_use)
+    }
+
+    fn fold_trait_adaptation<'new>(
+        &mut self,
+        arena: &'new Bump,
+        adaptation: &TraitAdaptation<'_, 'src>,
+    ) -> TraitAdaptation<'new, 'src> {
+        fold_trait_adaptation(self, arena, adaptation)
+    }
+
+    fn fold_name<'new>(&mut self, arena: &'new Bump, name: &Name<'_, 'src>) -> Name<'new, 'src> {
+        fold_name(self, arena, name)
+    }
+}
+
+// =============================================================================
+// Public free functions — default recursion for each trait method
+// =============================================================================
+
+pub fn fold_program<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    program: &Program<'_, 'src>,
+) -> Program<'new, 'src> {
+    Program {
+        stmts: fold_stmts(folder, arena, &program.stmts),
+        span: program.span,
+    }
+}
+
+pub fn fold_stmt<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    stmt: &Stmt<'_, 'src>,
+) -> Stmt<'new, 'src> {
+    let kind = match &stmt.kind {
+        StmtKind::Expression(expr) => {
+            StmtKind::Expression(arena.alloc(folder.fold_expr(arena, expr)))
+        }
+        StmtKind::Echo(exprs) => StmtKind::Echo(fold_exprs(folder, arena, exprs)),
+        StmtKind::Return(expr) => {
+            StmtKind::Return(expr.map(|e| &*arena.alloc(folder.fold_expr(arena, e))))
+        }
+        StmtKind::Block(stmts) => StmtKind::Block(fold_stmts(folder, arena, stmts)),
+        StmtKind::If(if_stmt) => {
+            let mut elseif_branches =
+                ArenaVec::with_capacity_in(if_stmt.elseif_branches.len(), arena);
+            for branch in if_stmt.elseif_branches.iter() {
+                elseif_branches.push(ElseIfBranch {
+                    condition: folder.fold_expr(arena, &branch.condition),
+                    body: folder.fold_stmt(arena, &branch.body),
+                    span: branch.span,
+                });
+            }
+            let new_if = arena.alloc(IfStmt {
+                condition: folder.fold_expr(arena, &if_stmt.condition),
+                then_branch: arena.alloc(folder.fold_stmt(arena, if_stmt.then_branch)),
+                elseif_branches,
+                else_branch: if_stmt
+                    .else_branch
+                    .map(|b| &*arena.alloc(folder.fold_stmt(arena, b))),
+                uses_alternative: if_stmt.uses_alternative,
+            });
+            StmtKind::If(new_if)
+        }
+        StmtKind::While(w) => {
+            let new_w = arena.alloc(WhileStmt {
+                condition: folder.fold_expr(arena, &w.condition),
+                body: arena.alloc(folder.fold_stmt(arena, w.body)),
+                uses_alternative: w.uses_alternative,
+            });
+            StmtKind::While(new_w)
+        }
+        StmtKind::For(f) => {
+            let new_f = arena.alloc(ForStmt {
+                init: fold_exprs(folder, arena, &f.init),
+                condition: fold_exprs(folder, arena, &f.condition),
+                update: fold_exprs(folder, arena, &f.update),
+                body: arena.alloc(folder.fold_stmt(arena, f.body)),
+                uses_alternative: f.uses_alternative,
+            });
+            StmtKind::For(new_f)
+        }
+        StmtKind::Foreach(fe) => {
+            let new_fe = arena.alloc(ForeachStmt {
+                expr: folder.fold_expr(arena, &fe.expr),
+                key: fe.key.as_ref().map(|k| folder.fold_expr(arena, k)),
+                value: folder.fold_expr(arena, &fe.value),
+                body: arena.alloc(folder.fold_stmt(arena, fe.body)),
+                uses_alternative: fe.uses_alternative,
+            });
+            StmtKind::Foreach(new_fe)
+        }
+        StmtKind::DoWhile(dw) => {
+            let new_dw = arena.alloc(DoWhileStmt {
+                body: arena.alloc(folder.fold_stmt(arena, dw.body)),
+                condition: folder.fold_expr(arena, &dw.condition),
+            });
+            StmtKind::DoWhile(new_dw)
+        }
+        StmtKind::Function(func) => {
+            StmtKind::Function(arena.alloc(fold_function_decl(folder, arena, func)))
+        }
+        StmtKind::Break(expr) => {
+            StmtKind::Break(expr.map(|e| &*arena.alloc(folder.fold_expr(arena, e))))
+        }
+        StmtKind::Continue(expr) => {
+            StmtKind::Continue(expr.map(|e| &*arena.alloc(folder.fold_expr(arena, e))))
+        }
+        StmtKind::Switch(sw) => {
+            let mut cases = ArenaVec::with_capacity_in(sw.cases.len(), arena);
+            for case in sw.cases.iter() {
+                cases.push(SwitchCase {
+                    value: case.value.as_ref().map(|v| folder.fold_expr(arena, v)),
+                    body: fold_stmts(folder, arena, &case.body),
+                    span: case.span,
+                });
+            }
+            let new_sw = arena.alloc(SwitchStmt {
+                expr: folder.fold_expr(arena, &sw.expr),
+                cases,
+                uses_alternative: sw.uses_alternative,
+            });
+            StmtKind::Switch(new_sw)
+        }
+        StmtKind::Goto(ident) => StmtKind::Goto(*ident),
+        StmtKind::Label(s) => StmtKind::Label(arena.alloc_str(s)),
+        StmtKind::Declare(decl) => {
+            let mut directives = ArenaVec::with_capacity_in(decl.directives.len(), arena);
+            for (name, expr) in decl.directives.iter() {
+                directives.push((*name, folder.fold_expr(arena, expr)));
+            }
+            let new_decl = arena.alloc(DeclareStmt {
+                directives,
+                body: decl.body.map(|b| &*arena.alloc(folder.fold_stmt(arena, b))),
+                uses_alternative: decl.uses_alternative,
+            });
+            StmtKind::Declare(new_decl)
+        }
+        StmtKind::Unset(exprs) => StmtKind::Unset(fold_exprs(folder, arena, exprs)),
+        StmtKind::Throw(expr) => StmtKind::Throw(arena.alloc(folder.fold_expr(arena, expr))),
+        StmtKind::TryCatch(tc) => {
+            let mut catches = ArenaVec::with_capacity_in(tc.catches.len(), arena);
+            for catch in tc.catches.iter() {
+                catches.push(folder.fold_catch_clause(arena, catch));
+            }
+            let new_tc = arena.alloc(TryCatchStmt {
+                body: fold_stmts(folder, arena, &tc.body),
+                catches,
+                finally: tc.finally.as_ref().map(|f| fold_stmts(folder, arena, f)),
+            });
+            StmtKind::TryCatch(new_tc)
+        }
+        StmtKind::Global(exprs) => StmtKind::Global(fold_exprs(folder, arena, exprs)),
+        StmtKind::Class(class) => {
+            StmtKind::Class(arena.alloc(fold_class_decl(folder, arena, class)))
+        }
+        StmtKind::Interface(iface) => {
+            StmtKind::Interface(arena.alloc(fold_interface_decl(folder, arena, iface)))
+        }
+        StmtKind::Trait(t) => StmtKind::Trait(arena.alloc(fold_trait_decl(folder, arena, t))),
+        StmtKind::Enum(e) => StmtKind::Enum(arena.alloc(fold_enum_decl(folder, arena, e))),
+        StmtKind::Namespace(ns) => {
+            let new_ns = arena.alloc(NamespaceDecl {
+                name: ns.name.as_ref().map(|n| folder.fold_name(arena, n)),
+                body: match &ns.body {
+                    NamespaceBody::Braced(stmts) => {
+                        NamespaceBody::Braced(fold_stmts(folder, arena, stmts))
+                    }
+                    NamespaceBody::Simple => NamespaceBody::Simple,
+                },
+            });
+            StmtKind::Namespace(new_ns)
+        }
+        StmtKind::Use(use_decl) => {
+            let mut uses = ArenaVec::with_capacity_in(use_decl.uses.len(), arena);
+            for item in use_decl.uses.iter() {
+                uses.push(UseItem {
+                    name: folder.fold_name(arena, &item.name),
+                    alias: item.alias,
+                    kind: item.kind,
+                    span: item.span,
+                });
+            }
+            let new_use = arena.alloc(UseDecl {
+                kind: use_decl.kind,
+                uses,
+            });
+            StmtKind::Use(new_use)
+        }
+        StmtKind::Const(items) => {
+            let mut new_items = ArenaVec::with_capacity_in(items.len(), arena);
+            for item in items.iter() {
+                new_items.push(ConstItem {
+                    name: item.name,
+                    value: folder.fold_expr(arena, &item.value),
+                    attributes: fold_attrs(folder, arena, &item.attributes),
+                    span: item.span,
+                    doc_comment: item.doc_comment.as_ref().map(fold_comment),
+                });
+            }
+            StmtKind::Const(new_items)
+        }
+        StmtKind::StaticVar(vars) => {
+            let mut new_vars = ArenaVec::with_capacity_in(vars.len(), arena);
+            for var in vars.iter() {
+                new_vars.push(StaticVar {
+                    name: var.name,
+                    default: var.default.as_ref().map(|d| folder.fold_expr(arena, d)),
+                    span: var.span,
+                });
+            }
+            StmtKind::StaticVar(new_vars)
+        }
+        StmtKind::HaltCompiler(s) => StmtKind::HaltCompiler(s),
+        StmtKind::Nop => StmtKind::Nop,
+        StmtKind::InlineHtml(s) => StmtKind::InlineHtml(s),
+        StmtKind::Error => StmtKind::Error,
+    };
+    Stmt {
+        kind,
+        span: stmt.span,
+    }
+}
+
+pub fn fold_expr<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    expr: &Expr<'_, 'src>,
+) -> Expr<'new, 'src> {
+    let kind = match &expr.kind {
+        ExprKind::Int(n) => ExprKind::Int(*n),
+        ExprKind::Float(f) => ExprKind::Float(*f),
+        ExprKind::String(s) => ExprKind::String(arena.alloc_str(s)),
+        ExprKind::InterpolatedString(parts) => {
+            ExprKind::InterpolatedString(fold_string_parts(folder, arena, parts))
+        }
+        ExprKind::Heredoc { label, parts } => ExprKind::Heredoc {
+            label,
+            parts: fold_string_parts(folder, arena, parts),
+        },
+        ExprKind::Nowdoc { label, value } => ExprKind::Nowdoc {
+            label,
+            value: arena.alloc_str(value),
+        },
+        ExprKind::ShellExec(parts) => ExprKind::ShellExec(fold_string_parts(folder, arena, parts)),
+        ExprKind::Bool(b) => ExprKind::Bool(*b),
+        ExprKind::Null => ExprKind::Null,
+        ExprKind::Variable(name) => ExprKind::Variable(fold_name_str(*name, arena)),
+        ExprKind::VariableVariable(inner) => {
+            ExprKind::VariableVariable(arena.alloc(folder.fold_expr(arena, inner)))
+        }
+        ExprKind::Identifier(name) => ExprKind::Identifier(fold_name_str(*name, arena)),
+        ExprKind::Assign(assign) => ExprKind::Assign(AssignExpr {
+            target: arena.alloc(folder.fold_expr(arena, assign.target)),
+            op: assign.op,
+            value: arena.alloc(folder.fold_expr(arena, assign.value)),
+            by_ref: assign.by_ref,
+        }),
+        ExprKind::Binary(binary) => ExprKind::Binary(BinaryExpr {
+            left: arena.alloc(folder.fold_expr(arena, binary.left)),
+            op: binary.op,
+            right: arena.alloc(folder.fold_expr(arena, binary.right)),
+        }),
+        ExprKind::UnaryPrefix(u) => ExprKind::UnaryPrefix(UnaryPrefixExpr {
+            op: u.op,
+            operand: arena.alloc(folder.fold_expr(arena, u.operand)),
+        }),
+        ExprKind::UnaryPostfix(u) => ExprKind::UnaryPostfix(UnaryPostfixExpr {
+            operand: arena.alloc(folder.fold_expr(arena, u.operand)),
+            op: u.op,
+        }),
+        ExprKind::Ternary(t) => ExprKind::Ternary(TernaryExpr {
+            condition: arena.alloc(folder.fold_expr(arena, t.condition)),
+            then_expr: t
+                .then_expr
+                .map(|e| &*arena.alloc(folder.fold_expr(arena, e))),
+            else_expr: arena.alloc(folder.fold_expr(arena, t.else_expr)),
+        }),
+        ExprKind::NullCoalesce(nc) => ExprKind::NullCoalesce(NullCoalesceExpr {
+            left: arena.alloc(folder.fold_expr(arena, nc.left)),
+            right: arena.alloc(folder.fold_expr(arena, nc.right)),
+        }),
+        ExprKind::FunctionCall(call) => ExprKind::FunctionCall(FunctionCallExpr {
+            name: arena.alloc(folder.fold_expr(arena, call.name)),
+            args: fold_args(folder, arena, &call.args),
+        }),
+        ExprKind::Array(elements) => {
+            let mut new_elements = ArenaVec::with_capacity_in(elements.len(), arena);
+            for elem in elements.iter() {
+                new_elements.push(ArrayElement {
+                    key: elem.key.as_ref().map(|k| folder.fold_expr(arena, k)),
+                    value: folder.fold_expr(arena, &elem.value),
+                    unpack: elem.unpack,
+                    by_ref: elem.by_ref,
+                    span: elem.span,
+                });
+            }
+            ExprKind::Array(new_elements)
+        }
+        ExprKind::ArrayAccess(access) => ExprKind::ArrayAccess(ArrayAccessExpr {
+            array: arena.alloc(folder.fold_expr(arena, access.array)),
+            index: access
+                .index
+                .map(|i| &*arena.alloc(folder.fold_expr(arena, i))),
+        }),
+        ExprKind::Print(e) => ExprKind::Print(arena.alloc(folder.fold_expr(arena, e))),
+        ExprKind::Parenthesized(e) => {
+            ExprKind::Parenthesized(arena.alloc(folder.fold_expr(arena, e)))
+        }
+        ExprKind::Cast(kind, e) => ExprKind::Cast(*kind, arena.alloc(folder.fold_expr(arena, e))),
+        ExprKind::ErrorSuppress(e) => {
+            ExprKind::ErrorSuppress(arena.alloc(folder.fold_expr(arena, e)))
+        }
+        ExprKind::Isset(exprs) => ExprKind::Isset(fold_exprs(folder, arena, exprs)),
+        ExprKind::Empty(e) => ExprKind::Empty(arena.alloc(folder.fold_expr(arena, e))),
+        ExprKind::Include(kind, e) => {
+            ExprKind::Include(*kind, arena.alloc(folder.fold_expr(arena, e)))
+        }
+        ExprKind::Eval(e) => ExprKind::Eval(arena.alloc(folder.fold_expr(arena, e))),
+        ExprKind::Exit(e) => ExprKind::Exit(e.map(|e| &*arena.alloc(folder.fold_expr(arena, e)))),
+        ExprKind::MagicConst(k) => ExprKind::MagicConst(*k),
+        ExprKind::Clone(e) => ExprKind::Clone(arena.alloc(folder.fold_expr(arena, e))),
+        ExprKind::CloneWith(obj, overrides) => ExprKind::CloneWith(
+            arena.alloc(folder.fold_expr(arena, obj)),
+            arena.alloc(folder.fold_expr(arena, overrides)),
+        ),
+        ExprKind::New(new_expr) => ExprKind::New(NewExpr {
+            class: arena.alloc(folder.fold_expr(arena, new_expr.class)),
+            args: fold_args(folder, arena, &new_expr.args),
+        }),
+        ExprKind::PropertyAccess(access) => ExprKind::PropertyAccess(PropertyAccessExpr {
+            object: arena.alloc(folder.fold_expr(arena, access.object)),
+            property: arena.alloc(folder.fold_expr(arena, access.property)),
+        }),
+        ExprKind::NullsafePropertyAccess(access) => {
+            ExprKind::NullsafePropertyAccess(PropertyAccessExpr {
+                object: arena.alloc(folder.fold_expr(arena, access.object)),
+                property: arena.alloc(folder.fold_expr(arena, access.property)),
+            })
+        }
+        ExprKind::MethodCall(call) => ExprKind::MethodCall(arena.alloc(MethodCallExpr {
+            object: arena.alloc(folder.fold_expr(arena, call.object)),
+            method: arena.alloc(folder.fold_expr(arena, call.method)),
+            args: fold_args(folder, arena, &call.args),
+        })),
+        ExprKind::NullsafeMethodCall(call) => {
+            ExprKind::NullsafeMethodCall(arena.alloc(MethodCallExpr {
+                object: arena.alloc(folder.fold_expr(arena, call.object)),
+                method: arena.alloc(folder.fold_expr(arena, call.method)),
+                args: fold_args(folder, arena, &call.args),
+            }))
+        }
+        ExprKind::StaticPropertyAccess(access) => {
+            ExprKind::StaticPropertyAccess(StaticAccessExpr {
+                class: arena.alloc(folder.fold_expr(arena, access.class)),
+                member: arena.alloc(folder.fold_expr(arena, access.member)),
+            })
+        }
+        ExprKind::StaticMethodCall(call) => {
+            ExprKind::StaticMethodCall(arena.alloc(StaticMethodCallExpr {
+                class: arena.alloc(folder.fold_expr(arena, call.class)),
+                method: arena.alloc(folder.fold_expr(arena, call.method)),
+                args: fold_args(folder, arena, &call.args),
+            }))
+        }
+        ExprKind::StaticDynMethodCall(call) => {
+            ExprKind::StaticDynMethodCall(arena.alloc(StaticDynMethodCallExpr {
+                class: arena.alloc(folder.fold_expr(arena, call.class)),
+                method: arena.alloc(folder.fold_expr(arena, call.method)),
+                args: fold_args(folder, arena, &call.args),
+            }))
+        }
+        ExprKind::ClassConstAccess(access) => ExprKind::ClassConstAccess(StaticAccessExpr {
+            class: arena.alloc(folder.fold_expr(arena, access.class)),
+            member: arena.alloc(folder.fold_expr(arena, access.member)),
+        }),
+        ExprKind::ClassConstAccessDynamic { class, member } => ExprKind::ClassConstAccessDynamic {
+            class: arena.alloc(folder.fold_expr(arena, class)),
+            member: arena.alloc(folder.fold_expr(arena, member)),
+        },
+        ExprKind::StaticPropertyAccessDynamic { class, member } => {
+            ExprKind::StaticPropertyAccessDynamic {
+                class: arena.alloc(folder.fold_expr(arena, class)),
+                member: arena.alloc(folder.fold_expr(arena, member)),
+            }
+        }
+        ExprKind::Closure(closure) => {
+            let mut use_vars = ArenaVec::with_capacity_in(closure.use_vars.len(), arena);
+            for var in closure.use_vars.iter() {
+                use_vars.push(folder.fold_closure_use_var(var));
+            }
+            let new_closure = arena.alloc(ClosureExpr {
+                is_static: closure.is_static,
+                by_ref: closure.by_ref,
+                params: fold_params(folder, arena, &closure.params),
+                use_vars,
+                return_type: closure
+                    .return_type
+                    .as_ref()
+                    .map(|t| folder.fold_type_hint(arena, t)),
+                body: fold_stmts(folder, arena, &closure.body),
+                attributes: fold_attrs(folder, arena, &closure.attributes),
+            });
+            ExprKind::Closure(new_closure)
+        }
+        ExprKind::ArrowFunction(arrow) => {
+            let new_arrow = arena.alloc(ArrowFunctionExpr {
+                is_static: arrow.is_static,
+                by_ref: arrow.by_ref,
+                params: fold_params(folder, arena, &arrow.params),
+                return_type: arrow
+                    .return_type
+                    .as_ref()
+                    .map(|t| folder.fold_type_hint(arena, t)),
+                body: arena.alloc(folder.fold_expr(arena, arrow.body)),
+                attributes: fold_attrs(folder, arena, &arrow.attributes),
+            });
+            ExprKind::ArrowFunction(new_arrow)
+        }
+        ExprKind::Match(match_expr) => ExprKind::Match(MatchExpr {
+            subject: arena.alloc(folder.fold_expr(arena, match_expr.subject)),
+            arms: {
+                let mut arms = ArenaVec::with_capacity_in(match_expr.arms.len(), arena);
+                for arm in match_expr.arms.iter() {
+                    arms.push(folder.fold_match_arm(arena, arm));
+                }
+                arms
+            },
+        }),
+        ExprKind::ThrowExpr(e) => ExprKind::ThrowExpr(arena.alloc(folder.fold_expr(arena, e))),
+        ExprKind::Yield(y) => ExprKind::Yield(YieldExpr {
+            key: y.key.map(|k| &*arena.alloc(folder.fold_expr(arena, k))),
+            value: y.value.map(|v| &*arena.alloc(folder.fold_expr(arena, v))),
+            is_from: y.is_from,
+        }),
+        ExprKind::AnonymousClass(class) => {
+            ExprKind::AnonymousClass(arena.alloc(fold_class_decl(folder, arena, class)))
+        }
+        ExprKind::CallableCreate(cc) => {
+            let kind = match &cc.kind {
+                CallableCreateKind::Function(name) => {
+                    CallableCreateKind::Function(arena.alloc(folder.fold_expr(arena, name)))
+                }
+                CallableCreateKind::Method { object, method } => CallableCreateKind::Method {
+                    object: arena.alloc(folder.fold_expr(arena, object)),
+                    method: arena.alloc(folder.fold_expr(arena, method)),
+                },
+                CallableCreateKind::NullsafeMethod { object, method } => {
+                    CallableCreateKind::NullsafeMethod {
+                        object: arena.alloc(folder.fold_expr(arena, object)),
+                        method: arena.alloc(folder.fold_expr(arena, method)),
+                    }
+                }
+                CallableCreateKind::StaticMethod { class, method } => {
+                    CallableCreateKind::StaticMethod {
+                        class: arena.alloc(folder.fold_expr(arena, class)),
+                        method: arena.alloc(folder.fold_expr(arena, method)),
+                    }
+                }
+            };
+            ExprKind::CallableCreate(CallableCreateExpr { kind })
+        }
+        ExprKind::Omit => ExprKind::Omit,
+        ExprKind::Error => ExprKind::Error,
+    };
+    Expr {
+        kind,
+        span: expr.span,
+    }
+}
+
+pub fn fold_param<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    param: &Param<'_, 'src>,
+) -> Param<'new, 'src> {
+    Param {
+        name: param.name,
+        type_hint: param
+            .type_hint
+            .as_ref()
+            .map(|t| folder.fold_type_hint(arena, t)),
+        default: param.default.as_ref().map(|d| folder.fold_expr(arena, d)),
+        by_ref: param.by_ref,
+        variadic: param.variadic,
+        is_readonly: param.is_readonly,
+        is_final: param.is_final,
+        visibility: param.visibility,
+        set_visibility: param.set_visibility,
+        attributes: fold_attrs(folder, arena, &param.attributes),
+        hooks: fold_hooks(folder, arena, &param.hooks),
+        span: param.span,
+    }
+}
+
+pub fn fold_arg<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    arg: &Arg<'_, 'src>,
+) -> Arg<'new, 'src> {
+    Arg {
+        name: arg.name.as_ref().map(|n| folder.fold_name(arena, n)),
+        value: folder.fold_expr(arena, &arg.value),
+        unpack: arg.unpack,
+        by_ref: arg.by_ref,
+        span: arg.span,
+    }
+}
+
+pub fn fold_class_member<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    member: &ClassMember<'_, 'src>,
+) -> ClassMember<'new, 'src> {
+    let kind = match &member.kind {
+        ClassMemberKind::Property(prop) => {
+            ClassMemberKind::Property(fold_property_decl(folder, arena, prop))
+        }
+        ClassMemberKind::Method(method) => {
+            ClassMemberKind::Method(fold_method_decl(folder, arena, method))
+        }
+        ClassMemberKind::ClassConst(cc) => {
+            ClassMemberKind::ClassConst(fold_class_const_decl(folder, arena, cc))
+        }
+        ClassMemberKind::TraitUse(tu) => {
+            ClassMemberKind::TraitUse(folder.fold_trait_use(arena, tu))
+        }
+    };
+    ClassMember {
+        kind,
+        span: member.span,
+    }
+}
+
+pub fn fold_enum_member<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    member: &EnumMember<'_, 'src>,
+) -> EnumMember<'new, 'src> {
+    let kind = match &member.kind {
+        EnumMemberKind::Case(case) => EnumMemberKind::Case(EnumCase {
+            name: case.name,
+            value: case.value.as_ref().map(|v| folder.fold_expr(arena, v)),
+            attributes: fold_attrs(folder, arena, &case.attributes),
+            doc_comment: case.doc_comment.as_ref().map(fold_comment),
+        }),
+        EnumMemberKind::Method(method) => {
+            EnumMemberKind::Method(fold_method_decl(folder, arena, method))
+        }
+        EnumMemberKind::ClassConst(cc) => {
+            EnumMemberKind::ClassConst(fold_class_const_decl(folder, arena, cc))
+        }
+        EnumMemberKind::TraitUse(tu) => EnumMemberKind::TraitUse(folder.fold_trait_use(arena, tu)),
+    };
+    EnumMember {
+        kind,
+        span: member.span,
+    }
+}
+
+pub fn fold_property_hook<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    hook: &PropertyHook<'_, 'src>,
+) -> PropertyHook<'new, 'src> {
+    let body = match &hook.body {
+        PropertyHookBody::Block(stmts) => PropertyHookBody::Block(fold_stmts(folder, arena, stmts)),
+        PropertyHookBody::Expression(expr) => {
+            PropertyHookBody::Expression(folder.fold_expr(arena, expr))
+        }
+        PropertyHookBody::Abstract => PropertyHookBody::Abstract,
+    };
+    PropertyHook {
+        kind: hook.kind,
+        body,
+        is_final: hook.is_final,
+        by_ref: hook.by_ref,
+        params: fold_params(folder, arena, &hook.params),
+        attributes: fold_attrs(folder, arena, &hook.attributes),
+        span: hook.span,
+    }
+}
+
+pub fn fold_type_hint<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    type_hint: &TypeHint<'_, 'src>,
+) -> TypeHint<'new, 'src> {
+    let kind = match &type_hint.kind {
+        TypeHintKind::Named(name) => TypeHintKind::Named(folder.fold_name(arena, name)),
+        TypeHintKind::Keyword(builtin, span) => TypeHintKind::Keyword(*builtin, *span),
+        TypeHintKind::Nullable(inner) => {
+            TypeHintKind::Nullable(arena.alloc(folder.fold_type_hint(arena, inner)))
+        }
+        TypeHintKind::Union(types) => {
+            let mut new_types = ArenaVec::with_capacity_in(types.len(), arena);
+            for t in types.iter() {
+                new_types.push(folder.fold_type_hint(arena, t));
+            }
+            TypeHintKind::Union(new_types)
+        }
+        TypeHintKind::Intersection(types) => {
+            let mut new_types = ArenaVec::with_capacity_in(types.len(), arena);
+            for t in types.iter() {
+                new_types.push(folder.fold_type_hint(arena, t));
+            }
+            TypeHintKind::Intersection(new_types)
+        }
+    };
+    TypeHint {
+        kind,
+        span: type_hint.span,
+    }
+}
+
+pub fn fold_attribute<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    attribute: &Attribute<'_, 'src>,
+) -> Attribute<'new, 'src> {
+    Attribute {
+        name: folder.fold_name(arena, &attribute.name),
+        args: fold_args(folder, arena, &attribute.args),
+        span: attribute.span,
+    }
+}
+
+pub fn fold_catch_clause<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    catch: &CatchClause<'_, 'src>,
+) -> CatchClause<'new, 'src> {
+    let mut types = ArenaVec::with_capacity_in(catch.types.len(), arena);
+    for ty in catch.types.iter() {
+        types.push(folder.fold_name(arena, ty));
+    }
+    CatchClause {
+        types,
+        var: catch.var,
+        body: fold_stmts(folder, arena, &catch.body),
+        span: catch.span,
+    }
+}
+
+pub fn fold_match_arm<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    arm: &MatchArm<'_, 'src>,
+) -> MatchArm<'new, 'src> {
+    let conditions = arm.conditions.as_ref().map(|conds| {
+        let mut new_conds = ArenaVec::with_capacity_in(conds.len(), arena);
+        for c in conds.iter() {
+            new_conds.push(folder.fold_expr(arena, c));
+        }
+        new_conds
+    });
+    MatchArm {
+        conditions,
+        body: folder.fold_expr(arena, &arm.body),
+        span: arm.span,
+    }
+}
+
+pub fn fold_trait_use<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    trait_use: &TraitUseDecl<'_, 'src>,
+) -> TraitUseDecl<'new, 'src> {
+    let mut traits = ArenaVec::with_capacity_in(trait_use.traits.len(), arena);
+    for t in trait_use.traits.iter() {
+        traits.push(folder.fold_name(arena, t));
+    }
+    let mut adaptations = ArenaVec::with_capacity_in(trait_use.adaptations.len(), arena);
+    for a in trait_use.adaptations.iter() {
+        adaptations.push(folder.fold_trait_adaptation(arena, a));
+    }
+    TraitUseDecl {
+        traits,
+        adaptations,
+    }
+}
+
+pub fn fold_trait_adaptation<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    adaptation: &TraitAdaptation<'_, 'src>,
+) -> TraitAdaptation<'new, 'src> {
+    let kind = match &adaptation.kind {
+        TraitAdaptationKind::Precedence {
+            trait_name,
+            method,
+            insteadof,
+        } => {
+            let mut new_insteadof = ArenaVec::with_capacity_in(insteadof.len(), arena);
+            for n in insteadof.iter() {
+                new_insteadof.push(folder.fold_name(arena, n));
+            }
+            TraitAdaptationKind::Precedence {
+                trait_name: folder.fold_name(arena, trait_name),
+                method: folder.fold_name(arena, method),
+                insteadof: new_insteadof,
+            }
+        }
+        TraitAdaptationKind::Alias {
+            trait_name,
+            method,
+            new_modifier,
+            new_name,
+        } => TraitAdaptationKind::Alias {
+            trait_name: trait_name.as_ref().map(|n| folder.fold_name(arena, n)),
+            method: folder.fold_name(arena, method),
+            new_modifier: *new_modifier,
+            new_name: new_name.as_ref().map(|n| folder.fold_name(arena, n)),
+        },
+    };
+    TraitAdaptation {
+        kind,
+        span: adaptation.span,
+    }
+}
+
+pub fn fold_name<'new, 'src, F: Fold<'src> + ?Sized>(
+    _folder: &mut F,
+    arena: &'new Bump,
+    name: &Name<'_, 'src>,
+) -> Name<'new, 'src> {
+    match name {
+        Name::Simple { value, span } => Name::Simple { value, span: *span },
+        Name::Complex { parts, kind, span } => {
+            let mut new_parts = ArenaVec::with_capacity_in(parts.len(), arena);
+            for &part in parts.iter() {
+                new_parts.push(part);
+            }
+            Name::Complex {
+                parts: new_parts,
+                kind: *kind,
+                span: *span,
+            }
+        }
+        Name::Error { span } => Name::Error { span: *span },
+    }
+}
+
+// =============================================================================
+// Private helpers — complex declaration types
+// =============================================================================
+
+fn fold_function_decl<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    func: &FunctionDecl<'_, 'src>,
+) -> FunctionDecl<'new, 'src> {
+    FunctionDecl {
+        name: func.name,
+        params: fold_params(folder, arena, &func.params),
+        body: fold_stmts(folder, arena, &func.body),
+        return_type: func
+            .return_type
+            .as_ref()
+            .map(|t| folder.fold_type_hint(arena, t)),
+        by_ref: func.by_ref,
+        attributes: fold_attrs(folder, arena, &func.attributes),
+        doc_comment: func.doc_comment.as_ref().map(fold_comment),
+    }
+}
+
+fn fold_method_decl<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    method: &MethodDecl<'_, 'src>,
+) -> MethodDecl<'new, 'src> {
+    MethodDecl {
+        name: method.name,
+        visibility: method.visibility,
+        is_static: method.is_static,
+        is_abstract: method.is_abstract,
+        is_final: method.is_final,
+        by_ref: method.by_ref,
+        params: fold_params(folder, arena, &method.params),
+        return_type: method
+            .return_type
+            .as_ref()
+            .map(|t| folder.fold_type_hint(arena, t)),
+        body: method.body.as_ref().map(|b| fold_stmts(folder, arena, b)),
+        attributes: fold_attrs(folder, arena, &method.attributes),
+        doc_comment: method.doc_comment.as_ref().map(fold_comment),
+    }
+}
+
+fn fold_property_decl<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    prop: &PropertyDecl<'_, 'src>,
+) -> PropertyDecl<'new, 'src> {
+    PropertyDecl {
+        name: prop.name,
+        visibility: prop.visibility,
+        set_visibility: prop.set_visibility,
+        is_static: prop.is_static,
+        is_readonly: prop.is_readonly,
+        type_hint: prop
+            .type_hint
+            .as_ref()
+            .map(|t| folder.fold_type_hint(arena, t)),
+        default: prop.default.as_ref().map(|d| folder.fold_expr(arena, d)),
+        attributes: fold_attrs(folder, arena, &prop.attributes),
+        hooks: fold_hooks(folder, arena, &prop.hooks),
+        doc_comment: prop.doc_comment.as_ref().map(fold_comment),
+    }
+}
+
+fn fold_class_const_decl<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    cc: &ClassConstDecl<'_, 'src>,
+) -> ClassConstDecl<'new, 'src> {
+    ClassConstDecl {
+        name: cc.name,
+        visibility: cc.visibility,
+        is_final: cc.is_final,
+        type_hint: cc
+            .type_hint
+            .map(|t| &*arena.alloc(folder.fold_type_hint(arena, t))),
+        value: folder.fold_expr(arena, &cc.value),
+        attributes: fold_attrs(folder, arena, &cc.attributes),
+        doc_comment: cc.doc_comment.as_ref().map(fold_comment),
+    }
+}
+
+fn fold_class_decl<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    class: &ClassDecl<'_, 'src>,
+) -> ClassDecl<'new, 'src> {
+    let mut members = ArenaVec::with_capacity_in(class.members.len(), arena);
+    for member in class.members.iter() {
+        members.push(folder.fold_class_member(arena, member));
+    }
+    ClassDecl {
+        name: class.name,
+        modifiers: class.modifiers.clone(),
+        extends: class.extends.as_ref().map(|n| folder.fold_name(arena, n)),
+        implements: {
+            let mut v = ArenaVec::with_capacity_in(class.implements.len(), arena);
+            for n in class.implements.iter() {
+                v.push(folder.fold_name(arena, n));
+            }
+            v
+        },
+        members,
+        attributes: fold_attrs(folder, arena, &class.attributes),
+        doc_comment: class.doc_comment.as_ref().map(fold_comment),
+    }
+}
+
+fn fold_interface_decl<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    iface: &InterfaceDecl<'_, 'src>,
+) -> InterfaceDecl<'new, 'src> {
+    let mut extends = ArenaVec::with_capacity_in(iface.extends.len(), arena);
+    for n in iface.extends.iter() {
+        extends.push(folder.fold_name(arena, n));
+    }
+    let mut members = ArenaVec::with_capacity_in(iface.members.len(), arena);
+    for member in iface.members.iter() {
+        members.push(folder.fold_class_member(arena, member));
+    }
+    InterfaceDecl {
+        name: iface.name,
+        extends,
+        members,
+        attributes: fold_attrs(folder, arena, &iface.attributes),
+        doc_comment: iface.doc_comment.as_ref().map(fold_comment),
+    }
+}
+
+fn fold_trait_decl<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    t: &TraitDecl<'_, 'src>,
+) -> TraitDecl<'new, 'src> {
+    let mut members = ArenaVec::with_capacity_in(t.members.len(), arena);
+    for member in t.members.iter() {
+        members.push(folder.fold_class_member(arena, member));
+    }
+    TraitDecl {
+        name: t.name,
+        members,
+        attributes: fold_attrs(folder, arena, &t.attributes),
+        doc_comment: t.doc_comment.as_ref().map(fold_comment),
+    }
+}
+
+fn fold_enum_decl<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    e: &EnumDecl<'_, 'src>,
+) -> EnumDecl<'new, 'src> {
+    let mut members = ArenaVec::with_capacity_in(e.members.len(), arena);
+    for member in e.members.iter() {
+        members.push(folder.fold_enum_member(arena, member));
+    }
+    EnumDecl {
+        name: e.name,
+        scalar_type: e.scalar_type.as_ref().map(|n| folder.fold_name(arena, n)),
+        implements: {
+            let mut v = ArenaVec::with_capacity_in(e.implements.len(), arena);
+            for n in e.implements.iter() {
+                v.push(folder.fold_name(arena, n));
+            }
+            v
+        },
+        members,
+        attributes: fold_attrs(folder, arena, &e.attributes),
+        doc_comment: e.doc_comment.as_ref().map(fold_comment),
+    }
+}
+
+// =============================================================================
+// Private helpers — collection folding
+// =============================================================================
+
+fn fold_stmts<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    stmts: &[Stmt<'_, 'src>],
+) -> ArenaVec<'new, Stmt<'new, 'src>> {
+    let mut vec = ArenaVec::with_capacity_in(stmts.len(), arena);
+    for stmt in stmts {
+        vec.push(folder.fold_stmt(arena, stmt));
+    }
+    vec
+}
+
+fn fold_exprs<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    exprs: &[Expr<'_, 'src>],
+) -> ArenaVec<'new, Expr<'new, 'src>> {
+    let mut vec = ArenaVec::with_capacity_in(exprs.len(), arena);
+    for expr in exprs {
+        vec.push(folder.fold_expr(arena, expr));
+    }
+    vec
+}
+
+fn fold_args<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    args: &[Arg<'_, 'src>],
+) -> ArenaVec<'new, Arg<'new, 'src>> {
+    let mut vec = ArenaVec::with_capacity_in(args.len(), arena);
+    for arg in args {
+        vec.push(folder.fold_arg(arena, arg));
+    }
+    vec
+}
+
+fn fold_params<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    params: &[Param<'_, 'src>],
+) -> ArenaVec<'new, Param<'new, 'src>> {
+    let mut vec = ArenaVec::with_capacity_in(params.len(), arena);
+    for param in params {
+        vec.push(folder.fold_param(arena, param));
+    }
+    vec
+}
+
+fn fold_attrs<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    attrs: &[Attribute<'_, 'src>],
+) -> ArenaVec<'new, Attribute<'new, 'src>> {
+    let mut vec = ArenaVec::with_capacity_in(attrs.len(), arena);
+    for attr in attrs {
+        vec.push(folder.fold_attribute(arena, attr));
+    }
+    vec
+}
+
+fn fold_hooks<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    hooks: &[PropertyHook<'_, 'src>],
+) -> ArenaVec<'new, PropertyHook<'new, 'src>> {
+    let mut vec = ArenaVec::with_capacity_in(hooks.len(), arena);
+    for hook in hooks {
+        vec.push(folder.fold_property_hook(arena, hook));
+    }
+    vec
+}
+
+fn fold_string_parts<'new, 'src, F: Fold<'src> + ?Sized>(
+    folder: &mut F,
+    arena: &'new Bump,
+    parts: &[StringPart<'_, 'src>],
+) -> ArenaVec<'new, StringPart<'new, 'src>> {
+    let mut vec = ArenaVec::with_capacity_in(parts.len(), arena);
+    for part in parts {
+        vec.push(match part {
+            StringPart::Literal(s) => StringPart::Literal(arena.alloc_str(s)),
+            StringPart::Expr(e) => StringPart::Expr(folder.fold_expr(arena, e)),
+        });
+    }
+    vec
+}
+
+// =============================================================================
+// Private helpers — leaf types
+// =============================================================================
+
+pub fn fold_name_str<'new, 'src>(
+    name: NameStr<'_, 'src>,
+    arena: &'new Bump,
+) -> NameStr<'new, 'src> {
+    if let Some(s) = name.__into_src_str() {
+        NameStr::__src(s)
+    } else {
+        NameStr::__arena(arena.alloc_str(name.as_str()))
+    }
+}
+
+fn fold_comment<'src>(comment: &Comment<'src>) -> Comment<'src> {
+    Comment {
+        kind: comment.kind,
+        text: comment.text,
+        span: comment.span,
+    }
+}

--- a/crates/php-ast/src/lib.rs
+++ b/crates/php-ast/src/lib.rs
@@ -29,6 +29,7 @@
 //! ```
 
 pub mod ast;
+pub mod fold;
 pub mod span;
 pub mod visitor;
 

--- a/crates/php-ast/tests/fold.rs
+++ b/crates/php-ast/tests/fold.rs
@@ -1,0 +1,1099 @@
+use bumpalo::Bump;
+use php_ast::ast::*;
+use php_ast::fold::{
+    fold_arg, fold_attribute, fold_catch_clause, fold_class_member, fold_enum_member, fold_expr,
+    fold_match_arm, fold_name, fold_name_str, fold_param, fold_property_hook, fold_stmt,
+    fold_trait_adaptation, fold_trait_use, fold_type_hint, Fold,
+};
+use php_ast::Span;
+
+struct Identity;
+impl<'src> Fold<'src> for Identity {}
+
+#[test]
+fn identity_fold_preserves_expression_stmt() {
+    // PHP: $x = 1;
+    let arena = Bump::new();
+    let out = Bump::new();
+
+    let one = arena.alloc(Expr {
+        kind: ExprKind::Int(1),
+        span: Span::DUMMY,
+    });
+    let var_x = arena.alloc(Expr {
+        kind: ExprKind::Variable(NameStr::__src("x")),
+        span: Span::DUMMY,
+    });
+    let assign = arena.alloc(Expr {
+        kind: ExprKind::Assign(AssignExpr {
+            target: var_x,
+            op: AssignOp::Assign,
+            value: one,
+            by_ref: false,
+        }),
+        span: Span::DUMMY,
+    });
+    let mut stmts = ArenaVec::new_in(&arena);
+    stmts.push(Stmt {
+        kind: StmtKind::Expression(assign),
+        span: Span::DUMMY,
+    });
+    let program = Program {
+        stmts,
+        span: Span::DUMMY,
+    };
+
+    let folded = Identity.fold_program(&out, &program);
+    assert_eq!(folded.stmts.len(), 1);
+    assert!(matches!(
+        &folded.stmts[0].kind,
+        StmtKind::Expression(e) if matches!(e.kind, ExprKind::Assign(_))
+    ));
+}
+
+#[test]
+fn identity_fold_preserves_arena_strings() {
+    // PHP: "hello world";
+    let arena = Bump::new();
+    let out = Bump::new();
+
+    let s = arena.alloc_str("hello world");
+    let expr = Expr {
+        kind: ExprKind::String(s),
+        span: Span::DUMMY,
+    };
+    let folded_expr = Identity.fold_expr(&out, &expr);
+    match folded_expr.kind {
+        ExprKind::String(t) => assert_eq!(t, "hello world"),
+        _ => panic!("expected String"),
+    }
+}
+
+#[test]
+fn identity_fold_preserves_source_name_str() {
+    // PHP: $myVar;
+    let out = Bump::new();
+
+    let name = NameStr::__src("myVar");
+    let expr = Expr {
+        kind: ExprKind::Variable(name),
+        span: Span::DUMMY,
+    };
+    let folded_expr = Identity.fold_expr(&out, &expr);
+    match folded_expr.kind {
+        ExprKind::Variable(n) => {
+            assert_eq!(n.as_str(), "myVar");
+            assert!(
+                n.__into_src_str().is_some(),
+                "src-borrowed name should stay as Src"
+            );
+        }
+        _ => panic!("expected Variable"),
+    }
+}
+
+#[test]
+fn arena_name_str_is_reallocated_into_new_arena() {
+    // PHP: $arenaName;  (NameStr::Arena variant — synthesized name, not from source text)
+    let src_arena = Bump::new();
+    let out = Bump::new();
+
+    let s = src_arena.alloc_str("arenaName");
+    let name = NameStr::__arena(s);
+    let expr = Expr {
+        kind: ExprKind::Variable(name),
+        span: Span::DUMMY,
+    };
+    let folded_expr = Identity.fold_expr(&out, &expr);
+    let ExprKind::Variable(n) = folded_expr.kind else {
+        panic!("expected Variable")
+    };
+    assert_eq!(n.as_str(), "arenaName");
+    assert!(
+        n.__into_arena_str().is_some(),
+        "arena-borrowed name should remain as Arena after fold"
+    );
+    // Must point into `out`, not into `src_arena`
+    assert_ne!(
+        n.as_str().as_ptr(),
+        s.as_ptr(),
+        "folded arena NameStr should be re-allocated, not aliasing the source arena"
+    );
+}
+
+#[test]
+fn string_literal_is_reallocated_into_new_arena() {
+    // PHP: "hello world";
+    let src_arena = Bump::new();
+    let out = Bump::new();
+
+    let s = src_arena.alloc_str("hello world");
+    let expr = Expr {
+        kind: ExprKind::String(s),
+        span: Span::DUMMY,
+    };
+    let folded_expr = Identity.fold_expr(&out, &expr);
+    let ExprKind::String(t) = folded_expr.kind else {
+        panic!("expected String")
+    };
+    assert_eq!(t, "hello world");
+    // Must be a fresh allocation in `out`, not a pointer into `src_arena`
+    assert_ne!(
+        t.as_ptr(),
+        s.as_ptr(),
+        "folded string literal should be re-allocated, not aliasing the source arena"
+    );
+}
+
+/// `fold_closure_use_var` takes no arena — `ClosureUseVar` is `'src`-only.
+/// Verify the trait can be implemented without an arena parameter and that
+/// custom impls can intercept use-var capture lists.
+#[test]
+fn custom_fold_closure_use_var_no_arena_param() {
+    // PHP: function() use (&$x) {}
+    struct DropByRef;
+    impl<'src> Fold<'src> for DropByRef {
+        fn fold_closure_use_var(&mut self, var: &ClosureUseVar<'src>) -> ClosureUseVar<'src> {
+            ClosureUseVar {
+                by_ref: false,
+                ..*var
+            }
+        }
+    }
+
+    let arena = Bump::new();
+    let out = Bump::new();
+
+    let mut use_vars = ArenaVec::new_in(&arena);
+    use_vars.push(ClosureUseVar {
+        name: "x",
+        by_ref: true,
+        span: Span::DUMMY,
+    });
+    let closure = arena.alloc(ClosureExpr {
+        is_static: false,
+        by_ref: false,
+        params: ArenaVec::new_in(&arena),
+        use_vars,
+        return_type: None,
+        body: ArenaVec::new_in(&arena),
+        attributes: ArenaVec::new_in(&arena),
+    });
+    let expr = Expr {
+        kind: ExprKind::Closure(closure),
+        span: Span::DUMMY,
+    };
+
+    let folded = DropByRef.fold_expr(&out, &expr);
+    let ExprKind::Closure(c) = folded.kind else {
+        panic!("expected Closure")
+    };
+    assert_eq!(c.use_vars.len(), 1);
+    assert!(!c.use_vars[0].by_ref, "by_ref should have been cleared");
+    assert_eq!(c.use_vars[0].name, "x");
+}
+
+/// `fold_name_str` is public so callers synthesizing new names can correctly
+/// handle the Src/Arena distinction without re-implementing the logic.
+#[test]
+fn fold_name_str_pub_preserves_src_variant() {
+    // PHP: Foo  (NameStr::Src — source-borrowed, should stay Src after fold)
+    let out = Bump::new();
+    let name = NameStr::__src("Foo");
+    let result = fold_name_str(name, &out);
+    assert_eq!(result.as_str(), "Foo");
+    assert!(result.__into_src_str().is_some(), "Src should remain Src");
+}
+
+#[test]
+fn fold_name_str_pub_reallocates_arena_variant() {
+    // PHP: Bar  (NameStr::Arena — synthesized name, must be re-allocated into out arena)
+    let src_arena = Bump::new();
+    let out = Bump::new();
+    let s = src_arena.alloc_str("Bar");
+    let name = NameStr::__arena(s);
+    let result = fold_name_str(name, &out);
+    assert_eq!(result.as_str(), "Bar");
+    assert!(
+        result.__into_arena_str().is_some(),
+        "Arena should remain Arena"
+    );
+    assert_ne!(
+        result.as_str().as_ptr(),
+        s.as_ptr(),
+        "should be re-allocated into out, not aliasing src_arena"
+    );
+}
+
+#[test]
+fn custom_fold_transforms_ints() {
+    // PHP: 3 + 4  — override negates every Int literal
+    struct NegateInts;
+    impl<'src> Fold<'src> for NegateInts {
+        fn fold_expr<'new>(
+            &mut self,
+            arena: &'new Bump,
+            expr: &Expr<'_, 'src>,
+        ) -> Expr<'new, 'src> {
+            if let ExprKind::Int(n) = expr.kind {
+                return Expr {
+                    kind: ExprKind::Int(-n),
+                    span: expr.span,
+                };
+            }
+            fold_expr(self, arena, expr)
+        }
+    }
+
+    let arena = Bump::new();
+    let out = Bump::new();
+
+    let left = arena.alloc(Expr {
+        kind: ExprKind::Int(3),
+        span: Span::DUMMY,
+    });
+    let right = arena.alloc(Expr {
+        kind: ExprKind::Int(4),
+        span: Span::DUMMY,
+    });
+    let binary = Expr {
+        kind: ExprKind::Binary(BinaryExpr {
+            left,
+            op: BinaryOp::Add,
+            right,
+        }),
+        span: Span::DUMMY,
+    };
+
+    let folded = NegateInts.fold_expr(&out, &binary);
+    let ExprKind::Binary(b) = folded.kind else {
+        panic!("expected Binary")
+    };
+    assert!(matches!(b.left.kind, ExprKind::Int(-3)));
+    assert!(matches!(b.right.kind, ExprKind::Int(-4)));
+}
+
+// =============================================================================
+// Arena string re-allocation — pointer-distinctness tests
+// These verify that &'arena str fields are copied into the NEW arena, not passed
+// through as pointers into the source arena. JSON comparison cannot catch this.
+// =============================================================================
+
+/// `StmtKind::Label` stores `&'arena str`. The fold must re-allocate it.
+#[test]
+fn stmt_label_arena_string_is_reallocated() {
+    // PHP: my_label:
+    let src = Bump::new();
+    let out = Bump::new();
+    let s = src.alloc_str("my_label");
+    let stmt = Stmt {
+        kind: StmtKind::Label(s),
+        span: Span::DUMMY,
+    };
+    let folded = Identity.fold_stmt(&out, &stmt);
+    let StmtKind::Label(t) = &folded.kind else {
+        panic!("expected Label")
+    };
+    assert_eq!(*t, "my_label");
+    assert_ne!(
+        t.as_ptr(),
+        s.as_ptr(),
+        "Label text must be re-allocated into the output arena"
+    );
+}
+
+/// `ExprKind::Nowdoc.value` is `&'arena str`. The fold must re-allocate it.
+/// `.label` is `&'src str` and must NOT be re-allocated.
+#[test]
+fn nowdoc_value_is_reallocated_label_is_not() {
+    // PHP: <<<'EOT'\nnowdoc body\nEOT
+    let src = Bump::new();
+    let out = Bump::new();
+    let val = src.alloc_str("nowdoc body");
+    let expr = Expr {
+        kind: ExprKind::Nowdoc {
+            label: "EOT",
+            value: val,
+        },
+        span: Span::DUMMY,
+    };
+    let folded = Identity.fold_expr(&out, &expr);
+    let ExprKind::Nowdoc { label, value } = folded.kind else {
+        panic!("expected Nowdoc")
+    };
+    assert_eq!(value, "nowdoc body");
+    assert_ne!(
+        value.as_ptr(),
+        val.as_ptr(),
+        "Nowdoc value must be re-allocated"
+    );
+    assert_eq!(label, "EOT");
+    assert_eq!(
+        label.as_ptr(),
+        "EOT".as_ptr(),
+        "Nowdoc label is &'src str and must NOT be re-allocated"
+    );
+}
+
+/// `StringPart::Literal` inside `InterpolatedString` is `&'arena str`. Must be re-allocated.
+/// `StringPart::Expr` wraps an expression and must be recursively folded.
+#[test]
+fn string_part_literal_in_interpolated_string_is_reallocated() {
+    // PHP: "hello $name"
+    let src = Bump::new();
+    let out = Bump::new();
+    let s = src.alloc_str("hello ");
+    let var_expr = Expr {
+        kind: ExprKind::Variable(NameStr::__src("name")),
+        span: Span::DUMMY,
+    };
+    let mut parts = ArenaVec::new_in(&src);
+    parts.push(StringPart::Literal(s));
+    parts.push(StringPart::Expr(var_expr));
+    let expr = Expr {
+        kind: ExprKind::InterpolatedString(parts),
+        span: Span::DUMMY,
+    };
+    let folded = Identity.fold_expr(&out, &expr);
+    let ExprKind::InterpolatedString(p) = &folded.kind else {
+        panic!("expected InterpolatedString")
+    };
+    assert_eq!(p.len(), 2);
+    let StringPart::Literal(t) = &p[0] else {
+        panic!("expected Literal part")
+    };
+    assert_eq!(*t, "hello ");
+    assert_ne!(t.as_ptr(), s.as_ptr(), "Literal part must be re-allocated");
+    assert!(
+        matches!(&p[1], StringPart::Expr(_)),
+        "Expr part must survive fold"
+    );
+}
+
+// =============================================================================
+// Custom override dispatch — one test per trait method that lacked coverage.
+// Each test verifies the override IS called and its return value IS used.
+// =============================================================================
+
+#[test]
+fn fold_stmt_override_transforms_nop_to_error() {
+    // PHP: ;  (Nop statement — bare semicolon)
+    struct NopToError;
+    impl<'src> Fold<'src> for NopToError {
+        fn fold_stmt<'new>(
+            &mut self,
+            arena: &'new Bump,
+            stmt: &Stmt<'_, 'src>,
+        ) -> Stmt<'new, 'src> {
+            if matches!(stmt.kind, StmtKind::Nop) {
+                return Stmt {
+                    kind: StmtKind::Error,
+                    span: stmt.span,
+                };
+            }
+            fold_stmt(self, arena, stmt)
+        }
+    }
+    let arena = Bump::new();
+    let out = Bump::new();
+    let mut stmts = ArenaVec::new_in(&arena);
+    stmts.push(Stmt {
+        kind: StmtKind::Nop,
+        span: Span::DUMMY,
+    });
+    let program = Program {
+        stmts,
+        span: Span::DUMMY,
+    };
+    let folded = NopToError.fold_program(&out, &program);
+    assert!(
+        matches!(folded.stmts[0].kind, StmtKind::Error),
+        "fold_stmt override must replace Nop with Error"
+    );
+}
+
+/// `fold_type_hint` override must be dispatched and its result must be used.
+/// `Keyword` has no child type hints, so `fold_type_hint` (free fn) returns it
+/// unchanged, and the override then wraps it once: `int` → `?int`.
+#[test]
+fn fold_type_hint_override_wraps_keyword() {
+    // PHP: function f(): int {}  — type hint `int` wrapped to `?int` by override
+    struct WrapNullable;
+    impl<'src> Fold<'src> for WrapNullable {
+        fn fold_type_hint<'new>(
+            &mut self,
+            arena: &'new Bump,
+            th: &TypeHint<'_, 'src>,
+        ) -> TypeHint<'new, 'src> {
+            let inner = fold_type_hint(self, arena, th);
+            TypeHint {
+                kind: TypeHintKind::Nullable(arena.alloc(inner)),
+                span: th.span,
+            }
+        }
+    }
+    let out = Bump::new();
+    let th = TypeHint {
+        kind: TypeHintKind::Keyword(BuiltinType::Int, Span::DUMMY),
+        span: Span::DUMMY,
+    };
+    let folded = WrapNullable.fold_type_hint(&out, &th);
+    // Keyword has no children — free fn returns it unchanged, override wraps once: ?int
+    assert!(matches!(folded.kind, TypeHintKind::Nullable(_)));
+    let TypeHintKind::Nullable(inner) = &folded.kind else {
+        panic!("expected Nullable")
+    };
+    assert!(
+        matches!(inner.kind, TypeHintKind::Keyword(BuiltinType::Int, _)),
+        "inner must be the original Keyword — not re-wrapped because Keyword has no children"
+    );
+}
+
+/// When the override is applied to a Nullable(int) input the free fn recurses
+/// into the inner type via the overridden `fold_type_hint`, so the inner also
+/// gets wrapped: `?int` → `?(?int)` at the free-fn level, then the top-level
+/// override wraps once more → `?(? (?int))`.
+#[test]
+fn fold_type_hint_override_recurses_into_nullable() {
+    // PHP: function f(): ?int {}  — nullable wraps recursively on each visit
+    struct WrapNullable;
+    impl<'src> Fold<'src> for WrapNullable {
+        fn fold_type_hint<'new>(
+            &mut self,
+            arena: &'new Bump,
+            th: &TypeHint<'_, 'src>,
+        ) -> TypeHint<'new, 'src> {
+            let inner = fold_type_hint(self, arena, th);
+            TypeHint {
+                kind: TypeHintKind::Nullable(arena.alloc(inner)),
+                span: th.span,
+            }
+        }
+    }
+    let arena = Bump::new();
+    let out = Bump::new();
+    // Build `?int`
+    let int_hint = arena.alloc(TypeHint {
+        kind: TypeHintKind::Keyword(BuiltinType::Int, Span::DUMMY),
+        span: Span::DUMMY,
+    });
+    let nullable_int = TypeHint {
+        kind: TypeHintKind::Nullable(int_hint),
+        span: Span::DUMMY,
+    };
+    let folded = WrapNullable.fold_type_hint(&out, &nullable_int);
+    // Free fn processes Nullable(?int):
+    //   - recurses into inner `int` via overridden fold_type_hint → wraps to ?int
+    //   - free fn returns Nullable(?int)
+    // Override then wraps the whole thing → Nullable(Nullable(?int))
+    assert!(matches!(folded.kind, TypeHintKind::Nullable(_)));
+    let TypeHintKind::Nullable(level1) = &folded.kind else {
+        panic!("expected Nullable")
+    };
+    assert!(
+        matches!(level1.kind, TypeHintKind::Nullable(_)),
+        "fold_type_hint must recurse into Nullable children via the overridden method"
+    );
+}
+
+/// Union and Intersection inner types must all pass through `fold_type_hint`.
+#[test]
+fn fold_type_hint_recurses_into_union_and_intersection() {
+    // PHP: function f(): int|string {}
+    struct CountHints {
+        count: usize,
+    }
+    impl<'src> Fold<'src> for CountHints {
+        fn fold_type_hint<'new>(
+            &mut self,
+            arena: &'new Bump,
+            th: &TypeHint<'_, 'src>,
+        ) -> TypeHint<'new, 'src> {
+            self.count += 1;
+            fold_type_hint(self, arena, th)
+        }
+    }
+    let arena = Bump::new();
+    let out = Bump::new();
+    // Build `int|string`
+    let mut types = ArenaVec::new_in(&arena);
+    types.push(TypeHint {
+        kind: TypeHintKind::Keyword(BuiltinType::Int, Span::DUMMY),
+        span: Span::DUMMY,
+    });
+    types.push(TypeHint {
+        kind: TypeHintKind::Keyword(BuiltinType::String, Span::DUMMY),
+        span: Span::DUMMY,
+    });
+    let union_hint = TypeHint {
+        kind: TypeHintKind::Union(types),
+        span: Span::DUMMY,
+    };
+    let mut folder = CountHints { count: 0 };
+    folder.fold_type_hint(&out, &union_hint);
+    // 1 for the Union itself + 2 for the inner Keyword types
+    assert_eq!(
+        folder.count, 3,
+        "fold_type_hint must recurse into Union members"
+    );
+}
+
+#[test]
+fn fold_param_override_strips_default() {
+    // PHP: function f($x = 42) {}
+    struct ClearDefaults;
+    impl<'src> Fold<'src> for ClearDefaults {
+        fn fold_param<'new>(
+            &mut self,
+            arena: &'new Bump,
+            param: &Param<'_, 'src>,
+        ) -> Param<'new, 'src> {
+            Param {
+                default: None,
+                ..fold_param(self, arena, param)
+            }
+        }
+    }
+    let arena = Bump::new();
+    let out = Bump::new();
+    let param = Param {
+        name: Ident::name("x"),
+        type_hint: None,
+        default: Some(Expr {
+            kind: ExprKind::Int(42),
+            span: Span::DUMMY,
+        }),
+        by_ref: false,
+        variadic: false,
+        is_readonly: false,
+        is_final: false,
+        visibility: None,
+        set_visibility: None,
+        attributes: ArenaVec::new_in(&arena),
+        hooks: ArenaVec::new_in(&arena),
+        span: Span::DUMMY,
+    };
+    let folded = ClearDefaults.fold_param(&out, &param);
+    assert!(
+        folded.default.is_none(),
+        "fold_param override must clear the default"
+    );
+    assert_eq!(folded.name.as_str(), Some("x"), "other fields must survive");
+}
+
+#[test]
+fn fold_arg_override_clears_named_arg() {
+    // PHP: f(key: 1)
+    struct StripArgNames;
+    impl<'src> Fold<'src> for StripArgNames {
+        fn fold_arg<'new>(&mut self, arena: &'new Bump, arg: &Arg<'_, 'src>) -> Arg<'new, 'src> {
+            Arg {
+                name: None,
+                ..fold_arg(self, arena, arg)
+            }
+        }
+    }
+    let out = Bump::new();
+    let arg = Arg {
+        name: Some(Name::Simple {
+            value: "key",
+            span: Span::DUMMY,
+        }),
+        value: Expr {
+            kind: ExprKind::Int(1),
+            span: Span::DUMMY,
+        },
+        unpack: false,
+        by_ref: false,
+        span: Span::DUMMY,
+    };
+    let folded = StripArgNames.fold_arg(&out, &arg);
+    assert!(
+        folded.name.is_none(),
+        "fold_arg override must remove the arg name"
+    );
+    assert!(matches!(folded.value.kind, ExprKind::Int(1)));
+}
+
+#[test]
+fn fold_class_member_override_is_dispatched() {
+    // PHP: class C { const FOO = 1; }
+    struct CountMembers {
+        count: usize,
+    }
+    impl<'src> Fold<'src> for CountMembers {
+        fn fold_class_member<'new>(
+            &mut self,
+            arena: &'new Bump,
+            member: &ClassMember<'_, 'src>,
+        ) -> ClassMember<'new, 'src> {
+            self.count += 1;
+            fold_class_member(self, arena, member)
+        }
+    }
+    let arena = Bump::new();
+    let out = Bump::new();
+    let member = ClassMember {
+        kind: ClassMemberKind::ClassConst(ClassConstDecl {
+            name: Ident::name("FOO"),
+            visibility: None,
+            is_final: false,
+            type_hint: None,
+            value: Expr {
+                kind: ExprKind::Int(1),
+                span: Span::DUMMY,
+            },
+            attributes: ArenaVec::new_in(&arena),
+            doc_comment: None,
+        }),
+        span: Span::DUMMY,
+    };
+    let mut folder = CountMembers { count: 0 };
+    folder.fold_class_member(&out, &member);
+    assert_eq!(
+        folder.count, 1,
+        "fold_class_member must be dispatched once per member"
+    );
+}
+
+#[test]
+fn fold_enum_member_override_is_dispatched() {
+    // PHP: enum E { case Active; }
+    struct CountMembers {
+        count: usize,
+    }
+    impl<'src> Fold<'src> for CountMembers {
+        fn fold_enum_member<'new>(
+            &mut self,
+            arena: &'new Bump,
+            member: &EnumMember<'_, 'src>,
+        ) -> EnumMember<'new, 'src> {
+            self.count += 1;
+            fold_enum_member(self, arena, member)
+        }
+    }
+    let arena = Bump::new();
+    let out = Bump::new();
+    let member = EnumMember {
+        kind: EnumMemberKind::Case(EnumCase {
+            name: Ident::name("Active"),
+            value: None,
+            attributes: ArenaVec::new_in(&arena),
+            doc_comment: None,
+        }),
+        span: Span::DUMMY,
+    };
+    let mut folder = CountMembers { count: 0 };
+    folder.fold_enum_member(&out, &member);
+    assert_eq!(
+        folder.count, 1,
+        "fold_enum_member must be dispatched once per member"
+    );
+}
+
+/// `fold_trait_use` must be dispatched when a class/enum member is `TraitUse`.
+/// This is the only trait method whose dispatch path goes through another trait method
+/// (`fold_class_member`) rather than being callable directly from `fold_expr`/`fold_stmt`.
+#[test]
+fn fold_trait_use_override_is_dispatched_through_class_member() {
+    // PHP: class C { use T { foo insteadof U; } }
+    struct CountTraitUses {
+        count: usize,
+    }
+    impl<'src> Fold<'src> for CountTraitUses {
+        fn fold_trait_use<'new>(
+            &mut self,
+            arena: &'new Bump,
+            trait_use: &TraitUseDecl<'_, 'src>,
+        ) -> TraitUseDecl<'new, 'src> {
+            self.count += 1;
+            fold_trait_use(self, arena, trait_use)
+        }
+    }
+    let arena = Bump::new();
+    let out = Bump::new();
+    let mut traits = ArenaVec::new_in(&arena);
+    traits.push(Name::Simple {
+        value: "T",
+        span: Span::DUMMY,
+    });
+    let member = ClassMember {
+        kind: ClassMemberKind::TraitUse(TraitUseDecl {
+            traits,
+            adaptations: ArenaVec::new_in(&arena),
+        }),
+        span: Span::DUMMY,
+    };
+    let mut folder = CountTraitUses { count: 0 };
+    folder.fold_class_member(&out, &member);
+    assert_eq!(
+        folder.count, 1,
+        "fold_trait_use must be dispatched when fold_class_member processes a TraitUse member"
+    );
+}
+
+/// Override replaces any Block hook body with Abstract — verifies dispatch and result is used.
+#[test]
+fn fold_property_hook_override_block_body() {
+    // PHP: class C { public string $x { get { ; } } }
+    struct MakeAbstract;
+    impl<'src> Fold<'src> for MakeAbstract {
+        fn fold_property_hook<'new>(
+            &mut self,
+            arena: &'new Bump,
+            hook: &PropertyHook<'_, 'src>,
+        ) -> PropertyHook<'new, 'src> {
+            PropertyHook {
+                body: PropertyHookBody::Abstract,
+                ..fold_property_hook(self, arena, hook)
+            }
+        }
+    }
+    let arena = Bump::new();
+    let out = Bump::new();
+    let mut body_stmts = ArenaVec::new_in(&arena);
+    body_stmts.push(Stmt {
+        kind: StmtKind::Nop,
+        span: Span::DUMMY,
+    });
+    let hook = PropertyHook {
+        kind: PropertyHookKind::Get,
+        body: PropertyHookBody::Block(body_stmts),
+        is_final: false,
+        by_ref: false,
+        params: ArenaVec::new_in(&arena),
+        attributes: ArenaVec::new_in(&arena),
+        span: Span::DUMMY,
+    };
+    let folded = MakeAbstract.fold_property_hook(&out, &hook);
+    assert!(
+        matches!(folded.body, PropertyHookBody::Abstract),
+        "fold_property_hook override must replace Block body with Abstract"
+    );
+}
+
+/// Override replaces any Expression hook body with Abstract — verifies dispatch and result is used.
+#[test]
+fn fold_property_hook_override_expression_body() {
+    // PHP: class C { public string $x { set => 0; } }
+    struct MakeAbstract;
+    impl<'src> Fold<'src> for MakeAbstract {
+        fn fold_property_hook<'new>(
+            &mut self,
+            arena: &'new Bump,
+            hook: &PropertyHook<'_, 'src>,
+        ) -> PropertyHook<'new, 'src> {
+            PropertyHook {
+                body: PropertyHookBody::Abstract,
+                ..fold_property_hook(self, arena, hook)
+            }
+        }
+    }
+    let arena = Bump::new();
+    let out = Bump::new();
+    let hook = PropertyHook {
+        kind: PropertyHookKind::Set,
+        body: PropertyHookBody::Expression(Expr {
+            kind: ExprKind::Int(0),
+            span: Span::DUMMY,
+        }),
+        is_final: false,
+        by_ref: false,
+        params: ArenaVec::new_in(&arena),
+        attributes: ArenaVec::new_in(&arena),
+        span: Span::DUMMY,
+    };
+    let folded = MakeAbstract.fold_property_hook(&out, &hook);
+    assert!(
+        matches!(folded.body, PropertyHookBody::Abstract),
+        "fold_property_hook override must replace Expression body with Abstract"
+    );
+}
+
+#[test]
+fn fold_attribute_override_is_dispatched() {
+    // PHP: #[Route] function f() {}
+    struct CountAttrs {
+        count: usize,
+    }
+    impl<'src> Fold<'src> for CountAttrs {
+        fn fold_attribute<'new>(
+            &mut self,
+            arena: &'new Bump,
+            attr: &Attribute<'_, 'src>,
+        ) -> Attribute<'new, 'src> {
+            self.count += 1;
+            fold_attribute(self, arena, attr)
+        }
+    }
+    let arena = Bump::new();
+    let out = Bump::new();
+    let attr = Attribute {
+        name: Name::Simple {
+            value: "Route",
+            span: Span::DUMMY,
+        },
+        args: ArenaVec::new_in(&arena),
+        span: Span::DUMMY,
+    };
+    let mut folder = CountAttrs { count: 0 };
+    folder.fold_attribute(&out, &attr);
+    assert_eq!(
+        folder.count, 1,
+        "fold_attribute must be dispatched per attribute"
+    );
+}
+
+/// Verifies both a `conditions = Some(...)` arm and a `default` arm (conditions = None)
+/// pass through `fold_match_arm`.
+#[test]
+fn fold_match_arm_override_dispatched_for_both_arm_kinds() {
+    // PHP: match ($x) { 1 => 2, default => 0 }
+    struct CountArms {
+        count: usize,
+    }
+    impl<'src> Fold<'src> for CountArms {
+        fn fold_match_arm<'new>(
+            &mut self,
+            arena: &'new Bump,
+            arm: &MatchArm<'_, 'src>,
+        ) -> MatchArm<'new, 'src> {
+            self.count += 1;
+            fold_match_arm(self, arena, arm)
+        }
+    }
+    let arena = Bump::new();
+    let out = Bump::new();
+    let subject = arena.alloc(Expr {
+        kind: ExprKind::Variable(NameStr::__src("x")),
+        span: Span::DUMMY,
+    });
+    let mut conds = ArenaVec::new_in(&arena);
+    conds.push(Expr {
+        kind: ExprKind::Int(1),
+        span: Span::DUMMY,
+    });
+    let mut arms = ArenaVec::new_in(&arena);
+    // Regular arm: `1 => 2`
+    arms.push(MatchArm {
+        conditions: Some(conds),
+        body: Expr {
+            kind: ExprKind::Int(2),
+            span: Span::DUMMY,
+        },
+        span: Span::DUMMY,
+    });
+    // Default arm: `default => 0`
+    arms.push(MatchArm {
+        conditions: None,
+        body: Expr {
+            kind: ExprKind::Int(0),
+            span: Span::DUMMY,
+        },
+        span: Span::DUMMY,
+    });
+    let match_expr = Expr {
+        kind: ExprKind::Match(MatchExpr { subject, arms }),
+        span: Span::DUMMY,
+    };
+    let mut folder = CountArms { count: 0 };
+    folder.fold_expr(&out, &match_expr);
+    assert_eq!(
+        folder.count, 2,
+        "fold_match_arm must be dispatched for both regular and default arms"
+    );
+}
+
+#[test]
+fn fold_catch_clause_override_clears_var() {
+    // PHP: try {} catch (Exception $e) {}
+    struct DropCatchVar;
+    impl<'src> Fold<'src> for DropCatchVar {
+        fn fold_catch_clause<'new>(
+            &mut self,
+            arena: &'new Bump,
+            catch: &CatchClause<'_, 'src>,
+        ) -> CatchClause<'new, 'src> {
+            CatchClause {
+                var: None,
+                ..fold_catch_clause(self, arena, catch)
+            }
+        }
+    }
+    let arena = Bump::new();
+    let out = Bump::new();
+    let mut types = ArenaVec::new_in(&arena);
+    types.push(Name::Simple {
+        value: "Exception",
+        span: Span::DUMMY,
+    });
+    let catch = CatchClause {
+        types,
+        var: Some("e"),
+        body: ArenaVec::new_in(&arena),
+        span: Span::DUMMY,
+    };
+    let folded = DropCatchVar.fold_catch_clause(&out, &catch);
+    assert!(
+        folded.var.is_none(),
+        "fold_catch_clause override must clear the catch variable"
+    );
+    assert_eq!(folded.types.len(), 1);
+}
+
+#[test]
+fn fold_trait_adaptation_override_is_dispatched() {
+    // PHP: use T { foo as bar; }
+    struct CountAdaptations {
+        count: usize,
+    }
+    impl<'src> Fold<'src> for CountAdaptations {
+        fn fold_trait_adaptation<'new>(
+            &mut self,
+            arena: &'new Bump,
+            adaptation: &TraitAdaptation<'_, 'src>,
+        ) -> TraitAdaptation<'new, 'src> {
+            self.count += 1;
+            fold_trait_adaptation(self, arena, adaptation)
+        }
+    }
+    let out = Bump::new();
+    let adaptation = TraitAdaptation {
+        kind: TraitAdaptationKind::Alias {
+            trait_name: None,
+            method: Name::Simple {
+                value: "foo",
+                span: Span::DUMMY,
+            },
+            new_modifier: None,
+            new_name: Some(Name::Simple {
+                value: "bar",
+                span: Span::DUMMY,
+            }),
+        },
+        span: Span::DUMMY,
+    };
+    let mut folder = CountAdaptations { count: 0 };
+    folder.fold_trait_adaptation(&out, &adaptation);
+    assert_eq!(folder.count, 1, "fold_trait_adaptation must be dispatched");
+}
+
+#[test]
+fn fold_name_override_is_dispatched() {
+    // PHP: f(key: 1)  — fold_arg recurses into its name field through fold_name
+    struct CountNames {
+        count: usize,
+    }
+    impl<'src> Fold<'src> for CountNames {
+        fn fold_name<'new>(
+            &mut self,
+            arena: &'new Bump,
+            name: &Name<'_, 'src>,
+        ) -> Name<'new, 'src> {
+            self.count += 1;
+            fold_name(self, arena, name)
+        }
+    }
+    let out = Bump::new();
+    let arg = Arg {
+        name: Some(Name::Simple {
+            value: "key",
+            span: Span::DUMMY,
+        }),
+        value: Expr {
+            kind: ExprKind::Int(1),
+            span: Span::DUMMY,
+        },
+        unpack: false,
+        by_ref: false,
+        span: Span::DUMMY,
+    };
+    let mut folder = CountNames { count: 0 };
+    folder.fold_arg(&out, &arg);
+    assert_eq!(
+        folder.count, 1,
+        "fold_name must be dispatched for the named arg"
+    );
+}
+
+// =============================================================================
+// Option/None edge cases — verify None fields stay None through the fold
+// =============================================================================
+
+#[test]
+fn return_none_stays_none() {
+    // PHP: return;
+    let arena = Bump::new();
+    let out = Bump::new();
+    let mut stmts = ArenaVec::new_in(&arena);
+    stmts.push(Stmt {
+        kind: StmtKind::Return(None),
+        span: Span::DUMMY,
+    });
+    let program = Program {
+        stmts,
+        span: Span::DUMMY,
+    };
+    let folded = Identity.fold_program(&out, &program);
+    assert!(
+        matches!(&folded.stmts[0].kind, StmtKind::Return(None)),
+        "Return(None) must fold to Return(None)"
+    );
+}
+
+#[test]
+fn foreach_without_key_stays_none() {
+    // PHP: foreach ($items as $item) ;
+    let arena = Bump::new();
+    let out = Bump::new();
+    let nop = arena.alloc(Stmt {
+        kind: StmtKind::Nop,
+        span: Span::DUMMY,
+    });
+    let foreach = arena.alloc(ForeachStmt {
+        expr: Expr {
+            kind: ExprKind::Variable(NameStr::__src("items")),
+            span: Span::DUMMY,
+        },
+        key: None,
+        value: Expr {
+            kind: ExprKind::Variable(NameStr::__src("item")),
+            span: Span::DUMMY,
+        },
+        body: nop,
+        uses_alternative: false,
+    });
+    let stmt = Stmt {
+        kind: StmtKind::Foreach(foreach),
+        span: Span::DUMMY,
+    };
+    let folded = Identity.fold_stmt(&out, &stmt);
+    let StmtKind::Foreach(f) = &folded.kind else {
+        panic!("expected Foreach")
+    };
+    assert!(
+        f.key.is_none(),
+        "foreach key=None must remain None after fold"
+    );
+}
+
+/// `MatchArm::conditions = None` represents the `default` arm.
+/// Verify it stays None after identity fold (not confused with an empty conditions vec).
+#[test]
+fn match_default_arm_conditions_none_stays_none() {
+    // PHP: match ($x) { default => 0 }  — conditions=None is the default arm, not empty conditions
+    let out = Bump::new();
+    let arm = MatchArm {
+        conditions: None,
+        body: Expr {
+            kind: ExprKind::Int(0),
+            span: Span::DUMMY,
+        },
+        span: Span::DUMMY,
+    };
+    let folded = Identity.fold_match_arm(&out, &arm);
+    assert!(
+        folded.conditions.is_none(),
+        "default arm (conditions=None) must stay None — must not be confused with empty vec"
+    );
+}

--- a/crates/php-parser/tests/fold.rs
+++ b/crates/php-parser/tests/fold.rs
@@ -1,0 +1,79 @@
+//! Integration tests for the fold API using the real parser and full fixture corpus.
+//! Verifies that the identity fold rebuilds every parsed AST into an identical JSON
+//! representation, covering all statement and expression variants across the fixture suite.
+
+mod common;
+
+use bumpalo::Bump;
+use php_ast::fold::Fold;
+
+struct Identity;
+impl<'src> Fold<'src> for Identity {}
+
+fn to_json(program: &php_ast::Program) -> String {
+    serde_json::to_string(program).unwrap()
+}
+
+fn php_version(v: (u32, u32)) -> php_rs_parser::PhpVersion {
+    match v {
+        (7, 4) => php_rs_parser::PhpVersion::Php74,
+        (8, 0) => php_rs_parser::PhpVersion::Php80,
+        (8, 1) => php_rs_parser::PhpVersion::Php81,
+        (8, 2) => php_rs_parser::PhpVersion::Php82,
+        (8, 3) => php_rs_parser::PhpVersion::Php83,
+        (8, 4) => php_rs_parser::PhpVersion::Php84,
+        (8, 5) => php_rs_parser::PhpVersion::Php85,
+        _ => panic!("unsupported PHP version: {}.{}", v.0, v.1),
+    }
+}
+
+/// Parses every `.phpt` fixture (including error fixtures — the parser always produces a tree),
+/// identity-folds into a fresh arena, and asserts the JSON output is bit-for-bit identical.
+///
+/// This single test exercises all 53 ExprKind variants and 32 StmtKind variants present in
+/// the corpus without requiring a hand-written case per variant.
+#[test]
+fn identity_fold_matches_original_json_across_corpus() {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let mut paths = common::collect_phpt_files(&dir);
+    paths.sort();
+
+    let mut failures = Vec::new();
+
+    for path in &paths {
+        let rel = path
+            .strip_prefix(&dir)
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        let content = std::fs::read_to_string(path).unwrap();
+        let (min_php, source) = common::parse_fixture(&content);
+        let src_arena = Bump::new();
+
+        let result = if let Some(ver) = min_php {
+            php_rs_parser::parse_versioned(&src_arena, source, php_version(ver))
+        } else {
+            php_rs_parser::parse(&src_arena, source)
+        };
+
+        let original_json = to_json(&result.program);
+
+        let out_arena = Bump::new();
+        let folded = Identity.fold_program(&out_arena, &result.program);
+        let folded_json = to_json(&folded);
+
+        if original_json != folded_json {
+            failures.push(format!(
+                "fold changed AST in {rel}\noriginal:\n{original_json}\nfolded:\n{folded_json}"
+            ));
+        }
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "{} identity-fold mismatch(es):\n{}",
+            failures.len(),
+            failures.join("\n---\n")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `php_ast::fold::Fold<'src>` — the transformation counterpart of the existing `Visitor` trait. Where `Visitor` walks the tree read-only, `Fold` rebuilds it from one bumpalo arena into a fresh output arena, which is the only sound design for arena-allocated ASTs (in-place `VisitorMut` would break arena lifetime invariants).
- Provides 16 overridable trait methods covering all node types, each backed by a public free `fold_*` function for default recursion. Callers override only the nodes they want to transform; everything else recurses automatically.
- Correctly handles the `NameStr::Src`/`Arena` distinction — source-borrowed strings pass through untouched; arena-allocated strings (`StmtKind::Label`, `ExprKind::Nowdoc.value`, `StringPart::Literal`, etc.) are re-allocated into the output arena.

## Tests

- **31 unit tests** in `crates/php-ast/tests/fold.rs` covering arena pointer-distinctness (the one thing JSON comparison cannot catch), override dispatch for all 16 trait methods, and `None`/`Option` edge cases.
- **Corpus integration test** in `crates/php-parser/tests/fold.rs` — identity-folds every `.phpt` fixture and asserts the JSON output is bit-for-bit identical to the original parse, exercising all statement and expression variants without a hand-written case per variant.