### PR TITLE
chore(release): 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-05-14
+
+### Added
+
+- `Fold` trait for arena-to-arena AST transformations — enables efficient rewriting of AST nodes with the bump arena as the target allocation context (`php-ast`).
+- Printer now preserves blank lines from source in switch cases and enum members, maintaining semantic formatting hints from the original code (`php-printer`).
+
+### Fixed
+
+- Printer now correctly tracks `has_php_content` state across blank lines, preventing spurious `<?php` tags from being emitted (`php-printer`).
+
+---
+
 ## [0.11.1] - 2026-05-12
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -26,11 +26,11 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.11.1" }
-php-lexer = { path = "crates/php-lexer", version = "0.11.1" }
-php-rs-parser = { path = "crates/php-parser", version = "0.11.1" }
-phpdoc-parser = { path = "crates/phpdoc-parser", version = "0.11.1" }
-php-printer = { path = "crates/php-printer", version = "0.11.1" }
+php-ast = { path = "crates/php-ast", version = "0.12.0" }
+php-lexer = { path = "crates/php-lexer", version = "0.12.0" }
+php-rs-parser = { path = "crates/php-parser", version = "0.12.0" }
+phpdoc-parser = { path = "crates/phpdoc-parser", version = "0.12.0" }
+php-printer = { path = "crates/php-printer", version = "0.12.0" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

Release version 0.12.0 with new Fold trait for AST transformations and improved blank line preservation in the printer.

### Changes

- **Fold trait** (`php-ast`): Enable arena-to-arena AST transformations
- **Blank line preservation** (`php-printer`): Preserve formatting hints from source in switch cases and enum members
- Comprehensive test coverage for both features
- CI improvements for clippy and fold tests

### Version Bumps

All workspace crates bumped to 0.12.0:
- php-ast
- php-lexer
- php-rs-parser
- phpdoc-parser
- php-printer
- php-wasm