### PR TITLE
chore(release): bump version to 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2026-05-15
+
+### Added
+
+- `visit_comment` hook in the `Visitor` trait for traversing doc comments on declarations (`php-ast`).
+
+### Fixed
+
+- Doc comments no longer leak across scope boundaries during parsing — scoped comments are properly isolated to their declaration context (`php-rs-parser`).
+
+### Tests
+
+- Comprehensive comment fixture coverage across all supported PHP versions (`php-rs-parser`).
+
+---
+
 ## [0.12.0] - 2026-05-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["jorgsowa"]
@@ -26,11 +26,11 @@ repository = "https://github.com/jorgsowa/rust-php-parser"
 homepage = "https://github.com/jorgsowa/rust-php-parser"
 
 [workspace.dependencies]
-php-ast = { path = "crates/php-ast", version = "0.12.0" }
-php-lexer = { path = "crates/php-lexer", version = "0.12.0" }
-php-rs-parser = { path = "crates/php-parser", version = "0.12.0" }
-phpdoc-parser = { path = "crates/phpdoc-parser", version = "0.12.0" }
-php-printer = { path = "crates/php-printer", version = "0.12.0" }
+php-ast = { path = "crates/php-ast", version = "0.12.1" }
+php-lexer = { path = "crates/php-lexer", version = "0.12.1" }
+php-rs-parser = { path = "crates/php-parser", version = "0.12.1" }
+phpdoc-parser = { path = "crates/phpdoc-parser", version = "0.12.1" }
+php-printer = { path = "crates/php-printer", version = "0.12.1" }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

Release version 0.12.1 with doc comment scope fixes and visitor enhancements.

**Changes:**
- Add `visit_comment` hook to `Visitor` trait for traversing doc comments on declarations
- Fix doc comments leaking across scope boundaries during parsing
- Expand comment fixture coverage across all PHP versions (7.4–8.5)

## Checklist
- [x] Version bumped in Cargo.toml
- [x] CHANGELOG.md updated
- [x] All tests passing
- [x] Pre-commit hooks passed